### PR TITLE
ENH Replace gpuci_conda_retry with gpuci_mamba_retry

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,7 +42,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Installing packages needed for rapids-cmake"
-gpuci_conda_retry  install -y \
+gpuci_mamba_retry  install -y \
                   "cudatoolkit=$CUDA_REL" \
                   "rapids-build-env=$MINOR_VERSION.*"
 


### PR DESCRIPTION
`mamba` was recently added to gpuCI build environment, testing usage and solvability with this PR which should speed up build times.