### PR TITLE
Verify that rapids-cmake always preserves CPM arguments

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
   GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        origin/main
+  GIT_TAG        origin/branch-21.06
   )
 FetchContent_MakeAvailable(rapids-cmake)
 include(rapids-cmake)
@@ -31,7 +31,7 @@ include(rapids-find)
 
 rapids_cuda_init_architectures(integration)
 
-project(integration VERSION 0.20.0 LANGUAGES C CXX CUDA)
+project(integration VERSION 21.06 LANGUAGES C CXX CUDA)
 message(STATUS "Example: CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
 
 option(CUDA_STATIC_RUNTIME "Use CUDA static runtime" OFF)

--- a/rapids-cmake/export/template/cpm.cmake.in
+++ b/rapids-cmake/export/template/cpm.cmake.in
@@ -7,7 +7,7 @@ if(possible_build_dir AND NOT DEFINED @name@_DIR)
   set(@name@_DIR "${possible_build_dir}")
 endif()
 
-CPMFindPackage(@name@
+CPMFindPackage(
   "@RAPIDS_CPM_ARGS@"
   )
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -23,7 +23,7 @@ include(utils/cmake_build_test.cmake)
 
 
 add_subdirectory(cmake)
-# add_subdirectory(cpm)
+add_subdirectory(cpm)
 add_subdirectory(cuda)
 add_subdirectory(export)
 add_subdirectory(find)

--- a/testing/cpm/cpm_find-existing-build-dir/CMakeLists.txt
+++ b/testing/cpm/cpm_find-existing-build-dir/CMakeLists.txt
@@ -1,0 +1,47 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(rapids-test-project LANGUAGES CXX)
+
+include("${rapids-cmake-testing-dir}/cpm/make_fake_project_build_dir_with_config.cmake")
+
+make_fake_project_build_dir_with_config(RapidsTestFind 2021.01.02
+    RapidsTestFindConfig.cmake
+    RapidsTestFindConfigVersion.cmake)
+
+make_fake_project_build_dir_with_config(RapidsTestFind2 0.2
+    rapidstestfind2-config.cmake
+    rapidstestfind2-config-version.cmake)
+
+rapids_cpm_init()
+
+set(CMAKE_PREFIX_PATH
+  "${CMAKE_CURRENT_BINARY_DIR}/RapidsTestFind-build/"
+  "${CMAKE_CURRENT_BINARY_DIR}/RapidsTestFind2-build/"
+  )
+
+rapids_cpm_find(RapidsTestFind 2021.01.02)
+rapids_cpm_find(RapidsTestFind2 0.2)
+
+if(NOT TARGET RapidsTest::RapidsTest)
+  message(FATAL_ERROR "RapidsTest targets should be generated")
+endif()
+if(NOT TARGET RapidsTest2::RapidsTest)
+  message(FATAL_ERROR "RapidsTest2 targets should be generated")
+endif()

--- a/testing/cpm/cpm_find-existing-build-dir/RapidsTestFindConfig.cmake
+++ b/testing/cpm/cpm_find-existing-build-dir/RapidsTestFindConfig.cmake
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+@PACKAGE_INIT@
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-options-escaped )
+include("${CMAKE_CURRENT_LIST_DIR}/RapidsTestFindConfigVersion.cmake")
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE GLOBAL)
+
+check_required_components(RapidsTest2)

--- a/testing/cpm/cpm_find-existing-build-dir/rapidstestfind2-config.cmake
+++ b/testing/cpm/cpm_find-existing-build-dir/rapidstestfind2-config.cmake
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+@PACKAGE_INIT@
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-options-escaped )
+include("${CMAKE_CURRENT_LIST_DIR}/rapidstestfind2-config-version.cmake")
+
+add_library(RapidsTest2::RapidsTest IMPORTED INTERFACE GLOBAL)
+
+check_required_components(RapidsTest2)

--- a/testing/cpm/cpm_find-options-escaped/CMakeLists.txt
+++ b/testing/cpm/cpm_find-options-escaped/CMakeLists.txt
@@ -1,0 +1,52 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(rapids-test-project LANGUAGES CXX)
+
+rapids_cpm_init()
+rapids_cpm_find( RapidsTest 20.09.00
+                 GLOBAL_TARGETS RapidsTest::RapidsTest
+                 BUILD_EXPORT_SET example_export_set
+                   CPM_ARGS
+                      DOWNLOAD_COMMAND "ls" #Fake comment
+                      OPTIONS
+                        "BUILD_TESTS TRUE"
+                        "BUILD_EXAMPLES FALSE"
+                   )
+add_library(exampleLib INTERFACE)
+install(TARGETS exampleLib EXPORT example_export_set)
+
+include(${rapids-cmake-dir}/export/export.cmake)
+rapids_export(BUILD rapids-test-project
+  EXPORT_SET example_export_set
+  )
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-test-project-dependencies.cmake")
+  message(FATAL_ERROR "rapids_cpm_find(BUILD) failed to generate a CPM configuration")
+endif()
+
+# We need to validate that we propagate NAME, VERSION, and CPM ARGS properly to
+# the exported dependency file
+set(to_match_string [=["NAME;RapidsTest;VERSION;20.09.00;DOWNLOAD_COMMAND;ls;OPTIONS;BUILD_TESTS TRUE;BUILD_EXAMPLES FALSE"]=])
+file(READ "${CMAKE_BINARY_DIR}/rapids-test-project-dependencies.cmake" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_cpm_find(BUILD) failed to perserve quotes around CPM arguments")
+endif()
+

--- a/testing/cpm/cpm_find-options-escaped/rapidstest-config.cmake
+++ b/testing/cpm/cpm_find-options-escaped/rapidstest-config.cmake
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+@PACKAGE_INIT@
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-options-escaped )
+cmake_minimum_required(VERSION 3.20)
+
+include("${CMAKE_CURRENT_LIST_DIR}/rapidstest-config-version.cmake")
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE GLOBAL)
+
+check_required_components(RapidsTest)

--- a/testing/cpm/make_fake_project_build_dir_with_config.cmake
+++ b/testing/cpm/make_fake_project_build_dir_with_config.cmake
@@ -14,5 +14,20 @@
 # limitations under the License.
 #=============================================================================
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-options-escaped )
+function(make_fake_project_build_dir_with_config name version config_file version_file)
+  include(CMakePackageConfigHelpers)
+
+  # Generate a fake config module for RapidsTestFind
+  set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${name}-build/")
+  file(MAKE_DIRECTORY ${build_dir})
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${config_file}"
+    "${build_dir}/${config_file}"
+    INSTALL_DESTINATION "${build_dir}/${config_file}"
+  )
+
+  write_basic_package_version_file("${build_dir}/${version_file}"
+    VERSION ${version}
+    COMPATIBILITY SameMajorVersion)
+endfunction()

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -16,15 +16,17 @@
 
 add_cmake_config_test( export_cpm-build.cmake )
 add_cmake_config_test( export_cpm-install.cmake )
+add_cmake_config_test( export_cpm-options-escaped.cmake )
 
-add_cmake_config_test( export-verify-file-names.cmake )
 add_cmake_config_test( export-verify-calendar-version-matching.cmake )
+add_cmake_config_test( export-verify-file-names.cmake )
 add_cmake_config_test( export-verify-version.cmake )
 
 add_cmake_config_test( export_package-build.cmake )
 add_cmake_config_test( export_package-install.cmake )
 add_cmake_config_test( export_package-multiple-export_sets.cmake )
 
+add_cmake_config_test( write_dependencies-cpm-preserve-options.cmake )
 add_cmake_config_test( write_dependencies-duplicate-cpm.cmake )
 add_cmake_config_test( write_dependencies-duplicate-packages.cmake )
 

--- a/testing/export/export_cpm-options-escaped.cmake
+++ b/testing/export/export_cpm-options-escaped.cmake
@@ -1,0 +1,63 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+
+
+rapids_export_cpm( build
+                   FAKE_CPM_PACKAGE
+                   test_export_set
+                   CPM_ARGS
+                      NAME FAKE_CPM_PACKAGE
+                      VERSION 1.0
+                      OPTIONS
+                        "FAKE_PACKAGE_OPTION_A TRUE"
+                        "FAKE_PACKAGE_OPTION_B FALSE"
+                   )
+
+rapids_export_cpm( install
+                   FAKE_CPM_PACKAGE
+                   test_export_set
+                   CPM_ARGS
+                      NAME FAKE_CPM_PACKAGE
+                      VERSION 1.0
+                      OPTIONS
+                        "FAKE_PACKAGE_OPTION_A TRUE"
+                        "FAKE_PACKAGE_OPTION_B FALSE"
+                   )
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
+  message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to generate a CPM configuration")
+endif()
+
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/FAKE_CPM_PACKAGE.cmake")
+  message(FATAL_ERROR "rapids_export_cpm(INSTALL) failed to generate a CPM configuration")
+endif()
+
+# We need to validate both of the files all CPM args in quotes
+#
+set(to_match_string [=["NAME;FAKE_CPM_PACKAGE;VERSION;1.0;OPTIONS;FAKE_PACKAGE_OPTION_A TRUE;FAKE_PACKAGE_OPTION_B FALSE"]=])
+
+file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to perserve quotes around CPM arguments")
+endif()
+
+file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/FAKE_CPM_PACKAGE.cmake" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_cpm(INSTALL) failed to perserve quotes around CPM arguments")
+endif()

--- a/testing/export/write_dependencies-cpm-preserve-options.cmake
+++ b/testing/export/write_dependencies-cpm-preserve-options.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/write_dependencies.cmake)
+
+rapids_export_cpm( INSTALL RMM test_set
+                   CPM_ARGS
+                    NAME RMM
+                    VERSION 2.0
+                    OPTIONS
+                      "FAKE_PACKAGE_ARGS FALSE"
+                   GLOBAL_TARGETS RMM::RMM_POOL
+                   )
+
+rapids_export_write_dependencies(install test_set "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake")
+
+# Parse the `export_set.cmake` file for correct escaped args to `CPMFindPackage` calls
+set(to_match_string [=["NAME;RMM;VERSION;2.0;OPTIONS;FAKE_PACKAGE_ARGS FALSE"]=])
+
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_write_dependencies(BUILD) failed to perserve quotes around CPM arguments")
+endif()


### PR DESCRIPTION
Per #16
We need to make sure that we properly escape CPM arguments so that `OPTIONAL` arguments are passed correctly.

This adds a collection of tests to verify that we always generate a CPMFindPackage call with all arguments in quotes
