### PR TITLE
Make sure we don't do a shallow clone on nvbench

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -8,6 +8,7 @@
     },
     "nvbench" : {
       "version" : "0.0",
+      "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
       "git_tag" : "ed27365a418d608f6ff2268ad93da5177caa647b"
     },


### PR DESCRIPTION
Needs to be a full clone to get the sha1