### PR TITLE
rapids_export_write_language properly executes each time CMake is run

### DIFF
--- a/rapids-cmake/export/write_language.cmake
+++ b/rapids-cmake/export/write_language.cmake
@@ -48,11 +48,6 @@ function(rapids_export_write_language type lang file_path)
 # since linking to a target with language standards
 # means `using`
 
-if(DEFINED CMAKE_@lang@_COMPILER)
-  #language already enabled
-  return()
-endif()
-
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   if(NOT DEFINED CMAKE_CURRENT_FUNCTION)
     #Can't be called inside a function


### PR DESCRIPTION
Previously after the first execution of CMake the resulting language
hooks wouldn't be installed and any target that required that
language to be global would error with an unknown link language.
