### PR TITLE
rapids_export now obeys CMake config file naming convention

### DIFF
--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -105,6 +105,7 @@ function(rapids_export type project_name)
   endif()
 
   #Write configuration and version files
+  string(TOLOWER ${project_name} project_name)
   if(type STREQUAL "install")
     set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/${project_name}")
     set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export")

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -17,6 +17,8 @@
 add_cmake_config_test( export_cpm-build.cmake )
 add_cmake_config_test( export_cpm-install.cmake )
 
+add_cmake_config_test( export-verify-file-names.cmake )
+
 add_cmake_config_test( export_package-build.cmake )
 add_cmake_config_test( export_package-install.cmake )
 add_cmake_config_test( export_package-multiple-export_sets.cmake )

--- a/testing/export/export-verify-file-names.cmake
+++ b/testing/export/export-verify-file-names.cmake
@@ -1,0 +1,50 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/export.cmake)
+
+project(FakEProJecT LANGUAGES CXX VERSION 3.1.4)
+
+
+rapids_export_cpm(BUILD RaFT fake_set
+                  CPM_ARGS
+                    FAKE_PACKAGE_ARGS TRUE
+                  )
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+rapids_export(BUILD FakEProJecT
+  EXPORT_SET fake_set
+  LANGUAGES CXX
+  )
+
+# Verify that build files have correct names
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/fakeproject-config.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config file name")
+endif()
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/fakeproject-config-version.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config-version file name")
+endif()
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/fakeproject-dependencies.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct dependencies file name")
+endif()
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/fakeproject-CXX-language.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct language file name")
+endif()


### PR DESCRIPTION
The generated configuration files need be all lowercase when using `-config.cmake`.
