### PR TITLE
find_package now will find modules that CPM has downloaded.

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -41,7 +41,8 @@ The CPM module will be downloaded based on the state of :cmake:variable:`CPM_SOU
 function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
-  set(CPM_DOWNLOAD_VERSION 7644c3a40fc7889f8dee53ce21e85dc390b883dc) # 0.32.1
+  # When changing version verify no new variables needs to be propagated
+  set(CPM_DOWNLOAD_VERSION 634800c61928d330a6e9559171509a5c3dd479d5) # 0.34.0
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)
@@ -75,5 +76,11 @@ function(rapids_cpm_download)
   endif()
 
   include(${CPM_DOWNLOAD_LOCATION})
+
+  # Propagate up any modified local variables that CPM has changed.
+  #
+  # Push up the modified CMAKE_MODULE_PATh to allow `find_package`
+  # calls to find packages that CPM already added.
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 
 endfunction()

--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -79,8 +79,8 @@ function(rapids_cpm_download)
 
   # Propagate up any modified local variables that CPM has changed.
   #
-  # Push up the modified CMAKE_MODULE_PATh to allow `find_package`
-  # calls to find packages that CPM already added.
+  # Push up the modified CMAKE_MODULE_PATh to allow `find_package` calls to find packages that CPM
+  # already added.
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 
 endfunction()

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -50,7 +50,8 @@ function(rapids_cpm_init)
   set(_rapids_options)
   set(_rapids_one_value OVERRIDE)
   set(_rapids_multi_value)
-  cmake_parse_arguments(RAPIDS "${_rapids_options}" "${_rapids_one_value}" "${_rapids_multi_value}" ${ARGN})
+  cmake_parse_arguments(RAPIDS "${_rapids_options}" "${_rapids_one_value}" "${_rapids_multi_value}"
+                        ${ARGN})
 
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
   rapids_cpm_load_preset_versions()
@@ -65,7 +66,7 @@ function(rapids_cpm_init)
 
   # Propagate up any modified local variables that CPM has changed.
   #
-  # Push up the modified CMAKE_MODULE_PATh to allow `find_package`
-  # calls to find packages that CPM already added.
+  # Push up the modified CMAKE_MODULE_PATh to allow `find_package` calls to find packages that CPM
+  # already added.
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -47,10 +47,10 @@ in the build tree of the calling project
 function(rapids_cpm_init)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.init")
 
-  set(options)
-  set(one_value OVERRIDE)
-  set(multi_value)
-  cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+  set(_rapids_options)
+  set(_rapids_one_value OVERRIDE)
+  set(_rapids_multi_value)
+  cmake_parse_arguments(RAPIDS "${_rapids_options}" "${_rapids_one_value}" "${_rapids_multi_value}" ${ARGN})
 
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
   rapids_cpm_load_preset_versions()
@@ -63,4 +63,9 @@ function(rapids_cpm_init)
   include("${rapids-cmake-dir}/cpm/detail/download.cmake")
   rapids_cpm_download()
 
+  # Propagate up any modified local variables that CPM has changed.
+  #
+  # Push up the modified CMAKE_MODULE_PATh to allow `find_package`
+  # calls to find packages that CPM already added.
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
 endfunction()

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -16,6 +16,7 @@
 add_cmake_config_test( rapids-cpm.cmake )
 
 add_cmake_config_test( cpm_find-add-pkg-source )
+add_cmake_config_test( cpm_find-and-find_package )
 add_cmake_config_test( cpm_find-existing-build-dir )
 add_cmake_config_test( cpm_find-existing-target )
 add_cmake_config_test( cpm_find-existing-target-to-export-sets )

--- a/testing/cpm/cpm_find-add-pkg-source/mock_zlib_source_dir/CMakeLists.txt
+++ b/testing/cpm/cpm_find-add-pkg-source/mock_zlib_source_dir/CMakeLists.txt
@@ -16,4 +16,4 @@
 cmake_minimum_required(VERSION 3.20)
 project(ZLIB LANGUAGES CXX)
 
-set(MOCK_ZLIB_FOUND TRUE)
+add_library(MOCK_ZLIB INTERFACE)

--- a/testing/cpm/cpm_find-and-find_package/CMakeLists.txt
+++ b/testing/cpm/cpm_find-and-find_package/CMakeLists.txt
@@ -17,13 +17,23 @@ include(${rapids-cmake-dir}/cpm/init.cmake)
 include(${rapids-cmake-dir}/cpm/find.cmake)
 
 cmake_minimum_required(VERSION 3.20)
-project(rapids-cpm-find-add-pkg-source LANGUAGES CXX)
+project(rapids-test-project LANGUAGES CXX)
 
-set(CPM_ZLIB_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/mock_zlib_source_dir")
+
+set(CPM_cucxx_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/mock_cucxx_source_dir")
 
 rapids_cpm_init()
-rapids_cpm_find(ZLIB 1.0)
+rapids_cpm_find(cucxx 1.0)
 
-if (NOT TARGET MOCK_ZLIB)
-  message(FATAL_ERROR "rapids_cpm_find failed to add ZLIB source dir ${CPM_ZLIB_SOURCE}")
+# Should find CPM generated `Findcucxx.cmake`
+find_package(cucxx REQUIRED)
+
+set(expected_find_path "${CPM_MODULE_PATH}/Findcucxx.cmake")
+if(NOT EXISTS "${expected_find_path}")
+  message(FATAL_ERROR "Findcucxx.cmake was not generated")
 endif()
+
+if(NOT TARGET MOCK_CUCXX)
+  message(FATAL_ERROR "cucxx targets should be generated")
+endif()
+

--- a/testing/cpm/cpm_find-and-find_package/mock_cucxx_source_dir/CMakeLists.txt
+++ b/testing/cpm/cpm_find-and-find_package/mock_cucxx_source_dir/CMakeLists.txt
@@ -13,17 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-include(${rapids-cmake-dir}/cpm/init.cmake)
-include(${rapids-cmake-dir}/cpm/find.cmake)
-
 cmake_minimum_required(VERSION 3.20)
-project(rapids-cpm-find-add-pkg-source LANGUAGES CXX)
+project(mock_cucxx LANGUAGES CXX)
 
-set(CPM_ZLIB_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/mock_zlib_source_dir")
-
-rapids_cpm_init()
-rapids_cpm_find(ZLIB 1.0)
-
-if (NOT TARGET MOCK_ZLIB)
-  message(FATAL_ERROR "rapids_cpm_find failed to add ZLIB source dir ${CPM_ZLIB_SOURCE}")
-endif()
+add_library(MOCK_CUCXX INTERFACE)


### PR DESCRIPTION
CPM sets up a module directory so when a cmake project uses `find_package` on a project that `CPM` has already downloaded.
This is an important feature of CPM that was accidentally broken by not propagating CMAKE_MODULE_PATH through `rapids_cpm_init`.

Fixes #89
