### PR TITLE
Make sure that rapids-cmake-dir cache variable is hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_minimum_required(VERSION 3.20.1 FATAL_ERROR)
 
 set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
 if(NOT DEFINED CACHE{rapids-cmake-dir})
-  set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE PATH "" FORCE)
+  set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE INTERNAL "" FORCE)
 endif()
 
 if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)


### PR DESCRIPTION
This make sure it is hidden from `ccache` / `cmake-gui` interface as the variable shouldn't be modified
