### PR TITLE
Introduce rapids_export_find_package_root command

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -96,6 +96,12 @@
           "flags": ["INSTALL", "BUILD"]
         }
       },
+      "rapids_export_find_package_root": {
+        "pargs": {
+          "nargs": 4,
+          "flags": ["INSTALL", "BUILD"]
+        }
+      },
       "rapids_export_package": {
         "pargs": {
           "nargs": "1+"

--- a/docs/command/rapids_export_find_package_root.rst
+++ b/docs/command/rapids_export_find_package_root.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/export/find_package_root.cmake

--- a/rapids-cmake/export/find_package_root.cmake
+++ b/rapids-cmake/export/find_package_root.cmake
@@ -59,7 +59,9 @@ function(rapids_export_find_package_root type name dir_path export_set)
 
   # Don't remove duplicates here as that cost should only be paid Once per export set. So that
   # should occur in `write_dependencies`
-  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_PACKAGES" ${name})
-  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_FOR_${name}" ${dir_path})
+  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_PACKAGES"
+                                                                          ${name})
+  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_FOR_${name}"
+                                                                          ${dir_path})
 
 endfunction()

--- a/rapids-cmake/export/find_package_root.cmake
+++ b/rapids-cmake/export/find_package_root.cmake
@@ -1,0 +1,65 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+rapids_export_find_package_root
+-------------------------------
+
+.. versionadded:: v21.10.00
+
+Record that for <PackageName> to be found correctly, the :cmake:variable:`<PackageName>_ROOT_DIR`
+needs to be set to the provided path.
+
+.. code-block:: cmake
+
+  rapids_export_find_package_root( (BUILD|INSTALL)
+                                   <PackageName>
+                                   <directory_path>
+                                   <ExportSet>
+                                   )
+
+When constructing complicated export sets, espically ones that
+install complicated dependencies it can be necessary to specify
+:cmake:variable:`PackageName_ROOT` so that we are sure we
+will find the packaged dependency.
+
+``BUILD``
+  Record that the `PackageName_ROOT` will be set to <directory_path>
+  before any find_dependency calls for `PackageName` for our build directory
+  export set.
+
+``INSTALL``
+  Record that the `PackageName_ROOT` will be set to <directory_path>
+  before any find_dependency calls for `PackageName` for our install directory
+  export set.
+
+#]=======================================================================]
+function(rapids_export_find_package_root type name dir_path export_set)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.export.find_package_root_dir")
+
+  string(TOLOWER ${type} type)
+
+  if(NOT TARGET rapids_export_${type}_${export_set})
+    add_library(rapids_export_${type}_${export_set} INTERFACE)
+  endif()
+
+  # Don't remove duplicates here as that cost should only be paid Once per export set. So that
+  # should occur in `write_dependencies`
+  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_PACKAGES" ${name})
+  set_property(TARGET rapids_export_${type}_${export_set} APPEND PROPERTY "FIND_ROOT_FOR_${name}" ${dir_path})
+
+endfunction()

--- a/rapids-cmake/export/write_dependencies.cmake
+++ b/rapids-cmake/export/write_dependencies.cmake
@@ -90,7 +90,7 @@ endif()\n")
   if(find_root_dirs)
     foreach(package IN LISTS find_root_dirs)
       get_property(root_dir_path TARGET rapids_export_${type}_${export_set}
-                 PROPERTY "FIND_ROOT_FOR_${package}")
+                   PROPERTY "FIND_ROOT_FOR_${package}")
       set(dep_content "set(${package}_ROOT \"${root_dir_path}\")")
       string(APPEND RAPIDS_EXPORT_CONTENTS "${dep_content}\n")
     endforeach()

--- a/rapids-cmake/export/write_dependencies.cmake
+++ b/rapids-cmake/export/write_dependencies.cmake
@@ -50,6 +50,11 @@ function(rapids_export_write_dependencies type export_set file_path)
     return()
   endif()
 
+  # Determine if we need have any `ROOT_DIR` variables we need to set.
+  get_property(find_root_dirs TARGET rapids_export_${type}_${export_set}
+               PROPERTY "FIND_ROOT_PACKAGES")
+  list(REMOVE_DUPLICATES find_root_dirs)
+
   # Determine if we need have any `FindModules` that we need to package.
   get_property(find_modules TARGET rapids_export_${type}_${export_set}
                PROPERTY "FIND_PACKAGES_TO_INSTALL")
@@ -80,6 +85,15 @@ if(NOT DEFINED CPM_SOURCE_CACHE)
   set(rapids_clear_cpm_cache true)
 endif()\n")
     endif()
+  endif()
+
+  if(find_root_dirs)
+    foreach(package IN LISTS find_root_dirs)
+      get_property(root_dir_path TARGET rapids_export_${type}_${export_set}
+                 PROPERTY "FIND_ROOT_FOR_${package}")
+      set(dep_content "set(${package}_ROOT \"${root_dir_path}\")")
+      string(APPEND RAPIDS_EXPORT_CONTENTS "${dep_content}\n")
+    endforeach()
   endif()
 
   if(find_modules)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -40,6 +40,7 @@ add_cmake_config_test( write_dependencies-cpm-preserve-options.cmake )
 add_cmake_config_test( write_dependencies-duplicate-cpm.cmake )
 add_cmake_config_test( write_dependencies-duplicate-packages.cmake )
 add_cmake_config_test( write_dependencies-multiple-directories )
+add_cmake_config_test( write_dependencies-root-dirs.cmake )
 
 add_cmake_build_test( write_language-multiple-nested-enables )
 add_cmake_build_test( write_language-nested-dirs )

--- a/testing/export/write_dependencies-root-dirs.cmake
+++ b/testing/export/write_dependencies-root-dirs.cmake
@@ -1,0 +1,46 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/find_package_root.cmake)
+include(${rapids-cmake-dir}/export/write_dependencies.cmake)
+
+rapids_export_find_package_root(BUILD RMM [=[${CMAKE_CURRENT_LIST_DIR}/fake/build/path]=] test_set)
+rapids_export_write_dependencies(build test_set "${CMAKE_CURRENT_BINARY_DIR}/build_export_set.cmake")
+
+# Parse the `build_export_set.cmake` file for correct escaped args
+# to `rapids_export_find_package_root` calls
+set(build_to_match_string [=[set(RMM_ROOT "${CMAKE_CURRENT_LIST_DIR}/fake/build/path"]=])
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/build_export_set.cmake" contents)
+string(FIND "${contents}" "${build_to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_write_dependencies(BUILD) failed to perserve variables in the directory path to rapids_export_find_package_root")
+endif()
+
+rapids_export_find_package_root(install RMM "/first/install/path" test_set)
+rapids_export_find_package_root(INSTALL RMM "/second/install/path" test_set)
+rapids_export_find_package_root(install PKG2 "/pkg2/install/path" test_set)
+rapids_export_write_dependencies(INSTALL test_set "${CMAKE_CURRENT_BINARY_DIR}/install_export_set.cmake")
+
+set(install_to_match_string_1 [=[set(RMM_ROOT "/first/install/path;/second/install/path"]=])
+set(install_to_match_string_2 [=[set(PKG2_ROOT "/pkg2/install/path"]=])
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/install_export_set.cmake" contents)
+string(FIND "${contents}" "${install_to_match_string_1}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_write_dependencies(INSTALL) failed to record all RMM_ROOT rapids_export_find_package_root commands")
+endif()
+string(FIND "${contents}" "${install_to_match_string_2}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_write_dependencies(INSTALL) failed to record all PKG2 rapids_export_find_package_root commands")
+endif()


### PR DESCRIPTION
The rapids_export_find_package_root allows projects to set
proper search paths for dependencies.

This is needed when a project either installs a dependency
in a non-standard place, or when a project has extra `rapids_export`
calls to export a dependency for build/install. Both of
these use-cases occur in cudf.