### PR TITLE
Make sure rapids-cmake doesn't produce CMake syntax warnings

### DIFF
--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -45,7 +45,7 @@ function(rapids_cpm_package_override filepath)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_override")
 
   if(NOT EXISTS "${filepath}")
-    message(FATAL_ERROR "rapids_cpm_package_override can't load "${filepath}", verify it exists")
+    message(FATAL_ERROR "rapids_cpm_package_override can't load '${filepath}', verify it exists")
   endif()
   file(READ "${filepath}" json_data)
 

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -117,6 +117,9 @@ function(add_cmake_test mode source_or_dir)
       set_tests_properties(${test_name} PROPERTIES WILL_FAIL ON)
       set_tests_properties(${test_name} PROPERTIES
         FAIL_REGULAR_EXPRESSION "${RAPIDS_TEST_SHOULD_FAIL}")
+    else()
+      # Error out if we detect any CMake syntax warnings
+      set_tests_properties(${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION "Syntax Warning")
     endif()
 
     # Apply a label to the test based on the folder it is in and the generator used


### PR DESCRIPTION
Fixes the syntax warning that existed in rapids-cmake/cpm/package_override.cmake. To make sure that other syntax warning don't creep into rapids-cmake we make them errors for all rapids-cmake tests