### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/rapids-cmake/cmake/install_lib_dir.cmake
+++ b/rapids-cmake/cmake/install_lib_dir.cmake
@@ -85,13 +85,20 @@ function(rapids_cmake_install_lib_dir out_variable_name)
     endif()
   else()
     # We need to defer to GNUInstallDirs but not allow it to set CMAKE_INSTALL_LIBDIR
+    set(remove_install_dir TRUE)
+    if(DEFINED CMAKE_INSTALL_LIBDIR)
+      set(remove_install_dir FALSE)
+    endif()
+
     include(GNUInstallDirs)
     set(computed_path "${CMAKE_INSTALL_LIBDIR}")
     if(modify_install_libdir)
       # GNUInstallDirs will have set `CMAKE_INSTALL_LIBDIR` as a cache path So we only need to make
       # sure our path overrides any local variable
       set(CMAKE_INSTALL_LIBDIR ${computed_path} PARENT_SCOPE)
-    else()
+    endif()
+
+    if(remove_install_dir)
       unset(CMAKE_INSTALL_LIBDIR CACHE)
     endif()
   endif()

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -118,12 +118,11 @@ set_target_properties(libcudacxx_includes PROPERTIES INTERFACE_INCLUDE_DIRECTORI
     endif()
 
     if(install_export)
-      include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
-      rapids_cmake_install_lib_dir(lib_dir)
-      install(DIRECTORY ${libcudacxx_SOURCE_DIR}/include/
-              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rapids/libcudacxx)
-      install(DIRECTORY ${libcudacxx_SOURCE_DIR}/libcxx/include/
-              DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rapids/libcxx/include)
+      include(GNUInstallDirs) # For CMAKE_INSTALL_INCLUDEDIR
+      install(DIRECTORY "${libcudacxx_SOURCE_DIR}/include/"
+              DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/libcudacxx")
+      install(DIRECTORY "${libcudacxx_SOURCE_DIR}/libcxx/include/"
+              DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/libcxx/include")
 
       include("${rapids-cmake-dir}/export/export.cmake")
       rapids_export(INSTALL libcudacxx

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -148,24 +148,25 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     rapids_cmake_install_lib_dir(install_location) # Use the correct conda aware path
 
     # We need to install the forwarders in `lib/cmake/thrust` and `lib/cmake/cub`
-    file(WRITE "${CMAKE_BINARY_DIR}/cmake/thrust-config.cmake"
+    set(scratch_dir
+        "${CMAKE_BINARY_DIR}/rapids-cmake/${RAPIDS_INSTALL_EXPORT_SET}/install/scratch/")
+
+    file(WRITE "${scratch_dir}/thrust-config.cmake"
          [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/thrust/cmake/thrust-config.cmake")]=]
     )
-    file(WRITE "${CMAKE_BINARY_DIR}/cmake/thrust-config-version.cmake"
+    file(WRITE "${scratch_dir}/thrust-config-version.cmake"
          [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/thrust/cmake/thrust-config-version.cmake")]=]
     )
-    install(FILES "${CMAKE_BINARY_DIR}/cmake/thrust-config.cmake"
-                  "${CMAKE_BINARY_DIR}/cmake/thrust-config-version.cmake"
+    install(FILES "${scratch_dir}/thrust-config.cmake" "${scratch_dir}/thrust-config-version.cmake"
             DESTINATION "${install_location}/cmake/thrust")
 
-    file(WRITE "${CMAKE_BINARY_DIR}/cmake/cub-config.cmake"
+    file(WRITE "${scratch_dir}/cub-config.cmake"
          [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/dependencies/cub/cub-config.cmake")]=]
     )
-    file(WRITE "${CMAKE_BINARY_DIR}/cmake/cub-config-version.cmake"
+    file(WRITE "${scratch_dir}/cub-config-version.cmake"
          [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/dependencies/cub/cub-config-version.cmake")]=]
     )
-    install(FILES "${CMAKE_BINARY_DIR}/cmake/cub-config.cmake"
-                  "${CMAKE_BINARY_DIR}/cmake/cub-config-version.cmake"
+    install(FILES "${scratch_dir}/cub-config.cmake" "${scratch_dir}/cub-config-version.cmake"
             DESTINATION "${install_location}/cmake/cub")
   endif()
 

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -71,7 +71,7 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(Thrust ${version} ${ARGN}
                   GLOBAL_TARGETS ${namespaces_name}::Thrust
-                  CPM_ARGS
+                  CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}

--- a/testing/cmake/CMakeLists.txt
+++ b/testing/cmake/CMakeLists.txt
@@ -24,10 +24,11 @@ add_cmake_config_test( conda_env-build.cmake )
 add_cmake_config_test( conda_env-invalid.cmake )
 add_cmake_config_test( conda_env-prefix.cmake )
 
+add_cmake_config_test( install_lib_dir-after-gnuinstalldir-include.cmake )
 add_cmake_config_test( install_lib_dir-build.cmake )
-add_cmake_config_test( install_lib_dir-no-conda.cmake )
 add_cmake_config_test( install_lib_dir-lib64-with-conda_build.cmake )
 add_cmake_config_test( install_lib_dir-lib64-with-conda_prefix.cmake )
+add_cmake_config_test( install_lib_dir-no-conda.cmake )
 add_cmake_config_test( install_lib_dir-prefix.cmake )
 
 add_cmake_config_test( make_global-already-imported-global.cmake )

--- a/testing/cmake/install_lib_dir-after-gnuinstalldir-include.cmake
+++ b/testing/cmake/install_lib_dir-after-gnuinstalldir-include.cmake
@@ -1,0 +1,40 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cmake/install_lib_dir.cmake)
+
+unset(ENV{CONDA_BUILD})
+unset(ENV{CONDA_PREFIX})
+
+include(GNUInstallDirs)
+set(old_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+
+rapids_cmake_install_lib_dir( lib_dir )
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir shouldn't have caused the CMAKE_INSTALL_LIBDIR variable to not exist")
+endif()
+
+if(NOT lib_dir STREQUAL CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected '${CMAKE_INSTALL_LIBDIR}' as it should match GNUInstallDirs")
+endif()
+
+if(NOT lib_dir STREQUAL old_CMAKE_INSTALL_LIBDIR)
+  message(FATAL_ERROR "rapids_cmake_install_lib_dir computed '${lib_dir}', but we expected '${CMAKE_INSTALL_LIBDIR}' as it should match GNUInstallDirs")
+endif()
+
+# unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
+# re-runs of the test to fail
+unset(CMAKE_INSTALL_LIBDIR)
+unset(CMAKE_INSTALL_LIBDIR CACHE)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.