### PR TITLE
rapids-cmake can now be correctly used by multiple adjacent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please see https://github.com/rapidsai/rapids-cmake/releases/tag/v21.08.0a for t
 ## 🐛 Bug Fixes
 - Add tests that verify all paths in each rapids-<component>.cmake file ([#24](https://github.com/rapidsai/rapids-cmake/pull/24))  [@robertmaynard](https://github.com/robertmaynard)
 - Correct issue where `rapids_export(DOCUMENTATION` content was being ignored([#30](https://github.com/rapidsai/rapids-cmake/pull/30))  [@robertmaynard](https://github.com/robertmaynard)
+- rapids-cmake can now be correctly used by multiple adjacent directories ([#33](https://github.com/rapidsai/rapids-cmake/pull/33))  [@robertmaynard](https://github.com/robertmaynard)
 
 
 # rapids-cmake 21.06.00 (Date TBD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,26 @@
 # limitations under the License.
 #=============================================================================
 #
-# This is an entry point for other projects using rapids-cmake
-# Nothing should happen except setup to allow usage of the core components
+# This is an entry point for the vast majorty of projects using rapids-cmake.
+#
+# Unlike `init.cmake` this will setup the following cache variables:
+# - CMAKE_MODULE_PATH
+# - rapids-cmake-dir
+#
+# This is done to make sure that rapids-cmake can be properly included
+# multiple times by sibling projects without issue
 #
 
 # Enfore the minimum required CMake version for all users
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
-# Hoist up this directory as a search path for CMake module
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+if(NOT "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake" IN_LIST CMAKE_MODULE_PATH)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" CACHE PATH "" FORCE)
+  mark_as_advanced(CMAKE_MODULE_PATH)
+endif()
 
-set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake" PARENT_SCOPE)
+if(NOT DEFINED CACHE{rapids-cmake-dir})
+  set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake" CACHE PATH "" FORCE)
+  mark_as_advanced(rapids-cmake-dir)
+endif()

--- a/init.cmake
+++ b/init.cmake
@@ -13,18 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+#
+# This is an entry point for other projects using rapids-cmake that
+# don't want any cache variables constructed
+#
+# Nothing should happen except setup to allow usage of the core components
+#
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+# Hoist up this directory as a search path for CMake module
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}")
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
-
-
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
-add_subdirectory(other)
+set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")

--- a/testing/other/CMakeLists.txt
+++ b/testing/other/CMakeLists.txt
@@ -14,17 +14,4 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
-
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
-
-
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
-add_subdirectory(other)
+add_cmake_config_test( verify_multiple_rapids_cmake_inclusions )

--- a/testing/other/verify_multiple_rapids_cmake_inclusions/A/CMakeLists.txt
+++ b/testing/other/verify_multiple_rapids_cmake_inclusions/A/CMakeLists.txt
@@ -14,17 +14,30 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+# verify no rapids-cmake variables have been specified
+if(DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "")
+endif()
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
+include(FetchContent)
+FetchContent_Declare(
+  rapids-cmake
+  SOURCE_DIR "${rapids-root-dir}"
+  )
+FetchContent_MakeAvailable(rapids-cmake)
 
+if(NOT DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "expected variable rapids-cmake_SOURCE_DIR to exist")
+endif()
 
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
-add_subdirectory(other)
+if(NOT DEFINED rapids-cmake-dir)
+  message(FATAL_ERROR "expected variable rapids-cmake-dir to exist")
+endif()
+
+if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)
+  message(FATAL_ERROR "expected variable rapids-cmake-dir to be inside CMAKE_MODULE_PATH")
+endif()
+
+if(NOT EXISTS "${rapids-cmake_SOURCE_DIR}/init.cmake")
+  message(FATAL_ERROR "")
+endif()

--- a/testing/other/verify_multiple_rapids_cmake_inclusions/B/CMakeLists.txt
+++ b/testing/other/verify_multiple_rapids_cmake_inclusions/B/CMakeLists.txt
@@ -14,17 +14,31 @@
 # limitations under the License.
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+# verify no rapids-cmake variables have been specified
+if(DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "")
+endif()
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
+include(FetchContent)
+FetchContent_Declare(
+  rapids-cmake
+  SOURCE_DIR "${rapids-root-dir}"
+  )
+FetchContent_MakeAvailable(rapids-cmake)
 
+if(NOT DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "")
+endif()
 
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
-add_subdirectory(other)
+if(NOT DEFINED rapids-cmake-dir)
+  message(FATAL_ERROR "")
+endif()
+
+if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)
+  message(FATAL_ERROR "")
+endif()
+
+if(NOT EXISTS "${rapids-cmake_SOURCE_DIR}/init.cmake")
+  message(FATAL_ERROR "")
+endif()
+

--- a/testing/other/verify_multiple_rapids_cmake_inclusions/CMakeLists.txt
+++ b/testing/other/verify_multiple_rapids_cmake_inclusions/CMakeLists.txt
@@ -13,18 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+cmake_minimum_required(VERSION 3.20)
+project(rapids-test-project LANGUAGES CXX)
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-project(rapids-cmake-testing LANGUAGES NONE)
+cmake_path(GET rapids-cmake-dir PARENT_PATH rapids-root-dir)
 
-enable_testing()
-include(utils/cmake_config_test.cmake)
-include(utils/cmake_build_test.cmake)
+# Remove this cache variable so we can properly test
+# fetching rapids-cmake work as intended
+unset(rapids-cmake-dir CACHE)
 
-
-add_subdirectory(cmake)
-add_subdirectory(cpm)
-add_subdirectory(cuda)
-add_subdirectory(export)
-add_subdirectory(find)
-add_subdirectory(other)
+add_subdirectory(A)
+add_subdirectory(B)


### PR DESCRIPTION
rapids-cmake can now be correctly used by multiple adjacent directories    
When in a situation where multiple projects are nested together in the following configuration:
```
- root
 - sub_project_1
 - sub_project_2    
```
If sub_project_1 doesn't import all the rapid-cmake components thatsub_project_2 requires it will cause weird runtime errors
