### PR TITLE
cmake-format: Now aware of `rapids_cmake_support_conda_env` flags

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -19,7 +19,8 @@
       },
       "rapids_cmake_support_conda_env": {
         "pargs": {
-          "nargs": 1
+          "nargs": 1,
+          "flags": ["MODIFY_PREFIX_PATH"]
         }
       },
       "rapids_cmake_write_version_file": {


### PR DESCRIPTION
cmake-format: Now aware of `rapids_cmake_support_conda_env` flags