### PR TITLE
Update update-version.sh [skip-ci]

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -36,3 +36,4 @@ sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_SHORT_T
 
 sed_runner 's/'"version =.*"'/'"version = \"${NEXT_SHORT_TAG}\""'/g' docs/conf.py
 sed_runner 's/'"release =.*"'/'"release = \"${NEXT_FULL_TAG}\""'/g' docs/conf.py
+sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' docs/basics.rst

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -31,8 +31,8 @@ function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_FULL_TAG})"'/g' RAPIDS.cmake
-sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_FULL_TAG})"'/g' rapids-cmake/rapids-version.cmake
+sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_SHORT_TAG})"'/g' RAPIDS.cmake
+sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_SHORT_TAG})"'/g' rapids-cmake/rapids-version.cmake
 
 sed_runner 's/'"version =.*"'/'"version = \"${NEXT_SHORT_TAG}\""'/g' docs/conf.py
 sed_runner 's/'"release =.*"'/'"release = \"${NEXT_FULL_TAG}\""'/g' docs/conf.py

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -5,53 +5,34 @@
 ################################
 
 ## Usage
-# bash update-version.sh <type>
-#     where <type> is either `major`, `minor`, `patch`
+# bash update-version.sh <new_version>
 
 set -e
 
-# Grab argument for release type
-RELEASE_TYPE=$1
+# Format is YY.MM.PP - no leading 'v' or trailing 'a'
+NEXT_FULL_TAG=$1
 
-# Get current version and calculate next versions
-CURRENT_TAG=`git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v'`
-CURRENT_MAJOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}'`
-CURRENT_MINOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}'`
-CURRENT_PATCH=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}'`
-NEXT_MAJOR=$((CURRENT_MAJOR + 1))
-NEXT_MINOR=$((CURRENT_MINOR + 1))
-NEXT_PATCH=$((CURRENT_PATCH + 1))
-NEXT_FULL_TAG=""
-NEXT_SHORT_TAG=""
+# Get current version
+CURRENT_TAG=$(git tag --merged HEAD | grep -xE '^v.*' | sort --version-sort | tail -n 1 | tr -d 'v')
+CURRENT_MAJOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}')
+CURRENT_MINOR=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}')
+CURRENT_PATCH=$(echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}')
+CURRENT_SHORT_TAG=${CURRENT_MAJOR}.${CURRENT_MINOR}
 
-# Determine release type
-if [ "$RELEASE_TYPE" == "major" ]; then
-  NEXT_FULL_TAG="${NEXT_MAJOR}.0.0"
-  NEXT_SHORT_TAG="${NEXT_MAJOR}.0"
-elif [ "$RELEASE_TYPE" == "minor" ]; then
-  NEXT_FULL_TAG="${CURRENT_MAJOR}.${NEXT_MINOR}.0"
-  NEXT_SHORT_TAG="${CURRENT_MAJOR}.${NEXT_MINOR}"
-elif [ "$RELEASE_TYPE" == "patch" ]; then
-  NEXT_FULL_TAG="${CURRENT_MAJOR}.${CURRENT_MINOR}.${NEXT_PATCH}"
-  NEXT_SHORT_TAG="${CURRENT_MAJOR}.${CURRENT_MINOR}"
-else
-  echo "Incorrect release type; use 'major', 'minor', or 'patch' as an argument"
-  exit 1
-fi
+#Get <major>.<minor> for next version
+NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
+NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
+NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
-echo "Preparing '$RELEASE_TYPE' release [$CURRENT_TAG -> $NEXT_FULL_TAG]"
+echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
     sed -i.bak ''"$1"'' $2 && rm -f ${2}.bak
 }
 
-sed_runner 's/'"  rapids-cmake-version .*"'/'"  rapids-cmake-version ${NEXT_FULL_TAG}"'/g' RAPIDS.cmake
-sed_runner 's/'"  rapids-cmake-version .*"'/'"  rapids-cmake-version ${NEXT_FULL_TAG}"'/g' rapids-cmake/rapids-version.cmake
+sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_FULL_TAG})"'/g' RAPIDS.cmake
+sed_runner 's/'"rapids-cmake-version .*)"'/'"rapids-cmake-version ${NEXT_FULL_TAG})"'/g' rapids-cmake/rapids-version.cmake
 
-sed_runner 's/version=.*/version=\"'"${NEXT_FULL_TAG}"'\",/g' python/setup.py
-
-sed_runner 's/'"PROJECT_NUMBER         = .*"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' doxygen/Doxyfile
-
-sed_runner 's/'"version =.*"'/'"version = \"${NEXT_SHORT_TAG}\""'/g' python/docs/conf.py
-sed_runner 's/'"release =.*"'/'"release = \"${NEXT_FULL_TAG}\""'/g' python/docs/conf.py
+sed_runner 's/'"version =.*"'/'"version = \"${NEXT_SHORT_TAG}\""'/g' docs/conf.py
+sed_runner 's/'"release =.*"'/'"release = \"${NEXT_FULL_TAG}\""'/g' docs/conf.py


### PR DESCRIPTION
Makes several changes to the `ci/release/update-version.sh` script
1. Updates the script to the CalVer style
2. Removes files that don't exist
3. Fixes file paths for docs updates
4. Fixes cmake sed commands

Evidence when executed on `branch-21.10` as `ci/release/update-version.sh 21.12.00`:
```diff --git a/RAPIDS.cmake b/RAPIDS.cmake
index 8923893..63bb073 100644
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -17,7 +17,7 @@
 # This is the preferred entry point for projects using rapids-cmake
 #

-set(rapids-cmake-version 21.10)
+set(rapids-cmake-version 21.12)
 include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
diff --git a/docs/conf.py b/docs/conf.py
index 60e0e04..2b831f7 100644
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,9 @@ author = "NVIDIA"
 # built documents.
 #
 # The short X.Y version.
-version = "0.20"
+version = "21.12"
 # The full version, including alpha/beta/rc tags.
-release = "0.20.0"
+release = "21.12.00"


 # -- General configuration ---------------------------------------------------
diff --git a/rapids-cmake/rapids-version.cmake b/rapids-cmake/rapids-version.cmake
index 5630350..d832f03 100644
--- a/rapids-cmake/rapids-version.cmake
+++ b/rapids-cmake/rapids-version.cmake
@@ -16,4 +16,4 @@
 # can't have an include guard on this file
 # that breaks its usage by cpm/detail/package_details

-set(rapids-cmake-version 21.10)
+set(rapids-cmake-version 21.12)
```