### PR TITLE
rapids_export correctly handles version strings with leading zeroes

### DIFF
--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -115,7 +115,18 @@ function(rapids_export type project_name)
                                   "${scratch_dir}/${project_name}-config.cmake"
                                   INSTALL_DESTINATION "${install_location}")
 
+    # Use explicit VERSION string without patch version to work around issue:
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/22207
+    # To do this we trim any leading zeroes from our major && minor version values
+    # as patch isn't used for compatibility.
+    string(REGEX REPLACE "^0+" "" version_minor "${PROJECT_VERSION_MINOR}")
+    string(REGEX REPLACE "^0+" "" version_major "${PROJECT_VERSION_MAJOR}")
+    set(rapdis_project_version "${version_major}.${version_minor}")
+    if(PROJECT_VERSION_PATCH)
+      string(APPEND rapdis_project_version ".${PROJECT_VERSION_PATCH}")
+    endif()
     write_basic_package_version_file("${scratch_dir}/${project_name}-config-version.cmake"
+                                     VERSION ${rapdis_project_version}
                                      COMPATIBILITY SameMinorVersion)
 
     install(EXPORT  ${RAPIDS_EXPORT_SET}
@@ -147,7 +158,18 @@ function(rapids_export type project_name)
                                   "${install_location}/${project_name}-config.cmake"
                                   INSTALL_DESTINATION "${install_location}")
 
+    # Use explicit VERSION string without patch version to work around issue:
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/22207
+    # To do this we trim any leading zeroes from our major && minor version values
+    # as patch isn't used for compatibility.
+    string(REGEX REPLACE "^0+" "" version_minor "${PROJECT_VERSION_MINOR}")
+    string(REGEX REPLACE "^0+" "" version_major "${PROJECT_VERSION_MAJOR}")
+    set(rapdis_project_version "${version_major}.${version_minor}")
+    if(PROJECT_VERSION_PATCH)
+      string(APPEND rapdis_project_version ".${PROJECT_VERSION_PATCH}")
+    endif()
     write_basic_package_version_file("${install_location}/${project_name}-config-version.cmake"
+                                     VERSION ${rapdis_project_version}
                                      COMPATIBILITY SameMinorVersion)
 
     export(EXPORT ${RAPIDS_EXPORT_SET}

--- a/rapids-cmake/export/template/config.cmake.in
+++ b/rapids-cmake/export/template/config.cmake.in
@@ -50,9 +50,10 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-config-version.cmake")
 
 # Set our version variables
-set(@project_name_uppercase@_VERSION_MAJOR ${CVF_VERSION_MAJOR})
-set(@project_name_uppercase@_VERSION_MINOR ${CVF_VERSION_MINOR})
-set(@project_name_uppercase@_VERSION "${CVF_VERSION_MAJOR}.${CVF_VERSION_MINOR}")
+set(@project_name_uppercase@_VERSION_MAJOR @PROJECT_VERSION_MAJOR@)
+set(@project_name_uppercase@_VERSION_MINOR @PROJECT_VERSION_MINOR@)
+set(@project_name_uppercase@_VERSION_PATCH @PROJECT_VERSION_PATCH@)
+set(@project_name_uppercase@_VERSION @PROJECT_VERSION@)
 
 
 set(rapids_global_targets @RAPIDS_GLOBAL_TARGETS@)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -18,6 +18,7 @@ add_cmake_config_test( export_cpm-build.cmake )
 add_cmake_config_test( export_cpm-install.cmake )
 
 add_cmake_config_test( export-verify-file-names.cmake )
+add_cmake_config_test( export-verify-calendar-version-matching.cmake )
 add_cmake_config_test( export-verify-version.cmake )
 
 add_cmake_config_test( export_package-build.cmake )

--- a/testing/export/export-verify-calendar-version-matching.cmake
+++ b/testing/export/export-verify-calendar-version-matching.cmake
@@ -16,7 +16,7 @@
 include(${rapids-cmake-dir}/export/cpm.cmake)
 include(${rapids-cmake-dir}/export/export.cmake)
 
-project(test LANGUAGES CXX VERSION 3.1.4)
+project(test LANGUAGES CXX VERSION 21.09.03)
 
 add_library(fakeLib INTERFACE)
 install(TARGETS fakeLib EXPORT fake_set)
@@ -31,19 +31,16 @@ if(NOT EXISTS "${CMAKE_BINARY_DIR}/test-config.cmake")
   message(FATAL_ERROR "rapids_export failed to generate correct config file name")
 endif()
 
-unset(TEST_VERSION)
-unset(TEST_VERSION_MAJOR)
-unset(TEST_VERSION_MINOR)
+set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+find_package(test 21.09.01 REQUIRED)
 
-set(CMAKE_FIND_PACKAGE_NAME test) # Emulate `find_package`
-include("${CMAKE_BINARY_DIR}/test-config.cmake")
+message(STATUS "TEST_VERSION ${TEST_VERSION}")
+message(STATUS "TEST_VERSION_VALUES ${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}")
 
-if(NOT TEST_VERSION VERSION_EQUAL 3.1.4)
+if(NOT TEST_VERSION VERSION_EQUAL 21.09.03)
   message(FATAL_ERROR "rapids_export failed to export version information")
 endif()
 
-if(NOT "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}" VERSION_EQUAL 3.1)
+if(NOT "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}" VERSION_EQUAL 21.09)
   message(FATAL_ERROR "rapids_export failed to export version major/minor information")
 endif()
-
-


### PR DESCRIPTION
As of CMake 3.20 the `find_package` logic doesn't properly handle
leading zeroes in version numbers. For example `find_package(Example 21.02)`
will try to match the minor version of `2` instead of `02`, causing
failures.

To work around this issue `rapids_export` now drops any leading
zeroes when calling `write_basic_package_version_file` so that
`find_package` works properly. To make sure that the version
reported by the generated config file is consistent we DONT
drop the zero there.

End result is that `find_package(Example 21.02)` works properly
and the EXAMPLE_VERSION variable will be `21.02`.

CMake issue: https://gitlab.kitware.com/cmake/cmake/-/issues/22207
