### PR TITLE
Set the `always_download` value in versions.json to the common case

### DIFF
--- a/docs/packages/example.json
+++ b/docs/packages/example.json
@@ -6,7 +6,7 @@
       "git_url" : "https://github.com/NVIDIA/thrust.git",
       "git_tag" : "${version}",
       "git_shallow" : true,
-      "always_download" : false
+      "always_download" : true
     }
   }
 }


### PR DESCRIPTION
It is vastly more common for `always_download` to be set to true for any override project. Since by setting `always_download` to true we turn off searching for a local copy. 

By providing an example that set it to false, we caused issues when people copied the example and ran into bugs that are hard to diagnose.

