### PR TITLE
rapids_export_cpm(BUILD) captures location of locally found packages

### DIFF
--- a/rapids-cmake/export/cpm.cmake
+++ b/rapids-cmake/export/cpm.cmake
@@ -63,9 +63,14 @@ function(rapids_export_cpm type name export_set)
   set(multi_value GLOBAL_TARGETS CPM_ARGS)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  # Export out the build-dir incase it has build directory find-package support
   if(type STREQUAL build)
-    set(build_dir "${${name}_BINARY_DIR}")
+    if(DEFINED ${name}_DIR AND ${name}_DIR)
+      # Export out where we found the existing local config module
+      set(possible_dir "${${name}_DIR}")
+    else()
+      # Export out the build-dir incase it has build directory find-package support
+      set(possible_dir "${${name}_BINARY_DIR}")
+    endif()
   endif()
 
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/cpm.cmake.in"

--- a/rapids-cmake/export/template/cpm.cmake.in
+++ b/rapids-cmake/export/template/cpm.cmake.in
@@ -2,16 +2,16 @@
 # CPM Search for @name@
 #
 # Make sure we search for a build-dir config module for the CPM project
-set(possible_build_dir "@build_dir@")
-if(possible_build_dir AND NOT DEFINED @name@_DIR)
-  set(@name@_DIR "${possible_build_dir}")
+set(possible_package_dir "@possible_dir@")
+if(possible_package_dir AND NOT DEFINED @name@_DIR)
+  set(@name@_DIR "${possible_package_dir}")
 endif()
 
 CPMFindPackage(
   "@RAPIDS_CPM_ARGS@"
   )
 
-if(possible_build_dir)
-  unset(possible_build_dir)
+if(possible_package_dir)
+  unset(possible_package_dir)
 endif()
 #=============================================================================

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -15,6 +15,7 @@
 #=============================================================================
 add_cmake_config_test( rapids-export.cmake )
 
+add_cmake_config_test( export_cpm-build-possible-dir.cmake )
 add_cmake_config_test( export_cpm-build.cmake )
 add_cmake_config_test( export_cpm-install.cmake )
 add_cmake_config_test( export_cpm-options-escaped.cmake )

--- a/testing/export/export_cpm-build-possible-dir.cmake
+++ b/testing/export/export_cpm-build-possible-dir.cmake
@@ -1,0 +1,63 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+
+# Verify valid dir is picked up
+set(FAKE_CPM_PACKAGE_DIR "/valid/looking/path")
+rapids_export_cpm( build
+                   FAKE_CPM_PACKAGE
+                   test_export_set
+                   CPM_ARGS
+                    FAKE_PACKAGE_ARGS TRUE
+                   )
+
+
+# Verify that cpm configuration files exist
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
+  message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
+endif()
+
+# verify that the expected path exists in FAKE_CPM_PACKAGE.cmake
+set(to_match_string [=[set(possible_package_dir "/valid/looking/path")]=])
+file(READ "${path}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to write out the possible_package_dir")
+endif()
+
+# Verify in-valid dir is ignored
+set(also_fake_cpm_package_DIR OFF)
+set(also_fake_cpm_package_BINARY_DIR /binary/dir/path/)
+rapids_export_cpm( BUILD
+                   also_fake_cpm_package
+                   test_export_set
+                   CPM_ARGS
+                    VERSION 2.0
+                   GLOBAL_TARGETS ABC::ABC ABC::CBA
+                   )
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/also_fake_cpm_package.cmake")
+if(NOT EXISTS "${path}")
+  message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
+endif()
+
+# verify that the expected path exists in also_fake_cpm_package.cmake
+set(to_match_string [=[set(possible_package_dir "/binary/dir/path/")]=])
+file(READ "${path}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to write out the possible_package_dir")
+endif()


### PR DESCRIPTION
When cpm find a local package via `<project>-config.cmake` we cache that location for our users

This fixes issues where a project will find a local install in `CMAKE_INSTALL_PREFIX` but consumers won't as they have a different `CMAKE_INSTALL_PREFIX`. 