### PR TITLE
rapids_cpm_spdlog specifies the correct install variable

### DIFF
--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -75,7 +75,7 @@ function(rapids_cpm_spdlog)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  OPTIONS "spdlog_INSTALL ${to_install}")
+                  OPTIONS "SPDLOG_INSTALL ${to_install}")
 
   # Propagate up variables that CPMFindPackage provide
   set(spdlog_SOURCE_DIR "${spdlog_SOURCE_DIR}" PARENT_SCOPE)


### PR DESCRIPTION
The variable is all uppercase instead of mixed case.