### PR TITLE
rapids_cpm_find restores CPM variables when project was already added

### DIFF
--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -151,6 +151,12 @@ function(rapids_cpm_find name version)
     else()
       CPMFindPackage(NAME ${name} VERSION ${version} ${RAPIDS_UNPARSED_ARGUMENTS})
     endif()
+  else()
+    # Restore any CPM variables that might be cached
+    cpm_check_if_package_already_added(${name} ${version})
+    if(CPM_PACKAGE_ALREADY_ADDED)
+      cpm_export_variables(${name})
+    endif()
   endif()
 
   set(extra_info)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -21,6 +21,7 @@ add_cmake_config_test( cpm_find-existing-build-dir )
 add_cmake_config_test( cpm_find-existing-target )
 add_cmake_config_test( cpm_find-existing-target-to-export-sets )
 add_cmake_config_test( cpm_find-options-escaped )
+add_cmake_config_test( cpm_find-restore-cpm-vars )
 
 add_cmake_config_test( cpm_init-bad-override-path.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")
 add_cmake_config_test( cpm_init-override-multiple.cmake )

--- a/testing/cpm/cpm_find-restore-cpm-vars/CMakeLists.txt
+++ b/testing/cpm/cpm_find-restore-cpm-vars/CMakeLists.txt
@@ -1,0 +1,72 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+
+cmake_minimum_required(VERSION 3.20)
+project(rapids-cpm-find-add-pkg-source LANGUAGES CXX)
+
+set(CPM_ZLIB_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/mock_zlib_source_dir")
+
+rapids_cpm_init()
+rapids_cpm_find(ZLIB 1.0)
+
+
+if (NOT TARGET MOCK_ZLIB)
+  message(FATAL_ERROR "rapids_cpm_find failed to add ZLIB source dir ${CPM_ZLIB_SOURCE}")
+endif()
+
+if(NOT DEFINED ZLIB_SOURCE_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_SOURCE_DIR variable")
+endif()
+if(NOT DEFINED ZLIB_BINARY_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_BINARY_DIR variable")
+endif()
+if(NOT DEFINED ZLIB_ADDED)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_ADDED variable")
+endif()
+
+if(NOT ZLIB_ADDED)
+  message(FATAL_ERROR "rapids_cpm_find failed to find local mock zlib")
+endif()
+
+set(old_source_dir ${ZLIB_SOURCE_DIR})
+set(old_binary_dir ${ZLIB_BINARY_DIR})
+unset(ZLIB_SOURCE_DIR)
+unset(ZLIB_BINARY_DIR)
+unset(ZLIB_ADDED)
+
+rapids_cpm_find(ZLIB 1.0)
+
+if(NOT DEFINED ZLIB_SOURCE_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_SOURCE_DIR variable")
+endif()
+if(NOT DEFINED ZLIB_BINARY_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_BINARY_DIR variable")
+endif()
+if(NOT DEFINED ZLIB_ADDED)
+  message(FATAL_ERROR "rapids_cpm_find failed to construct ZLIB_ADDED variable")
+endif()
+
+if(NOT old_source_dir STREQUAL ZLIB_SOURCE_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to restore correct ZLIB_SOURCE_DIR path")
+endif()
+if(NOT old_binary_dir STREQUAL ZLIB_BINARY_DIR)
+  message(FATAL_ERROR "rapids_cpm_find failed to restore correct ZLIB_BINARY_DIR path")
+endif()
+if(ZLIB_ADDED)
+  message(FATAL_ERROR "rapids_cpm_find failed to restore correct ZLIB_ADDED state ( second call should be ZLIB_ADDED=false )")
+endif()

--- a/testing/cpm/cpm_find-restore-cpm-vars/mock_zlib_source_dir/CMakeLists.txt
+++ b/testing/cpm/cpm_find-restore-cpm-vars/mock_zlib_source_dir/CMakeLists.txt
@@ -1,0 +1,19 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+project(ZLIB LANGUAGES CXX VERSION 1.0)
+
+add_library(MOCK_ZLIB INTERFACE)


### PR DESCRIPTION
Now when rapdis_cpm_find is used to find an existing project that was introduced via CPM we correctly restore CPM variables.

Fixes #117
