### PR TITLE
[REVIEW] FIX Install sphinxcontrib-moderncmakedomain in docs script

### DIFF
--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -28,6 +28,10 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+# Using absolute path of python executable to avoid obtaining wrong version of package
+gpuci_logger "Install pip only package"
+/opt/conda/envs/rapids/bin/python -m pip install sphinxcontrib-moderncmakedomain
+
 gpuci_logger "Check versions"
 python --version
 $CC --version


### PR DESCRIPTION
Installs the pip only package `sphinxcontrib-moderncmakedomain` using the build script. This dependency is missing in our docker images but also has no conda equivalent currently so we aren't adding it to our docs conda meta package.

If this package is ever added to conda in the future this should be removed and added to `rapids-doc-env` meta.yaml here: https://github.com/rapidsai/integration/blob/branch-21.10/conda/recipes/rapids-doc-env/meta.yaml