### PR TITLE
Testing: Enumerate every test for supported generators

### DIFF
--- a/testing/utils/cmake_build_test.cmake
+++ b/testing/utils/cmake_build_test.cmake
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+include_guard(GLOBAL)
 
 include(utils/cmake_test.cmake)
 

--- a/testing/utils/cmake_config_test.cmake
+++ b/testing/utils/cmake_config_test.cmake
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+include_guard(GLOBAL)
 
 include(utils/cmake_test.cmake)
 

--- a/testing/utils/cmake_detect_generators.cmake
+++ b/testing/utils/cmake_detect_generators.cmake
@@ -1,0 +1,50 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+
+#[=======================================================================[.rst:
+cmake_detect_generators
+-----------------------
+.. versionadded:: v21.06.00
+
+Reports back what generators from the set of below are usable on the current machine
+  - `Ninja`
+  - `Ninja Multi-Config`
+  - `Unix Makefiles`
+
+#]=======================================================================]
+function(cmake_detect_generators generator_name_var fancy_name_var)
+
+  # See CMakeUnixFindMake and CMakeNinjaFindMake
+  find_program(RAPIDS_TESTING_MAKE_GEN NAMES gmake make smake NAMES_PER_DIR)
+  find_program(RAPIDS_TESTING_NINJA_GEN NAMES ninja-build ninja samu NAMES_PER_DIR)
+
+  if(RAPIDS_TESTING_MAKE_GEN)
+    list(APPEND supported_gens "Unix Makefiles")
+    list(APPEND nice_names "makefile")
+  endif()
+
+  if(RAPIDS_TESTING_NINJA_GEN)
+    list(APPEND supported_gens "Ninja")
+    list(APPEND nice_names "ninja")
+
+    list(APPEND supported_gens "Ninja Multi-Config")
+    list(APPEND nice_names "ninja_multi-config")
+  endif()
+  set(${generator_name_var} "${supported_gens}" PARENT_SCOPE)
+  set(${fancy_name_var} "${nice_names}" PARENT_SCOPE)
+endfunction()

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -15,39 +15,47 @@
 #=============================================================================
 include_guard(GLOBAL)
 
+include(utils/cmake_detect_generators.cmake)
+
 #[=======================================================================[.rst:
 add_cmake_build_test
 --------------------
 
-generate a CMake tests given either a single CMake file or a directory.
-
 .. versionadded:: v21.06.00
 
-.. command:: add_cmake_build_test
+Generates a CMake test(s) for the given input CMake file or directory.
+Determines the set of supported generators from the below list and
+adds a test for each generator:
+  - `Ninja`
+  - `Ninja Multi-Config`
+  - `Unix Makefiles`
 
-  .. code-block:: cmake
+.. code-block:: cmake
 
-    add_cmake_build_test( (config|build|run|install)
-                          <SourceOrDir>
-                        )
+  add_cmake_build_test( (config|build|run|install)
+                        <SourceOrDir>
+                      )
 
-    ``config``
-      Generate a CMake project and runs CMake config and generate
-      step. Expects the test to raise an error to mark failures
+``config``
+  Generate a CMake project and runs CMake config and generate
+  step. Expects the test to raise an error to mark failures
 
-    ``build``
-      Generate and build a CMake project. The CMake config and generate
-      step is constructed as a setup fixture.
-      Expects the test to either raise an error during config, or fail
-      to build to mark failures
+``build``
+  Generate and build a CMake project. The CMake config and generate
+  step is constructed as a setup fixture.
+  Expects the test to either raise an error during config, or fail
+  to build to mark failures
 
-    ``install``
-      - Not implemented
+``install``
+  - Not implemented
 
 #]=======================================================================]
 function(add_cmake_test mode source_or_dir)
+
+  cmake_detect_generators(supported_generators nice_gen_names)
+
   string(TOLOWER ${mode} mode)
-  cmake_path(GET source_or_dir STEM test_name)
+  cmake_path(GET source_or_dir STEM test_name_stem)
 
   # Determine if we are past a relative source file or a directory
   set(have_source_dir FALSE)
@@ -62,41 +70,42 @@ function(add_cmake_test mode source_or_dir)
     message(FATAL_ERROR "Unable to find a file or directory named: ${source_or_dir}")
   endif()
 
+  foreach(generator gen_name IN ZIP_LISTS supported_generators nice_gen_names)
 
-  set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-build")
+    set(test_name "${test_name_stem}-${gen_name}")
+    set(build_dir "${CMAKE_CURRENT_BINARY_DIR}/${test_name}-build")
 
-  if(mode STREQUAL "config")
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_COMMAND}
-             -S ${src_dir} -B ${build_dir}
-             -G ${CMAKE_GENERATOR}
-             -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
-             -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
-  elseif(mode STREQUAL "build")
-    add_test(NAME ${test_name}_configure
-             COMMAND ${CMAKE_COMMAND}
-             -S ${src_dir} -B ${build_dir}
-             -G ${CMAKE_GENERATOR}
-             -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
-             -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
+    if(mode STREQUAL "config")
+      add_test(NAME ${test_name}
+               COMMAND ${CMAKE_COMMAND}
+               -S ${src_dir} -B ${build_dir}
+               -G "${generator}"
+               -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
+               -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
+    elseif(mode STREQUAL "build")
+      add_test(NAME ${test_name}_configure
+               COMMAND ${CMAKE_COMMAND}
+               -S ${src_dir} -B ${build_dir}
+               -G "${generator}"
+               -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
+               -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
 
-    add_test(NAME ${test_name}
-             COMMAND ${CMAKE_COMMAND}
-             --build ${build_dir} -j3 )
+      add_test(NAME ${test_name}
+               COMMAND ${CMAKE_COMMAND}
+               --build ${build_dir} -j3 )
 
-    set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})
-    set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED ${test_name})
+      set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})
+      set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED ${test_name})
+    elseif(mode STREQUAL "install")
+      message(FATAL_ERROR "install mode not yet implemented by add_cmake_build_test")
+    else()
+      message(FATAL_ERROR "${mode} mode not one of the valid modes (config|build|install) by add_cmake_build_test")
+    endif()
 
-
-  elseif(mode STREQUAL "install")
-    message(FATAL_ERROR "install mode not yet implemented by add_cmake_build_test")
-  else()
-    message(FATAL_ERROR "${mode} mode not one of the valid modes (config|build|install) by add_cmake_build_test")
-  endif()
-
-  # Apply a label to the test based on the folder it is in
-  get_filename_component(label_name ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
-  string(TOLOWER "${label_name}" lower_case_label )
-  set_tests_properties(${test_name} PROPERTIES LABELS ${lower_case_label})
+    # Apply a label to the test based on the folder it is in and the generator used
+    get_filename_component(label_name ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
+    string(TOLOWER "${label_name}" lower_case_label )
+    set_tests_properties(${test_name} PROPERTIES LABELS "${lower_case_label};${gen_name}")
+  endforeach()
 
 endfunction()


### PR DESCRIPTION
So now we can test the same function across 'Unix Makefiles', 'Ninja', and 'Ninja Multi-Config' from the same build/test directory.