### PR TITLE
rapids_cpm_find is more invariant as one would expect

### DIFF
--- a/testing/cpm/cpm_find-existing-target-to-export-sets/CMakeLists.txt
+++ b/testing/cpm/cpm_find-existing-target-to-export-sets/CMakeLists.txt
@@ -1,0 +1,82 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+include(${rapids-cmake-dir}/export/write_dependencies.cmake)
+
+project(rapids-existing-target LANGUAGES CXX)
+
+include("${rapids-cmake-testing-dir}/cpm/make_fake_project_build_dir_with_config.cmake")
+
+make_fake_project_build_dir_with_config(RapidsTestFind 2021.01.02
+    RapidsTestFindConfig.cmake
+    RapidsTestFindConfigVersion.cmake)
+
+rapids_cpm_init()
+
+set(CMAKE_PREFIX_PATH
+  "${CMAKE_CURRENT_BINARY_DIR}/RapidsTestFind-build/"
+  )
+
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE)
+
+rapids_cpm_find(RapidsTestFind 2021.01.02
+  GLOBAL_TARGETS RapidsTest::RapidsTest
+  INSTALL_EXPORT_SET setA)
+
+rapids_cpm_find(RapidsTestFind 2021.01.02
+  GLOBAL_TARGETS RapidsTest::RapidsTest
+  INSTALL_EXPORT_SET setB)
+
+rapids_cpm_find(RapidsTestFind 2021.01.02
+  GLOBAL_TARGETS RapidsTest::RapidsTest
+  BUILD_EXPORT_SET setB)
+
+
+function(verify_dependency_file file_name to_match)
+  file(STRINGS "${file_name}" text)
+  set(package_dependency_found FALSE)
+
+  foreach(line IN LISTS text)
+    if( line MATCHES ${to_match})
+      set(package_dependency_found TRUE)
+      break()
+    endif()
+  endforeach()
+
+  if(NOT package_dependency_found)
+    message(FATAL_ERROR "${file_name} failed to export RapidsTestFind properly")
+  endif()
+
+endfunction()
+
+set(file_path "${CMAKE_CURRENT_BINARY_DIR}/build_export_set.cmake")
+file(REMOVE "${file_path}")
+rapids_export_write_dependencies(build setB "${file_path}")
+verify_dependency_file("${file_path}" "[=[NAME;RapidsTestFind;VERSION;2021.01.02]=]")
+
+set(file_path "${CMAKE_CURRENT_BINARY_DIR}/install_export_setA.cmake")
+file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/install_export_setA.cmake")
+rapids_export_write_dependencies(build setB "${file_path}")
+verify_dependency_file("${file_path}" "[=[find_dependency(RapidsTestFind)]=]")
+
+set(file_path "${CMAKE_CURRENT_BINARY_DIR}/install_export_setB.cmake")
+file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/install_export_setB.cmake")
+rapids_export_write_dependencies(build setB "${file_path}")
+verify_dependency_file("${file_path}" "[=[find_dependency(RapidsTestFind)]=]")

--- a/testing/cpm/cpm_find-existing-target-to-export-sets/RapidsTestFindConfig.cmake
+++ b/testing/cpm/cpm_find-existing-target-to-export-sets/RapidsTestFindConfig.cmake
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-add_cmake_config_test( rapids-cpm.cmake )
+@PACKAGE_INIT@
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-existing-target )
-add_cmake_config_test( cpm_find-existing-target-to-export-sets )
-add_cmake_config_test( cpm_find-options-escaped )
+include("${CMAKE_CURRENT_LIST_DIR}/RapidsTestFindConfigVersion.cmake")
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE GLOBAL)
+
+check_required_components(RapidsTest2)

--- a/testing/cpm/cpm_find-existing-target/CMakeLists.txt
+++ b/testing/cpm/cpm_find-existing-target/CMakeLists.txt
@@ -13,9 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-add_cmake_config_test( rapids-cpm.cmake )
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-existing-target )
-add_cmake_config_test( cpm_find-existing-target-to-export-sets )
-add_cmake_config_test( cpm_find-options-escaped )
+cmake_minimum_required(VERSION 3.20)
+project(rapids-existing-target LANGUAGES CXX)
+
+include("${rapids-cmake-testing-dir}/cpm/make_fake_project_build_dir_with_config.cmake")
+
+make_fake_project_build_dir_with_config(RapidsTestFind 2021.01.02
+    RapidsTestFindConfig.cmake
+    RapidsTestFindConfigVersion.cmake)
+
+rapids_cpm_init()
+
+set(CMAKE_PREFIX_PATH
+  "${CMAKE_CURRENT_BINARY_DIR}/RapidsTestFind-build/"
+  )
+
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE)
+
+rapids_cpm_find(RapidsTestFind 2021.01.02 GLOBAL_TARGETS RapidsTest::RapidsTest)

--- a/testing/cpm/cpm_find-existing-target/RapidsTestFindConfig.cmake
+++ b/testing/cpm/cpm_find-existing-target/RapidsTestFindConfig.cmake
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-add_cmake_config_test( rapids-cpm.cmake )
+@PACKAGE_INIT@
 
-add_cmake_config_test( cpm_find-existing-build-dir )
-add_cmake_config_test( cpm_find-existing-target )
-add_cmake_config_test( cpm_find-existing-target-to-export-sets )
-add_cmake_config_test( cpm_find-options-escaped )
+include("${CMAKE_CURRENT_LIST_DIR}/RapidsTestFindConfigVersion.cmake")
+
+add_library(RapidsTest::RapidsTest IMPORTED INTERFACE GLOBAL)
+
+check_required_components(RapidsTest2)

--- a/testing/export/write_dependencies-duplicate-packages.cmake
+++ b/testing/export/write_dependencies-duplicate-packages.cmake
@@ -29,7 +29,6 @@ rapids_export_write_dependencies(build test_set "${CMAKE_CURRENT_BINARY_DIR}/exp
 
 file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake" text)
 
-set(duplicate_package )
 foreach(line IN LISTS text)
   # message(STATUS "1. line: ${line}")
   if( line MATCHES "find_dependency\\(ExactlyDuplicate\\)" )


### PR DESCRIPTION
Fixes #49

rapids_cpm_find now looks at the `GLOBAL_TARGETS` entries and will not call CPMFindPackage if any of them already exist.

This makes it safe to call `rapids_cpm_find` no matter what existing targets already exist. therefore users of rapids-cmake don't need to do manual `if(TARGET ...)` checks, resulting in missing packages in the export set.
