### PR TITLE
rapids_export verify DOCUMENTATION and FINAL_CODE_BLOCK work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please see https://github.com/rapidsai/rapids-cmake/releases/tag/v21.08.0a for t
 
 ## 🐛 Bug Fixes
 - Add tests that verify all paths in each rapids-<component>.cmake file ([#24](https://github.com/rapidsai/rapids-cmake/pull/24))  [@robertmaynard](https://github.com/robertmaynard)
+- Correct issue where `rapids_export(DOCUMENTATION` content was being ignored([#30](https://github.com/rapidsai/rapids-cmake/pull/30))  [@robertmaynard](https://github.com/robertmaynard)
 
 
 # rapids-cmake 21.06.00 (Date TBD)

--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -141,7 +141,7 @@ function(rapids_export type project_name)
   endif()
 
   set(RAPIDS_PROJECT_DOCUMENTATION "Generated ${project_name}-config module")
-  if(NOT DEFINED RAPIDS_DOCUMENTATION)
+  if(DEFINED RAPIDS_DOCUMENTATION)
     set(RAPIDS_PROJECT_DOCUMENTATION "${${RAPIDS_DOCUMENTATION}}")
   endif()
 

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -20,6 +20,8 @@ add_cmake_config_test( export_cpm-install.cmake )
 add_cmake_config_test( export_cpm-options-escaped.cmake )
 
 add_cmake_build_test( export-verify-build-namespaces )
+add_cmake_build_test( export-verify-code-block )
+add_cmake_build_test( export-verify-doc-string )
 add_cmake_config_test( export-verify-calendar-version-matching.cmake )
 add_cmake_config_test( export-verify-file-names.cmake )
 add_cmake_config_test( export-verify-version.cmake )

--- a/testing/export/export-verify-code-block/CMakeLists.txt
+++ b/testing/export/export-verify-code-block/CMakeLists.txt
@@ -1,0 +1,58 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/export.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(FakEProJecT LANGUAGES CXX VERSION 3.1.4)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+set(code_block
+  [=[
+set(code_block_variable "Unique String To Verify")
+]=])
+
+rapids_export(BUILD FakEProJecT
+  EXPORT_SET fake_set
+  NAMESPACE test::
+  FINAL_CODE_BLOCK code_block
+  )
+
+# Add a custom command that generates a second project
+# that verifies our target was exported with the correct
+# namespace
+file(WRITE "${CMAKE_BINARY_DIR}/verify/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.20)
+project(verify_build_targets LANGUAGES CXX)
+message(STATUS "${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake")
+if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config file name")
+endif()
+set(CMAKE_FIND_PACKAGE_NAME FakEProJecT) # Emulate `find_package`
+include("${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake")
+
+if(NOT code_block_variable STREQUAL "Unique String To Verify")
+  message(FATAL_ERROR "rapids_export failed to generate correct final code block")
+endif()
+  ]=])
+
+add_custom_target(verify_target_file ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/verify/build"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_BINARY_DIR}/verify" -B="${CMAKE_BINARY_DIR}/verify/build"
+  )
+
+

--- a/testing/export/export-verify-doc-string/CMakeLists.txt
+++ b/testing/export/export-verify-doc-string/CMakeLists.txt
@@ -1,0 +1,57 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/export.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(FakEProJecT LANGUAGES CXX VERSION 3.1.4)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+set(doc_string
+  [=[
+Unique String To Verify.
+]=])
+
+rapids_export(BUILD FakEProJecT
+  EXPORT_SET fake_set
+  NAMESPACE test::
+  DOCUMENTATION doc_string
+  )
+
+# Add a custom command that generates a second project
+# that verifies our target was exported with the correct
+# namespace
+file(WRITE "${CMAKE_BINARY_DIR}/verify/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.20)
+project(verify_build_targets LANGUAGES CXX)
+message(STATUS "${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake")
+if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config file name")
+endif()
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../fakeproject-config.cmake" contents)
+string(FIND "${contents}" "Unique String To Verify" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export failed to generate correct doc string")
+endif()
+  ]=])
+
+add_custom_target(verify_target_file ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/verify/build"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_BINARY_DIR}/verify" -B="${CMAKE_BINARY_DIR}/verify/build"
+  )
+
+


### PR DESCRIPTION
This corrects a bug inside how `rapids_export` handled `DOCUMENTATION` and also adds tests to verify that `DOCUMENTATION` and `FINAL_CODE_BLOCK` logic works as intended.