### PR TITLE
Tests now can be SERIAL and use FetchContent to get rapids-cmake

### DIFF
--- a/testing/utils/cmake_build_test.cmake
+++ b/testing/utils/cmake_build_test.cmake
@@ -18,5 +18,5 @@ include_guard(GLOBAL)
 include(utils/cmake_test.cmake)
 
 function(add_cmake_build_test source_or_dir)
-  add_cmake_test(BUILD "${source_or_dir}")
+  add_cmake_test(BUILD "${source_or_dir}" ${ARGN})
 endfunction()

--- a/testing/utils/cmake_config_test.cmake
+++ b/testing/utils/cmake_config_test.cmake
@@ -18,5 +18,5 @@ include_guard(GLOBAL)
 include(utils/cmake_test.cmake)
 
 function(add_cmake_config_test source_or_dir)
-  add_cmake_test(CONFIG "${source_or_dir}")
+  add_cmake_test(CONFIG "${source_or_dir}" ${ARGN})
 endfunction()

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -33,7 +33,8 @@ adds a test for each generator:
 .. code-block:: cmake
 
   add_cmake_build_test( (config|build|run|install)
-                        <SourceOrDir>
+                         <SourceOrDir>
+                         [SERIAL]
                       )
 
 ``config``
@@ -51,6 +52,10 @@ adds a test for each generator:
 
 #]=======================================================================]
 function(add_cmake_test mode source_or_dir)
+  set(options SERIAL)
+  set(one_value)
+  set(multi_value)
+  cmake_parse_arguments(RAPIDS_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   cmake_detect_generators(supported_generators nice_gen_names)
 
@@ -100,6 +105,10 @@ function(add_cmake_test mode source_or_dir)
       message(FATAL_ERROR "install mode not yet implemented by add_cmake_build_test")
     else()
       message(FATAL_ERROR "${mode} mode not one of the valid modes (config|build|install) by add_cmake_build_test")
+    endif()
+
+    if(RAPIDS_TEST_SERIAL)
+      set_tests_properties(${test_name} PROPERTIES RUN_SERIAL ON)
     endif()
 
     # Apply a label to the test based on the folder it is in and the generator used

--- a/testing/utils/project_template.cmake.in
+++ b/testing/utils/project_template.cmake.in
@@ -15,7 +15,29 @@
 #=============================================================================
 cmake_minimum_required(VERSION 3.20.1)
 
-add_subdirectory("${rapids-cmake-testing-dir}/../" rapids-cmake)
+include(FetchContent)
+
+set(local-rapids-cmake-root "${rapids-cmake-dir}/..")
+FetchContent_Declare(
+  rapids-cmake
+  GIT_REPOSITORY "${local-rapids-cmake-root}/.git"
+  GIT_TAG HEAD
+  )
+
+FetchContent_GetProperties(rapids-cmake)
+FetchContent_Populate(rapids-cmake)
+
+# Copy any local uncommited changes over
+file(COPY ${local-rapids-cmake-root}/rapids-cmake/
+     DESTINATION ${rapids-cmake_SOURCE_DIR}/rapids-cmake/)
+file(COPY ${local-rapids-cmake-root}/CMakeLists.txt
+     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
+file(COPY ${local-rapids-cmake-root}/init.cmake
+     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
+file(COPY ${local-rapids-cmake-root}/RAPIDS.cmake
+     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
+
+add_subdirectory(${rapids-cmake_SOURCE_DIR} ${rapids-cmake_BINARY_DIR})
 
 # We need to enable at least one language so that we get properly
 # generated system search paths.


### PR DESCRIPTION
To properly test `cpm` packages in rapids-cmake we need to fix
two major issues.

 1. A way to have tests that depend on the same CPM package
    not execute at the same time. This is required so we don't
    double checkout a project

 2. A way to checkout and build projects such as RMM that themselves
    use rapids-cmake without issue.

Number #1 is solved by the introduction of the `SERIAL` keyword

Number #2 is solved for most tests by having the `project_template`
that `.cmake` tests use get `rapids-cmake` via FETCH_CONENT. This
will allow us to verify local rapids-cmake changes against existing
projects that use rapids-cmake
