### PR TITLE
Correct regression specify rapids-cmake-dir as a cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@
 cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
 set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
+if(NOT DEFINED CACHE{rapids-cmake-dir})
+  set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE PATH "" FORCE)
+endif()
+
 if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)
   list(APPEND CMAKE_MODULE_PATH "${rapids-cmake-dir}")
 endif()


### PR DESCRIPTION
This is needed so that `init.cmake` can find the correct include module when `add_subdirectory` calls are nestled inside multiple
function calls
