### PR TITLE
rapids_cpm_libcudacxx handle CPM already finding libcudacxx before being called

### DIFF
--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -56,15 +56,10 @@ Result Variables
 function(rapids_cpm_libcudacxx)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.libcudacxx")
 
-  set(install_export FALSE)
-  if(INSTALL_EXPORT_SET IN_LIST ARGN)
-    set(install_export TRUE)
-  endif()
-
-  set(build_export FALSE)
-  if(BUILD_EXPORT_SET IN_LIST ARGN)
-    set(build_export TRUE)
-  endif()
+  set(options CPM_ARGS)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(multi_value)
+  cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(libcudacxx version repository tag shallow)
@@ -77,9 +72,22 @@ function(rapids_cpm_libcudacxx)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   DOWNLOAD_ONLY TRUE)
+  
+  if(RAPIDS_BUILD_EXPORT_SET)
+    include("${rapids-cmake-dir}/export/package.cmake")
+    rapids_export_package(BUILD ${name} ${RAPIDS_BUILD_EXPORT_SET} GLOBAL_TARGETS libcudacxx::libcudacxx)
+
+    include("${rapids-cmake-dir}/export/find_package_root.cmake")
+    rapids_export_find_package_root(BUILD libcudacxx [=[${CMAKE_CURRENT_LIST_DIR}]=] ${RAPIDS_BUILD_EXPORT_SET})
+  endif()
+
+  if(RAPIDS_INSTALL_EXPORT_SET)
+    include("${rapids-cmake-dir}/export/package.cmake")
+    rapids_export_package(INSTALL ${name} ${RAPIDS_INSTALL_EXPORT_SET} GLOBAL_TARGETS libcudacxx::libcudacxx)
+  endif()
 
   # establish the correct libcudacxx namespace aliases
-  if(libcudacxx_ADDED AND NOT TARGET rapids_libcudacxx)
+  if(NOT TARGET rapids_libcudacxx AND NOT TARGET libcudacxx::libcudacxx AND libcudacxx_SOURCE_DIR)
     add_library(rapids_libcudacxx INTERFACE)
     set_target_properties(rapids_libcudacxx PROPERTIES EXPORT_NAME libcudacxx)
 
@@ -109,7 +117,7 @@ if(NOT TARGET libcudacxx_includes)
 endif()
     ]=])
 
-    if(build_export)
+    if(RAPIDS_BUILD_EXPORT_SET)
       include("${rapids-cmake-dir}/export/export.cmake")
       rapids_export(BUILD libcudacxx
                     EXPORT_SET libcudacxx-targets
@@ -119,7 +127,7 @@ endif()
                     FINAL_CODE_BLOCK code_string)
     endif()
 
-    if(install_export)
+    if(RAPIDS_INSTALL_EXPORT_SET)
       include(GNUInstallDirs) # For CMAKE_INSTALL_INCLUDEDIR
       install(DIRECTORY "${libcudacxx_SOURCE_DIR}/include/"
               DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/libcudacxx")

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -65,7 +65,7 @@ function(rapids_cpm_libcudacxx)
   rapids_cpm_package_details(libcudacxx version repository tag shallow)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(libcudacxx ${version} ${ARGN}
+  rapids_cpm_find(libcudacxx ${version} ${RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS libcudacxx::libcudacxx
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -72,18 +72,21 @@ function(rapids_cpm_libcudacxx)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   DOWNLOAD_ONLY TRUE)
-  
+
   if(RAPIDS_BUILD_EXPORT_SET)
     include("${rapids-cmake-dir}/export/package.cmake")
-    rapids_export_package(BUILD ${name} ${RAPIDS_BUILD_EXPORT_SET} GLOBAL_TARGETS libcudacxx::libcudacxx)
+    rapids_export_package(BUILD ${name} ${RAPIDS_BUILD_EXPORT_SET}
+                          GLOBAL_TARGETS libcudacxx::libcudacxx)
 
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD libcudacxx [=[${CMAKE_CURRENT_LIST_DIR}]=] ${RAPIDS_BUILD_EXPORT_SET})
+    rapids_export_find_package_root(BUILD libcudacxx [=[${CMAKE_CURRENT_LIST_DIR}]=]
+                                    ${RAPIDS_BUILD_EXPORT_SET})
   endif()
 
   if(RAPIDS_INSTALL_EXPORT_SET)
     include("${rapids-cmake-dir}/export/package.cmake")
-    rapids_export_package(INSTALL ${name} ${RAPIDS_INSTALL_EXPORT_SET} GLOBAL_TARGETS libcudacxx::libcudacxx)
+    rapids_export_package(INSTALL ${name} ${RAPIDS_INSTALL_EXPORT_SET}
+                          GLOBAL_TARGETS libcudacxx::libcudacxx)
   endif()
 
   # establish the correct libcudacxx namespace aliases

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -75,7 +75,7 @@ function(rapids_cpm_libcudacxx)
 
   if(RAPIDS_BUILD_EXPORT_SET)
     include("${rapids-cmake-dir}/export/package.cmake")
-    rapids_export_package(BUILD ${name} ${RAPIDS_BUILD_EXPORT_SET}
+    rapids_export_package(BUILD libcudacxx ${RAPIDS_BUILD_EXPORT_SET}
                           GLOBAL_TARGETS libcudacxx::libcudacxx)
 
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
@@ -85,7 +85,7 @@ function(rapids_cpm_libcudacxx)
 
   if(RAPIDS_INSTALL_EXPORT_SET)
     include("${rapids-cmake-dir}/export/package.cmake")
-    rapids_export_package(INSTALL ${name} ${RAPIDS_INSTALL_EXPORT_SET}
+    rapids_export_package(INSTALL libcudacxx ${RAPIDS_INSTALL_EXPORT_SET}
                           GLOBAL_TARGETS libcudacxx::libcudacxx)
   endif()
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -35,6 +35,7 @@ add_cmake_config_test( cpm_package_override-simple.cmake )
 add_cmake_config_test( cpm_gtest-export.cmake )
 add_cmake_config_test( cpm_gtest-simple.cmake )
 
+add_cmake_config_test( cpm_libcudacxx-after_cpmfind.cmake )
 add_cmake_config_test( cpm_libcudacxx-export.cmake )
 add_cmake_config_test( cpm_libcudacxx-simple.cmake )
 

--- a/testing/cpm/cpm_libcudacxx-after_cpmfind.cmake
+++ b/testing/cpm/cpm_libcudacxx-after_cpmfind.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
+
+rapids_cpm_init()
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+rapids_cpm_package_details(libcudacxx version repository tag shallow)
+
+include("${rapids-cmake-dir}/cpm/find.cmake")
+rapids_cpm_find(libcudacxx ${version}
+                CPM_ARGS
+                GIT_REPOSITORY ${repository}
+                GIT_TAG ${tag}
+                GIT_SHALLOW ${shallow}
+                DOWNLOAD_ONLY TRUE)
+
+                
+rapids_cpm_libcudacxx()
+if(NOT TARGET libcudacxx::libcudacxx)
+  message(FATAL_ERROR "Expected libcudacxx::libcudacxx target to exist")
+endif()
+
+rapids_cpm_libcudacxx()


### PR DESCRIPTION
Consider the following example CMake example:

```cmake
CPMFindPackage(libcudacxx ..... )
rapids_cpm_libcudacxx()
target_link_libraries(... PRIVATE libcudacxx::libcudacxx)
```

The first line will check out libcudacxx from source. This will result in the second line not checking out libcudacxx, and therefore not creating the `libcudacxx::libcudacxx` target, causing downstream failures.

On first pass this seems to be an impossible state to get into as all RAPIDS projects should be using `rapids_cpm_libcudacxx`. The problem was that before this PR, rapids-cmake would generate the above `CPMFindPackage` call when `rapids_cpm_libcudacxx` was called with a BUILD_EXPORT_SET.

