### PR TITLE
Rapids export properly sets version variables

### DIFF
--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -106,6 +106,7 @@ function(rapids_export type project_name)
 
   #Write configuration and version files
   string(TOLOWER ${project_name} project_name)
+  string(TOUPPER ${project_name} project_name_uppercase)
   if(type STREQUAL "install")
     set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/${project_name}")
     set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export")

--- a/rapids-cmake/export/template/config.cmake.in
+++ b/rapids-cmake/export/template/config.cmake.in
@@ -23,10 +23,10 @@ Result Variables
 
 This module will set the following variables::
 
-  @project_name@_FOUND
-  @project_name@_VERSION
-  @project_name@_VERSION_MAJOR
-  @project_name@_VERSION_MINOR
+  @project_name_uppercase@_FOUND
+  @project_name_uppercase@_VERSION
+  @project_name_uppercase@_VERSION_MAJOR
+  @project_name_uppercase@_VERSION_MINOR
 
 #]=======================================================================]
 
@@ -43,8 +43,16 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@project_name@-dependencies.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-dependencies.cmake")
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-targets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@project_name@-targets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-targets.cmake")
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-config-version.cmake")
+
+# Set our version variables
+set(@project_name_uppercase@_VERSION_MAJOR ${CVF_VERSION_MAJOR})
+set(@project_name_uppercase@_VERSION_MINOR ${CVF_VERSION_MINOR})
+set(@project_name_uppercase@_VERSION "${CVF_VERSION_MAJOR}.${CVF_VERSION_MINOR}")
 
 
 set(rapids_global_targets @RAPIDS_GLOBAL_TARGETS@)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -18,6 +18,7 @@ add_cmake_config_test( export_cpm-build.cmake )
 add_cmake_config_test( export_cpm-install.cmake )
 
 add_cmake_config_test( export-verify-file-names.cmake )
+add_cmake_config_test( export-verify-version.cmake )
 
 add_cmake_config_test( export_package-build.cmake )
 add_cmake_config_test( export_package-install.cmake )

--- a/testing/export/export-verify-version.cmake
+++ b/testing/export/export-verify-version.cmake
@@ -1,0 +1,49 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/export.cmake)
+
+project(test LANGUAGES CXX VERSION 3.1.4)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+rapids_export(BUILD test
+  EXPORT_SET fake_set
+  LANGUAGES CXX
+  )
+
+# Verify that build files have correct names
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/test-config.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config file name")
+endif()
+
+unset(TEST_VERSION)
+unset(TEST_VERSION_MAJOR)
+unset(TEST_VERSION_MINOR)
+
+set(CMAKE_FIND_PACKAGE_NAME test) # Emulate `find_package`
+include("${CMAKE_BINARY_DIR}/test-config.cmake")
+
+if(NOT TEST_VERSION VERSION_EQUAL 3.1)
+  message(FATAL_ERROR "rapids_export failed to export version information")
+endif()
+
+if(NOT "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}" VERSION_EQUAL 3.1)
+  message(FATAL_ERROR "rapids_export failed to export version major/minor information")
+endif()
+
+


### PR DESCRIPTION
While `rapids-cmake` generated a `project-config.cmake` that listed it created version variables, it actually did not. 

This now generates the version values as encoded in the `project-config-version` file.

Also corrects an issue discovered while testing where `rapids_export` couldn't handle projects that generated no targets.