### PR TITLE
Support searching existing cpm build dirs

### DIFF
--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -101,7 +101,9 @@ function(rapids_cpm_find name version )
   if(DEFINED FETCHCONTENT_BASE_DIR)
     if (EXISTS "${FETCHCONTENT_BASE_DIR}/${name}-build/${lowercase_name}-config.cmake" OR
         EXISTS "${FETCHCONTENT_BASE_DIR}/${name}-build/${name}Config.cmake")
-      set(${name}_DIR "${FETCHCONTENT_BASE_DIR}/${name}-build/")
+      if (NOT DEFINED ${name}_DIR)
+        set(${name}_DIR "${FETCHCONTENT_BASE_DIR}/${name}-build/")
+      endif()
     endif()
   endif()
 

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -76,6 +76,13 @@ consistency. List all targets used by your project in `GLOBAL_TARGET`.
   Required placeholder to be provied before any extra arguments that need to
   be passed down to :cmake:command:`CPMFindPackage`.
 
+Search Behavior
+^^^^^^^^^^^^^^^
+
+  In addition to the default `CPM` search behavior, :cmake:command:`rapids_cpm_find`
+  looks for existing build directories of the given project and will prefer
+  those when they exist and have a `<PackageName>-config.cmake` or a
+  `<PackageName>Config.cmake` file.
 
 #]=======================================================================]
 function(rapids_cpm_find name version )
@@ -87,6 +94,15 @@ function(rapids_cpm_find name version )
 
   if(NOT DEFINED RAPIDS_CPM_ARGS)
     message(FATAL_ERROR "rapids_cpm_find requires you to specify CPM_ARGS before any CPM arguments")
+  endif()
+
+  # Prefer an existing build of the package if it exists
+  string(TOLOWER ${name} lowercase_name)
+  if(DEFINED FETCHCONTENT_BASE_DIR)
+    if (EXISTS "${FETCHCONTENT_BASE_DIR}/${name}-build/${lowercase_name}-config.cmake" OR
+        EXISTS "${FETCHCONTENT_BASE_DIR}/${name}-build/${name}Config.cmake")
+      set(${name}_DIR "${FETCHCONTENT_BASE_DIR}/${name}-build/")
+    endif()
   endif()
 
   CPMFindPackage(NAME ${name} VERSION ${version} ${RAPIDS_UNPARSED_ARGUMENTS})

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -19,54 +19,62 @@ include_guard(GLOBAL)
 rapids_cpm_find
 ---------------
 
-.. versionadded:: 0.20
+.. versionadded:: v21.06.00
 
-.. command:: rapids_cpm_find
+Allow projects to find or build a dependency via `CPM` with built-in
+tracking of these dependencies for correct export support.
 
-  .. code-block:: cmake
+.. code-block:: cmake
 
-    rapids_cpm_find( <PackageName> <version>
-                    [GLOBAL_TARGETS <targets...>]
-                    [BUILD_EXPORT_SET <export-name>]
-                    [INSTALL_EXPORT_SET <export-name>]
-                    <CPM_ARGS>
-                      all normal CPM options
-                  )
+  rapids_cpm_find(<PackageName> <version>
+                  [GLOBAL_TARGETS <targets...>]
+                  [BUILD_EXPORT_SET <export-name>]
+                  [INSTALL_EXPORT_SET <export-name>]
+                  <CPM_ARGS>
+                    all normal CPM options
+                )
 
-  Generate a CPMFindPackage call and associate relevant information
-  to the provided build and install exports.
+Generate a CPM FindPackage call and associate this with the listed
+build and install export set for correct export generation.
 
-  Note:
-    Adding an export set to `rapids_cpm_find` has different behavior
-    for build and install. Build exports a respective CPM call, since
-    we presume other CPM packages don't generate a correct build directory
-    config module. While install exports a `find_dependency` call as
-    we expect projects to have a valid install setup.
+Since the visibility of CMake's targets differ between targets built locally and those
+imported, :cmake:command:`rapids_cpm_find` promotes imported targets to be global so users have
+consistency. List all targets used by your project in `GLOBAL_TARGET`.
 
-    If you need different behavior you will need to use `rapids_export_package()`
-    or `rapids_export_cpm()`.
+.. note::
+  Requires :cmake:command:`rapids_cpm_init` to be called before usage
 
-  ``PackageName``
-    Name of the package to find.
+.. note::
+  Adding an export set to :cmake:command:`rapids_cpm_find` has different behavior
+  for build and install. Build exports a respective CPM call, since
+  we presume other CPM packages don't generate a correct build directory
+  config module. While install exports a `find_dependency` call as
+  we expect projects to have a valid install setup.
 
-  ``version``
-    Version of the package you would like CPM to find.
+  If you need different behavior you will need to use :cmake:command:`rapids_export_package()`
+  or :cmake:command:`rapids_export_cpm()`.
 
-  ``GLOBAL_TARGETS``
-    Which targets from this package should be made global. This information
-    will be propagated to any associated export set.
+``PackageName``
+  Name of the package to find.
 
-  ``BUILD_EXPORT_SET``
-    Record that a `CPMFindPackage(<PackageName> ...) call needs to occur as part of
-    our build directory export set.
+``version``
+  Version of the package you would like CPM to find.
 
-  ``INSTALL_EXPORT_SET``
-    Record a `find_dependency(<PackageName> ...) call needs to occur as part of
-    our build directory export set.
+``GLOBAL_TARGETS``
+  Which targets from this package should be made global. This information
+  will be propagated to any associated export set.
 
-  ``CPM_ARGS``
-    Required placeholder to be provied before any extra arguments that need to
-    be passed down to `CPMFindPackage`.
+``BUILD_EXPORT_SET``
+  Record that a :cmake:command:`CPMFindPackage(<PackageName> ...)` call needs to occur as part of
+  our build directory export set.
+
+``INSTALL_EXPORT_SET``
+  Record a :cmake:command:`find_dependency(<PackageName> ...)` call needs to occur as part of
+  our build directory export set.
+
+``CPM_ARGS``
+  Required placeholder to be provied before any extra arguments that need to
+  be passed down to :cmake:command:`CPMFindPackage`.
 
 
 #]=======================================================================]

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -1,0 +1,17 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+add_cmake_config_test( cpm_find-existing-build-dir )

--- a/testing/cpm/cpm_find-existing-build-dir/CMakeLists.txt
+++ b/testing/cpm/cpm_find-existing-build-dir/CMakeLists.txt
@@ -1,0 +1,60 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(rapids-test-project LANGUAGES CXX)
+
+
+function(generate_fake_build_dir_with_config name version config_file version_file)
+  include(CMakePackageConfigHelpers)
+
+  # Generate a fake config module for RapidsTestFind
+  set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${name}-build/")
+  file(MAKE_DIRECTORY ${build_dir})
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${config_file}"
+    "${build_dir}/${config_file}"
+    INSTALL_DESTINATION "${build_dir}/${config_file}"
+  )
+
+  write_basic_package_version_file("${build_dir}/${version_file}"
+    VERSION ${version}
+    COMPATIBILITY SameMajorVersion)
+endfunction()
+
+generate_fake_build_dir_with_config(RapidsTestFind 0.1
+    RapidsTestFindConfig.cmake
+    RapidsTestFindConfigVersion.cmake)
+
+generate_fake_build_dir_with_config(RapidsTestFind2 0.2
+    rapidstestfind2-config.cmake
+    rapidstestfind2-config-version.cmake)
+
+rapids_cpm_init()
+set(FETCHCONTENT_BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+set(CPM_LOCAL_PACKAGES_ONLY ON)
+rapids_cpm_find(RapidsTestFind 0.1.0)
+rapids_cpm_find(RapidsTestFind2 0.2.0)
+
+if(NOT TARGET RapidsTest::RapidsTest)
+  message(FATAL_ERROR "RapidsTest targets should be generated")
+endif()
+if(NOT TARGET RapidsTest2::RapidsTest)
+  message(FATAL_ERROR "RapidsTest2 targets should be generated")
+endif()

--- a/testing/cpm/cpm_find-existing-build-dir/RapidsTestFindConfig.cmake
+++ b/testing/cpm/cpm_find-existing-build-dir/RapidsTestFindConfig.cmake
@@ -13,17 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+set(RapidsTestFind_VERSION 0.1.0)
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+@PACKAGE_INIT@
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/RapidsTestFindVersion.cmake")
 
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE GLOBAL)
 
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
+check_required_components(RapidsTest)

--- a/testing/cpm/cpm_find-existing-build-dir/rapidstestfind2-config.cmake
+++ b/testing/cpm/cpm_find-existing-build-dir/rapidstestfind2-config.cmake
@@ -13,17 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+# set(RapidsTestFind2_VERSION 0.2.0)
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+@PACKAGE_INIT@
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/rapidstestfind2-version.cmake")
 
+add_library(RapidsTest2::RapidsTest IMPORTED INTERFACE GLOBAL)
 
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
+check_required_components(RapidsTest2)


### PR DESCRIPTION
Search for an existing CPM build directory for each package we add via `rapids_cpm_add`. If we find a suitable build directory with a config module we will specify `<PackageName>_DIR`.

Fixes #1 