### PR TITLE
Introduce rapids_cmake_install_lib_dir

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -7,6 +7,12 @@
           "nargs": 1
         }
       },
+      "rapids_cmake_install_lib_dir": {
+        "pargs": {
+          "nargs": 1,
+          "flags": ["MODIFY_INSTALL_LIBDIR"]
+        }
+      },
       "rapids_cmake_make_global": {
         "pargs": {
           "nargs": 1

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,7 @@ require.
    :titlesonly:
 
    /command/rapids_cmake_build_type
+   /command/rapids_cmake_install_lib_dir
    /command/rapids_cmake_make_global
    /command/rapids_cmake_parse_version
    /command/rapids_cmake_support_conda_env

--- a/docs/command/rapids_cmake_install_lib_dir.rst
+++ b/docs/command/rapids_cmake_install_lib_dir.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cmake/install_lib_dir.cmake

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -107,9 +107,9 @@ if(TARGET conda_env)
 endif()
 
 # - install targets -------------------------------------------------------------------------------
-
+rapids_cmake_install_lib_dir( lib_dir )
 install(TARGETS example
-        DESTINATION lib
+        DESTINATION ${lib_dir}
         EXPORT example-targets
         )
 

--- a/rapids-cmake/cmake/install_lib_dir.cmake
+++ b/rapids-cmake/cmake/install_lib_dir.cmake
@@ -1,0 +1,97 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+rapids_cmake_install_lib_dir
+------------------------------
+
+.. versionadded:: v21.10.00
+
+Establish a variable that holds the library installation directory.
+
+  .. code-block:: cmake
+
+    rapids_cmake_install_lib_dir( out_variable_name [MODIFY_INSTALL_LIBDIR] )
+
+Establishes a variable that holds the correct library installation directory
+( lib or lib64 or lib/<multiarch-tuple> ). This function is CONDA aware and
+will return `lib` when it detects a project is installing in the CONDA_PREFIX
+
+Also offers the ability to modify :cmake:variable:`CMAKE_INSTALL_LIBDIR` to
+be the computed installation directory.
+
+
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`CMAKE_INSTALL_LIBDIR` will be modifed to be the computed relative directory
+  (lib or lib64 or lib/<multiarch-tuple>) when `MODIFY_INSTALL_LIBDIR` is provided
+
+#]=======================================================================]
+function(rapids_cmake_install_lib_dir out_variable_name)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cmake.install_lib_dir")
+
+  set(modify_install_libdir FALSE)
+  if(ARGV1 STREQUAL "MODIFY_INSTALL_LIBDIR")
+    set(modify_install_libdir TRUE)
+  endif()
+
+  set(install_prefix "${CMAKE_INSTALL_PREFIX}")
+  cmake_path(ABSOLUTE_PATH install_prefix NORMALIZE)
+
+  set(use_conda_lib_dir FALSE)
+  if(DEFINED ENV{CONDA_BUILD} AND DEFINED ENV{PREFIX})
+    set(conda_prefix "$ENV{PREFIX}")
+    cmake_path(ABSOLUTE_PATH conda_prefix NORMALIZE)
+    if(install_prefix STREQUAL conda_prefix)
+      set(use_conda_lib_dir TRUE)
+    endif()
+  elseif(DEFINED ENV{CONDA_PREFIX})
+    set(conda_prefix "$ENV{CONDA_PREFIX}")
+    cmake_path(ABSOLUTE_PATH conda_prefix NORMALIZE)
+    if(install_prefix STREQUAL conda_prefix)
+      set(use_conda_lib_dir TRUE)
+    endif()
+  endif()
+
+  set(computed_path)
+  if(use_conda_lib_dir)
+    # CONDA requires everything to be installed to 'lib' no matter the distro
+    set(computed_path "lib")
+    if(modify_install_libdir)
+      # GNUInstallDirs sets `CMAKE_INSTALL_LIBDIR` as a cache path, so we need to do that as well
+      set(CMAKE_INSTALL_LIBDIR ${computed_path} CACHE PATH
+                                                      "Object code libraries (${computed_path})")
+
+      # Make sure our path overrides any local variable
+      set(CMAKE_INSTALL_LIBDIR ${computed_path} PARENT_SCOPE)
+    endif()
+  else()
+    # We need to defer to GNUInstallDirs but not allow it to set CMAKE_INSTALL_LIBDIR
+    include(GNUInstallDirs)
+    set(computed_path "${CMAKE_INSTALL_LIBDIR}")
+    if(modify_install_libdir)
+      # GNUInstallDirs will have set `CMAKE_INSTALL_LIBDIR` as a cache path So we only need to make
+      # sure our path overrides any local variable
+      set(CMAKE_INSTALL_LIBDIR ${computed_path} PARENT_SCOPE)
+    else()
+      unset(CMAKE_INSTALL_LIBDIR CACHE)
+    endif()
+  endif()
+
+  set(${out_variable_name} ${computed_path} PARENT_SCOPE)
+
+endfunction()

--- a/rapids-cmake/cmake/install_lib_dir.cmake
+++ b/rapids-cmake/cmake/install_lib_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -123,8 +123,9 @@ Example on how to properly use :cmake:command:`rapids_export`:
   add_library(example STATIC source.cu)
   target_compile_features(example PUBLIC $<BUILD_INTERFACE:cuda_std_17>)
 
+  rapids_cmake_install_lib_dir(lib_dir)
   install(TARGETS example
-          DESTINATION lib
+          DESTINATION ${lib_dir}
           EXPORT example-targets
           )
 
@@ -201,7 +202,10 @@ function(rapids_export type project_name)
   string(TOLOWER ${project_name} project_name)
   string(TOUPPER ${project_name} project_name_uppercase)
   if(type STREQUAL "install")
-    set(install_location "lib/cmake/${project_name}")
+    include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
+    rapids_cmake_install_lib_dir(install_location)
+    set(install_location "${install_location}/cmake/${project_name}")
+
     set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export")
 
     configure_package_config_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/config.cmake.in"

--- a/testing/cmake/CMakeLists.txt
+++ b/testing/cmake/CMakeLists.txt
@@ -24,6 +24,12 @@ add_cmake_config_test( conda_env-build.cmake )
 add_cmake_config_test( conda_env-invalid.cmake )
 add_cmake_config_test( conda_env-prefix.cmake )
 
+add_cmake_config_test( install_lib_dir-build.cmake )
+add_cmake_config_test( install_lib_dir-no-conda.cmake )
+add_cmake_config_test( install_lib_dir-lib64-with-conda_build.cmake )
+add_cmake_config_test( install_lib_dir-lib64-with-conda_prefix.cmake )
+add_cmake_config_test( install_lib_dir-prefix.cmake )
+
 add_cmake_config_test( make_global-already-imported-global.cmake )
 add_cmake_config_test( make_global-is-alias.cmake )
 add_cmake_config_test( make_global-no-targets.cmake )

--- a/testing/cmake/install_lib_dir-build.cmake
+++ b/testing/cmake/install_lib_dir-build.cmake
@@ -1,0 +1,59 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
+
+set(ENV{CONDA_BUILD} "1")
+set(ENV{PREFIX} "/opt/conda/prefix")
+set(CMAKE_INSTALL_PREFIX "/opt/conda/prefix")
+
+
+rapids_cmake_install_lib_dir( lib_dir )
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib' as we are in a CONDA env")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir shouldn't have caused the CMAKE_INSTALL_LIBDIR variable to exist")
+endif()
+
+rapids_cmake_install_lib_dir( lib_dir MODIFY_INSTALL_LIBDIR)
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib' as we are in a CONDA env")
+endif()
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR computed to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib' as we are in a CONDA env")
+endif()
+if(NOT $CACHE{CMAKE_INSTALL_LIBDIR} STREQUAL "lib")
+  message(FATAL_ERROR "CACHE{CMAKE_INSTALL_LIBDIR} computed to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib' as we are in a CONDA env")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR touched
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a local variable")
+endif()
+
+if(NOT DEFINED CACHE{CMAKE_INSTALL_LIBDIR})
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a cache variable")
+endif()
+
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)

--- a/testing/cmake/install_lib_dir-build.cmake
+++ b/testing/cmake/install_lib_dir-build.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cmake/install_lib_dir-lib64-with-conda_build.cmake
+++ b/testing/cmake/install_lib_dir-lib64-with-conda_build.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cmake/install_lib_dir-lib64-with-conda_build.cmake
+++ b/testing/cmake/install_lib_dir-lib64-with-conda_build.cmake
@@ -1,0 +1,53 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
+
+set(ENV{CONDA_BUILD} "1")
+set(ENV{PREFIX} "/opt/conda/prefix")
+set(CMAKE_INSTALL_PREFIX "/usr/local/")
+set(CMAKE_INSTALL_LIBDIR "lib64")
+
+rapids_cmake_install_lib_dir( lib_dir )
+
+if(NOT lib_dir STREQUAL "lib64")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib64'")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib64")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR now set to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib64'")
+endif()
+
+
+set(CMAKE_INSTALL_PREFIX "/opt/conda/prefix")
+set(CMAKE_INSTALL_LIBDIR "lib64")
+
+rapids_cmake_install_lib_dir( lib_dir MODIFY_INSTALL_LIBDIR )
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib'")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR now set to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib'")
+endif()
+
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)

--- a/testing/cmake/install_lib_dir-lib64-with-conda_prefix.cmake
+++ b/testing/cmake/install_lib_dir-lib64-with-conda_prefix.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cmake/install_lib_dir-lib64-with-conda_prefix.cmake
+++ b/testing/cmake/install_lib_dir-lib64-with-conda_prefix.cmake
@@ -1,0 +1,54 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
+
+unset(ENV{CONDA_BUILD})
+unset(ENV{CONDA_PREFIX})
+
+set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
+set(CMAKE_INSTALL_PREFIX "/opt/not-conda/prefix")
+set(CMAKE_INSTALL_LIBDIR "lib64")
+
+rapids_cmake_install_lib_dir( lib_dir )
+
+if(NOT lib_dir STREQUAL "lib64")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib64'")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib64")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR now set to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib64'")
+endif()
+
+set(CMAKE_INSTALL_PREFIX "/opt/conda/prefix")
+set(CMAKE_INSTALL_LIBDIR "lib64")
+
+rapids_cmake_install_lib_dir( lib_dir MODIFY_INSTALL_LIBDIR )
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib'")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR now set to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib'")
+endif()
+
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)

--- a/testing/cmake/install_lib_dir-no-conda.cmake
+++ b/testing/cmake/install_lib_dir-no-conda.cmake
@@ -13,10 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-include_guard(GLOBAL)
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/build_type.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/install_lib_dir.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/parse_version.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/support_conda_env.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/write_version_file.cmake)
+unset(ENV{CONDA_BUILD})
+unset(ENV{CONDA_PREFIX})
+
+rapids_cmake_install_lib_dir( lib_dir )
+if(DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir shouldn't have caused the CMAKE_INSTALL_LIBDIR variable to exist")
+endif()
+
+include(GNUInstallDirs)
+if(NOT lib_dir STREQUAL CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected '${CMAKE_INSTALL_LIBDIR}' as it should match GNUInstallDirs")
+endif()
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)

--- a/testing/cmake/install_lib_dir-no-conda.cmake
+++ b/testing/cmake/install_lib_dir-no-conda.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cmake/install_lib_dir-prefix.cmake
+++ b/testing/cmake/install_lib_dir-prefix.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cmake/install_lib_dir-prefix.cmake
+++ b/testing/cmake/install_lib_dir-prefix.cmake
@@ -1,0 +1,60 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
+
+unset(ENV{CONDA_BUILD})
+unset(ENV{CONDA_PREFIX})
+
+set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
+set(CMAKE_INSTALL_PREFIX "/opt/conda/prefix")
+
+rapids_cmake_install_lib_dir( lib_dir )
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib' as we are in a CONDA env")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR doesn't exist
+if(DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir shouldn't have caused the CMAKE_INSTALL_LIBDIR variable to exist")
+endif()
+
+rapids_cmake_install_lib_dir( lib_dir MODIFY_INSTALL_LIBDIR)
+
+if(NOT lib_dir STREQUAL "lib")
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected 'lib' as we are in a CONDA env")
+endif()
+if(NOT CMAKE_INSTALL_LIBDIR STREQUAL "lib")
+  message(FATAL_ERROR "CMAKE_INSTALL_LIBDIR computed to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib' as we are in a CONDA env")
+endif()
+if(NOT $CACHE{CMAKE_INSTALL_LIBDIR} STREQUAL "lib")
+  message(FATAL_ERROR "CACHE{CMAKE_INSTALL_LIBDIR} computed to '${CMAKE_INSTALL_LIBDIR}', but we expected 'lib' as we are in a CONDA env")
+endif()
+
+# verify CMAKE_INSTALL_LIBDIR touched
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a local variable")
+endif()
+
+if(NOT DEFINED CACHE{CMAKE_INSTALL_LIBDIR})
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a cache variable")
+endif()
+
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)


### PR DESCRIPTION
Fixes #60

rapids_cmake_install_lib_dir computes the correct lib direcotry (lib, lib64, ... ) with respect to how CONDA wants things done.

This is done by looking at `CMAKE_INSTALL_PREFIX` and seeing if it matches env{CONDA_PREFIX} or env{PREFIX} when env{CONDA_BUILD} is set. Under those conditions we will always return `lib` no matter the linux distro, under all other condtions `rapids_cmake_install_lib_dir` defers to `GNUInstallDirs`.

To make `rapids-cmake` consistent we also update `rapids_export` to use `rapids_cmake_install_lib_dir` to correctly compute the location where to install generated `<project>-config.cmake` files`.