### PR TITLE
add cmake formatting rules for rapids commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,8 @@ Here are some guidelines to help the review process go smoothly.
    - Each function should go into a separate `.cmake` file in the appropriate directory
    - Each user facing `.cmake` file should have include guards (`include_guard(GLOBAL)`)
    - Each user facing `.cmake` file should be documented using the rst structure
+   - Each user facing function should be added to the `cmake-format.json` document
+    - Run `cmake-genparsers -f json` on the `.cmake` file as a starting point
    - Each function first line should be `list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.<component>.<function>")`
 
    - A file should not modify any state simply by being included. State modification should

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Please see https://github.com/rapidsai/rapids-cmake/releases/tag/v21.08.0a for t
 ## 🚀 New Features
 
 - Introduce `rapids_cmake_write_version_file` to generate a C++ version header ([#23](https://github.com/rapidsai/rapids-cmake/pull/23)) [@robertmaynard](https://github.com/robertmaynard)
+- Introduce `cmake-format-rapids-cmake` to allow `cmake-format` to understand rapdids-cmake custom functions ([#29](https://github.com/rapidsai/rapids-cmake/pull/29)) [@robertmaynard](https://github.com/robertmaynard)
 
 ## 🛠️ Improvements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,9 @@ Please ensure that when you are creating new features you follow the following g
    - Each function should follow the `rapids_<component>_<file_name>` naming pattern
    - Each function should go into a separate `.cmake` file in the approiate directory
    - Each user facing `.cmake` file should have include guards (`include_guard(GLOBAL)`)
-   - Each user faceing `.cmake` file should be documented using the rst structure
+   - Each user facing `.cmake` file should be documented following the rst structure
+   - Each user facing function should be added to the `cmake-format.json` document
+    - Run `cmake-annotate --json` on the `.cmake` file as a starting point
    - Each function first line should be `list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.<component>.<function>")`
    - A file should not modify any state simply by being included. State modification should
      only occur inside functions unless absolutely neccessary due to restrctions of the CMake

--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -1,0 +1,154 @@
+{
+  "parse": {
+    "additional_commands": {
+
+      "rapids_cmake_build_type": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+      "rapids_cmake_make_global": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+      "rapids_cmake_parse_version": {
+        "pargs": {
+          "nargs": 3
+        }
+      },
+      "rapids_cmake_support_conda_env": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+      "rapids_cmake_write_version_file": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+
+     "rapids_cpm_find": {
+        "pargs": {
+          "nargs": "2+"
+        },
+        "kwargs": {
+          "BUILD_EXPORT_SET": 1,
+          "INSTALL_EXPORT_SET": 1,
+          "GLOBAL_TARGETS": "+",
+          "CPM_ARGS": "+",
+          "GIT_REPOSITORY": "1",
+          "GIT_TAG": "1",
+          "GIT_SHALLOW": "1",
+          "OPTIONS": "+"
+        }
+      },
+      "rapids_cpm_init": {
+        "pargs": {
+          "nargs": 0
+        }
+      },
+
+      "rapids_cuda_init_architectures": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+      "rapids_cuda_init_runtime": {
+        "pargs": {
+          "nargs": 2
+        }
+      },
+      "rapids_cuda_set_architectures": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
+
+      "rapids_export_cpm": {
+        "pargs": {
+          "nargs": "3+",
+          "flags": ["INSTALL", "BUILD"]
+        },
+        "kwargs": {
+          "GLOBAL_TARGETS": "+",
+          "CPM_ARGS": "+"
+        }
+      },
+      "rapids_export": {
+        "pargs": {
+          "nargs": "2+",
+          "flags": ["INSTALL", "BUILD"]
+        },
+        "kwargs": {
+          "EXPORT_SET": 1,
+          "NAMESPACE": 1,
+          "DOCUMENTATION": 1,
+          "FINAL_CODE_BLOCK": 1,
+          "GLOBAL_TARGETS": "+",
+          "LANGUAGES": "+"
+        }
+      },
+      "rapids_export_find_package_file": {
+        "pargs": {
+          "nargs": 3,
+          "flags": ["INSTALL", "BUILD"]
+        }
+      },
+      "rapids_export_package": {
+        "pargs": {
+          "nargs": "1+"
+        },
+        "kwargs": {
+          "GLOBAL_TARGETS": "+",
+          "INSTALL": 2,
+          "BUILD": 2
+        }
+      },
+      "rapids_export_write_dependencies": {
+        "pargs": {
+          "nargs": 3,
+          "flags": ["INSTALL", "BUILD"]
+        }
+      },
+      "rapids_export_write_language": {
+        "pargs": {
+          "nargs": 3,
+          "flags": ["INSTALL", "BUILD"]
+        }
+      },
+
+      "rapids_find_generate_module": {
+        "pargs": {
+          "nargs": "1+",
+          "flags": [
+            "NO_CONFIG"
+          ]
+        },
+        "kwargs": {
+          "VERSION": 1,
+          "BUILD_EXPORT_SET": 1,
+          "INSTALL_EXPORT_SET": 1,
+          "HEADER_NAMES": "+",
+          "LIBRARY_NAMES": "+",
+          "INCLUDE_SUFFIXES": "+"
+        }
+      },
+      "rapids_find_package": {
+        "pargs": {
+          "nargs": "1+",
+          "flags": [
+            "REQUIRED"
+          ]
+        },
+        "kwargs": {
+          "BUILD_EXPORT_SET": 1,
+          "INSTALL_EXPORT_SET": 1,
+          "GLOBAL_TARGETS": "+",
+          "FIND_ARGS": "+"
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
This allows projects that use `cmake-format` to have properly formatted `rapids_cmake` functions, as cmake-format supports multiple json files:

```
cmake-format --in-place --config-files cmake/config.json build/_deps/rapids-cmake-src/cmake-format-rapids-cmake.json
```