### PR TITLE
Pin NVBench to a known working SHA1

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -9,7 +9,7 @@
     "nvbench" : {
       "version" : "0.0",
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
-      "git_tag" : "main"
+      "git_tag" : "ed27365a418d608f6ff2268ad93da5177caa647b"
     },
     "rmm" : {
       "version" : "${rapids-cmake-version}",


### PR DESCRIPTION
NVBench has rolled out a new CMake build-system. Currently RAPIDS projects are seeing issues integrating it into other projects. So we are going to pin the NVBench SHA1 while upstream fixes issues.
