### PR TITLE
rapids_export_package(BUILD) captures location of locally found packages

### DIFF
--- a/rapids-cmake/export/cpm.cmake
+++ b/rapids-cmake/export/cpm.cmake
@@ -75,7 +75,7 @@ function(rapids_export_cpm type name export_set)
   endif()
 
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/cpm.cmake.in"
-                 "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/${name}.cmake" @ONLY)
+                 "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/cpm_${name}.cmake" @ONLY)
 
   if(NOT TARGET rapids_export_${type}_${export_set})
     add_library(rapids_export_${type}_${export_set} INTERFACE)

--- a/rapids-cmake/export/package.cmake
+++ b/rapids-cmake/export/package.cmake
@@ -54,6 +54,17 @@ function(rapids_export_package type name export_set)
   set(multi_value GLOBAL_TARGETS)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
+  if(type STREQUAL build)
+    if(DEFINED ${name}_DIR AND ${name}_DIR)
+      # Export out where we found the existing local config module
+      set(possible_dir "${${name}_DIR}")
+    endif()
+  endif()
+
+  configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/${type}_package.cmake.in"
+                 "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/package_${name}.cmake"
+                 @ONLY)
+
   if(NOT TARGET rapids_export_${type}_${export_set})
     add_library(rapids_export_${type}_${export_set} INTERFACE)
   endif()

--- a/rapids-cmake/export/template/build_package.cmake.in
+++ b/rapids-cmake/export/template/build_package.cmake.in
@@ -1,0 +1,15 @@
+#=============================================================================
+# find_dependency Search for @name@
+#
+# Make sure we search for a build-dir config module for the project
+set(possible_package_dir "@possible_dir@")
+if(possible_package_dir AND NOT DEFINED @name@_DIR)
+  set(@name@_DIR "${possible_package_dir}")
+endif()
+
+find_dependency(@name@)
+
+if(possible_package_dir)
+  unset(possible_package_dir)
+endif()
+#=============================================================================

--- a/rapids-cmake/export/template/install_package.cmake.in
+++ b/rapids-cmake/export/template/install_package.cmake.in
@@ -1,0 +1,1 @@
+find_dependency(@name@)

--- a/rapids-cmake/export/write_dependencies.cmake
+++ b/rapids-cmake/export/write_dependencies.cmake
@@ -105,15 +105,16 @@ endif()\n")
            [=[list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")]=] "\n")
   endif()
 
+  set(dep_dir "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}")
   foreach(dep IN LISTS deps)
-    if(EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/${dep}.cmake")
-      # We need inject the contents of this generated file into the file we are writing out. That
-      # way users can re-locate/install the file and it will still work
-      file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/${dep}.cmake" dep_content)
-    else()
-      set(dep_content "find_dependency(${dep})")
+    # We need inject the contents of this generated file into the file we are writing out. That way
+    # users can re-locate/install the file and it will still work
+    if(EXISTS "${dep_dir}/cpm_${dep}.cmake")
+      # CPM recording takes priority over a find_package() recording
+      file(READ "${dep_dir}/cpm_${dep}.cmake" dep_content)
+    elseif(EXISTS "${dep_dir}/package_${dep}.cmake")
+      file(READ "${dep_dir}/package_${dep}.cmake" dep_content)
     endif()
-
     string(APPEND RAPIDS_EXPORT_CONTENTS "${dep_content}\n")
   endforeach()
   string(APPEND RAPIDS_EXPORT_CONTENTS "\n")

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -33,13 +33,16 @@ add_cmake_config_test( export-verify-implicit-disabled-version.cmake )
 add_cmake_config_test( export-verify-implicit-major-version-only-matching.cmake )
 add_cmake_config_test( export-verify-version.cmake )
 
+add_cmake_config_test( export_package-build-possible-dir.cmake )
 add_cmake_config_test( export_package-build.cmake )
+add_cmake_config_test( export_package-install-possible-dir.cmake )
 add_cmake_config_test( export_package-install.cmake )
 add_cmake_config_test( export_package-multiple-export_sets.cmake )
 
 add_cmake_config_test( write_dependencies-cpm-preserve-options.cmake )
 add_cmake_config_test( write_dependencies-duplicate-cpm.cmake )
 add_cmake_config_test( write_dependencies-duplicate-packages.cmake )
+add_cmake_config_test( write_dependencies-duplicate-cpm-and-package.cmake )
 add_cmake_config_test( write_dependencies-multiple-directories )
 add_cmake_config_test( write_dependencies-root-dirs.cmake )
 

--- a/testing/export/export_cpm-build-possible-dir.cmake
+++ b/testing/export/export_cpm-build-possible-dir.cmake
@@ -26,8 +26,8 @@ rapids_export_cpm( build
 
 
 # Verify that cpm configuration files exist
-set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${path}")
   message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
 endif()
 
@@ -49,7 +49,7 @@ rapids_export_cpm( BUILD
                     VERSION 2.0
                    GLOBAL_TARGETS ABC::ABC ABC::CBA
                    )
-set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/also_fake_cpm_package.cmake")
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_also_fake_cpm_package.cmake")
 if(NOT EXISTS "${path}")
   message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
 endif()

--- a/testing/export/export_cpm-build.cmake
+++ b/testing/export/export_cpm-build.cmake
@@ -60,7 +60,7 @@ if( NOT requires_cpm)
 endif()
 
 # Verify that cpm configuration files exist
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake" OR
-   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/SECOND_FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_FAKE_CPM_PACKAGE.cmake" OR
+   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_SECOND_FAKE_CPM_PACKAGE.cmake")
   message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
 endif()

--- a/testing/export/export_cpm-install.cmake
+++ b/testing/export/export_cpm-install.cmake
@@ -59,7 +59,7 @@ if( NOT requires_cpm)
 endif()
 
 # Verify that cpm configuration files exist
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/fake_set/install/RaFT.cmake" OR
-   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/fake_set/install/RMM.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/fake_set/install/cpm_RaFT.cmake" OR
+   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/fake_set/install/cpm_RMM.cmake")
   message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
 endif()

--- a/testing/export/export_cpm-options-escaped.cmake
+++ b/testing/export/export_cpm-options-escaped.cmake
@@ -38,11 +38,11 @@ rapids_export_cpm( install
                         "FAKE_PACKAGE_OPTION_B FALSE"
                    )
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_FAKE_CPM_PACKAGE.cmake")
   message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to generate a CPM configuration")
 endif()
 
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/cpm_FAKE_CPM_PACKAGE.cmake")
   message(FATAL_ERROR "rapids_export_cpm(INSTALL) failed to generate a CPM configuration")
 endif()
 
@@ -50,13 +50,13 @@ endif()
 #
 set(to_match_string [=["NAME;FAKE_CPM_PACKAGE;VERSION;1.0;OPTIONS;FAKE_PACKAGE_OPTION_A TRUE;FAKE_PACKAGE_OPTION_B FALSE"]=])
 
-file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake" contents)
+file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_FAKE_CPM_PACKAGE.cmake" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)
 if(is_found EQUAL -1)
   message(FATAL_ERROR "rapids_export_cpm(BUILD) failed to perserve quotes around CPM arguments")
 endif()
 
-file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/FAKE_CPM_PACKAGE.cmake" contents)
+file(READ "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/cpm_FAKE_CPM_PACKAGE.cmake" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)
 if(is_found EQUAL -1)
   message(FATAL_ERROR "rapids_export_cpm(INSTALL) failed to perserve quotes around CPM arguments")

--- a/testing/export/export_package-build-possible-dir.cmake
+++ b/testing/export/export_package-build-possible-dir.cmake
@@ -1,0 +1,50 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/package.cmake)
+
+# Verify valid dir is picked up
+set(FAKE_PACKAGE_DIR "/valid/looking/path")
+rapids_export_package( build FAKE_PACKAGE test_export_set)
+
+# Verify that package configuration files exist
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_FAKE_PACKAGE.cmake")
+if(NOT EXISTS "${path}")
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()
+
+# verify that the expected path exists in FAKE_PACKAGE.cmake
+set(to_match_string [=[set(possible_package_dir "/valid/looking/path")]=])
+file(READ "${path}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()
+
+# Verify in-valid dir is ignored
+set(also_fake_package_DIR OFF)
+rapids_export_package( BUILD also_fake_package test_export_set)
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_also_fake_package.cmake")
+if(NOT EXISTS "${path}")
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()
+
+# verify that the expected path exists in also_fake_package.cmake
+set(to_match_string [=[set(possible_package_dir "")]=])
+file(READ "${path}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_package(BUILD) failed to write out the possible_package_dir")
+endif()

--- a/testing/export/export_package-build.cmake
+++ b/testing/export/export_package-build.cmake
@@ -38,3 +38,9 @@ get_target_property( global_targets rapids_export_build_test_export_set GLOBAL_T
 if( NOT "ZLIB::ZLIB" IN_LIST global_targets)
   message(FATAL_ERROR "rapids_export_package failed to record ZLIB::ZLIB needs to be global")
 endif()
+
+# Verify that temp package configuration files exist
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_ZLIB.cmake" OR
+   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_PNG.cmake")
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()

--- a/testing/export/export_package-install-possible-dir.cmake
+++ b/testing/export/export_package-install-possible-dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/export/export_package-install-possible-dir.cmake
+++ b/testing/export/export_package-install-possible-dir.cmake
@@ -1,0 +1,34 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/package.cmake)
+
+# Verify valid dir is picked up
+set(FAKE_PACKAGE_DIR "/valid/looking/path")
+rapids_export_package( install FAKE_PACKAGE test_export_set)
+
+# Verify that package configuration files exist
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/package_FAKE_PACKAGE.cmake")
+if(NOT EXISTS "${path}")
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()
+
+# verify that the expected path exists in FAKE_PACKAGE.cmake
+set(to_match_string [=[set(possible_package_dir "/valid/looking/path")]=])
+file(READ "${path}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(NOT is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_export_package shouldn't have generated a possible_package_dir")
+endif()

--- a/testing/export/export_package-install.cmake
+++ b/testing/export/export_package-install.cmake
@@ -46,3 +46,15 @@ if( NOT "PNG::PNG_V2" IN_LIST global_targets)
   message(FATAL_ERROR "rapids_export_package failed to record PNG::PNG_V2 needs to be global")
 endif()
 
+# Verify that temp install package configuration files exist
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/package_ZLIB.cmake" OR
+   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/install/package_PNG.cmake")
+  message(FATAL_ERROR "rapids_export_package failed to generate a find_package configuration")
+endif()
+
+# Verify that temp build package configuration files don't exist
+if(EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_ZLIB.cmake" OR
+   EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_PNG.cmake")
+  message(FATAL_ERROR "rapids_export_package(INSTALL) generated temp files in the wrong directory")
+endif()
+

--- a/testing/export/write_dependencies-duplicate-cpm-and-package.cmake
+++ b/testing/export/write_dependencies-duplicate-cpm-and-package.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+# Copyright (c) 2021, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/export/write_dependencies-duplicate-cpm-and-package.cmake
+++ b/testing/export/write_dependencies-duplicate-cpm-and-package.cmake
@@ -1,0 +1,56 @@
+#=============================================================================
+# Copyright (c) 2018-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/package.cmake)
+include(${rapids-cmake-dir}/export/write_dependencies.cmake)
+
+rapids_export_cpm( INSTALL
+                   RMM
+                   test_set
+                   CPM_ARGS RMM
+                    VERSION 2.0
+                    FAKE_PACKAGE_ARGS FALSE
+                   GLOBAL_TARGETS RMM::RMM_POOL
+                   )
+
+rapids_export_package(install RMM test_set)
+rapids_export_package(install ZLIB test_set)
+rapids_export_package(install PNG test_set)
+rapids_export_write_dependencies(install test_set "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake")
+
+# Parse the `export_set.cmake` file for correct number of `CPMFindPackage` calls
+# and entries in `rapids_global_targets`
+
+file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake" text)
+
+set(cpm_command_count 0)
+set(find_dependency_command_count 0)
+foreach(line IN LISTS text)
+  # message(STATUS "1. line: ${line}")
+  if( line MATCHES "CPMFindPackage" )
+    math(EXPR cpm_command_count "${cpm_command_count} + 1")
+  elseif(line MATCHES "find_dependency")
+    math(EXPR find_dependency_command_count "${find_dependency_command_count} + 1")
+  endif()
+endforeach()
+
+if(NOT cpm_command_count EQUAL 1)
+  message(FATAL_ERROR "Incorrect number of CPMFindPackage entries found. Expected 1, counted ${cpm_command_count}")
+endif()
+
+if(NOT find_dependency_command_count EQUAL 2)
+  message(FATAL_ERROR "Incorrect number of find_dependency entries found. Expected 2, counted ${find_dependency_command_count}")
+endif()

--- a/testing/export/write_dependencies-duplicate-cpm.cmake
+++ b/testing/export/write_dependencies-duplicate-cpm.cmake
@@ -49,16 +49,11 @@ rapids_export_write_dependencies(install test_set "${CMAKE_CURRENT_BINARY_DIR}/e
 
 file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/export_set.cmake" text)
 
-set(duplicate_package )
+set(find_package_count 0)
 foreach(line IN LISTS text)
   # message(STATUS "1. line: ${line}")
-  if( line MATCHES "CPMFindPackage\\(RMM" )
-    if(NOT DEFINED duplicate_package_parsed )
-      set(duplicate_package_parsed TRUE)
-    else()
-      #We parsed a duplicate package
-      message(FATAL_ERROR "Detected duplicate `CPMFindPackage` calls for the same package")
-    endif()
+  if( line MATCHES "CPMFindPackage" )
+    math(EXPR find_package_count "${find_package_count} + 1")
   endif()
 
   if( line MATCHES "set\\(rapids_global_targets" AND NOT line MATCHES "unset")
@@ -82,3 +77,7 @@ foreach(line IN LISTS text)
   endif()
 
 endforeach()
+
+if(NOT find_package_count EQUAL 2)
+  message(FATAL_ERROR "Too many CPMFindPackage entries found. Expected 2, counted ${find_package_count}")
+endif()

--- a/testing/export/write_dependencies-multiple-directories/CMakeLists.txt
+++ b/testing/export/write_dependencies-multiple-directories/CMakeLists.txt
@@ -63,7 +63,7 @@ if( NOT requires_cpm)
 endif()
 
 # Verify that cpm configuration files exist
-if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/FAKE_CPM_PACKAGE.cmake" OR
-   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/SECOND_FAKE_CPM_PACKAGE.cmake")
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_FAKE_CPM_PACKAGE.cmake" OR
+   NOT EXISTS "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/cpm_SECOND_FAKE_CPM_PACKAGE.cmake")
   message(FATAL_ERROR "rapids_export_cpm failed to generate a CPM configuration")
 endif()


### PR DESCRIPTION
When rapids_find_packages find a local package via `<project>-config.cmake` we cache that location for our users

This fixes issues where a project will find a local install in `CMAKE_INSTALL_PREFIX` but consumers won't as they have a different `CMAKE_INSTALL_PREFIX`.
