### PR TITLE
Remove rapids_cmake_install_lib_dir unstable side effect checks

### DIFF
--- a/testing/cmake/install_lib_dir-build.cmake
+++ b/testing/cmake/install_lib_dir-build.cmake
@@ -48,11 +48,6 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a local variable")
 endif()
 
-if(NOT DEFINED CACHE{CMAKE_INSTALL_LIBDIR})
-  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a cache variable")
-endif()
-
-
 # unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
 # re-runs of the test to fail
 unset(CMAKE_INSTALL_LIBDIR)

--- a/testing/cmake/install_lib_dir-prefix.cmake
+++ b/testing/cmake/install_lib_dir-prefix.cmake
@@ -49,10 +49,6 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a local variable")
 endif()
 
-if(NOT DEFINED CACHE{CMAKE_INSTALL_LIBDIR})
-  message(FATAL_ERROR "rapids_cmake_install_lib_dir should have caused the CMAKE_INSTALL_LIBDIR to be a cache variable")
-endif()
-
 
 # unset CMAKE_INSTALL_LIBDIR so it doesn't leak into our CMakeCache.txt and cause subsequent
 # re-runs of the test to fail


### PR DESCRIPTION
Remove checks around the `CMAKE_INSTALL_LIBDIR` cache state as that isn't easy to test across CMake versions. 

In addition `rapids_cmake_install_lib_dir` never states anything if this variable would exist or not exist in the cache after call, since it isn't part of the contract of the API we can remove the test.