### PR TITLE
Remove unneeded inclusions of the old setup_cpm_cache.cmake

### DIFF
--- a/testing/cpm/cpm_init-bad-override-path.cmake
+++ b/testing/cpm/cpm_init-bad-override-path.cmake
@@ -15,5 +15,4 @@
 #=============================================================================
 include(${rapids-cmake-dir}/cpm/init.cmake)
 
-include("${rapids-cmake-testing-dir}/cpm/setup_cpm_cache.cmake")
 rapids_cpm_init(OVERRIDE ${CMAKE_CURRENT_LIST_DIR}/bad_path.cmake)

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -15,9 +15,6 @@
 #=============================================================================
 include(${rapids-cmake-dir}/cpm/init.cmake)
 
-include("${rapids-cmake-testing-dir}/cpm/setup_cpm_cache.cmake")
-
-
 rapids_cpm_init()
 
 # Load the default values for nvbench and GTest projects

--- a/testing/cpm/cpm_init-override-simple.cmake
+++ b/testing/cpm/cpm_init-override-simple.cmake
@@ -15,8 +15,6 @@
 #=============================================================================
 include(${rapids-cmake-dir}/cpm/init.cmake)
 
-include("${rapids-cmake-testing-dir}/cpm/setup_cpm_cache.cmake")
-
 # Need to write out an override file
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[


### PR DESCRIPTION
As part of https://github.com/rapidsai/rapids-cmake/pull/81 the `setup_cpm_cache.cmake` file was moved and refactored.

In that PR all callers of setup_cpm_cache() had been updated, but I missed a couple of tests that just included the file. This removes those unneeded inclusions.