### PR TITLE
add exclude_from_all flag to version.json

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -56,6 +56,7 @@
           "GLOBAL_TARGETS": "+",
           "CPM_ARGS": "+",
           "DOWNLOAD_ONLY": "1",
+          "EXCLUDE_FROM_ALL": "1",
           "GIT_REPOSITORY": "1",
           "GIT_TAG": "1",
           "GIT_SHALLOW": "1",

--- a/docs/packages/example.json
+++ b/docs/packages/example.json
@@ -6,7 +6,8 @@
       "git_url" : "https://github.com/NVIDIA/thrust.git",
       "git_tag" : "${version}",
       "git_shallow" : true,
-      "always_download" : true
+      "always_download" : true,
+      "exclude_from_all" : false
     }
   }
 }

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -53,14 +53,27 @@ as needed.
 ``git_shallow``
 
     An optional boolean value that represents if we should do a shallow git clone
-    or not. If no such field exists the default is `git_shallow : true`
+    or not.
+
+    If no such field exists the default is `false`.
+
+``exclude_from_all``
+
+    An optional boolean value that represents the CMake `EXCLUDE_FROM_ALL` property.
+    If this is set to `true`, and the project is built from source all targets of that
+    project will be excluded from the `ALL` build rule. This means that any target
+    that isn't used by the consuming project will not be compiled. This is useful
+    when a project generates multiple targets that aren't required and the cost
+    of building them isn't desired.
+
+    If no such field exists the default is `false`.
 
 ``always_download``
 
-    An optional boolean value that represents if we CPM should just download the
-    package ( `CPM_DOWNLOAD_ALL` ) instead of first searching for it on the machine. If no such field
-    exists the default is `false` for default packages, any package that has an override will default
-    to `true`.
+    An optional boolean value that represents if CPM should just download the
+    package ( `CPM_DOWNLOAD_ALL` ) instead of first searching for it on the machine.
+
+    If no such field exists the default is `false` for default packages, and `true` for any package that has an override.
 
 rapids-cmake package versions
 #############################

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -26,10 +26,12 @@ rapids_cpm_package_details
                              <git_url_variable>
                              <git_tag_variable>
                              <shallow_variable>
+                             <exclude_from_all_variable>
                              )
 
 #]=======================================================================]
-function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var)
+function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var
+         exclude_from_all_var)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_details")
 
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
@@ -58,6 +60,9 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   set(git_shallow ON)
   rapids_cpm_json_get_value(git_shallow)
 
+  set(exclude_from_all OFF)
+  rapids_cpm_json_get_value(exclude_from_all)
+
   if(override_json_data)
     # The default value for always download is defined by having an override for this package. When
     # we have an override we presume the user doesn't want to use an existing local installed
@@ -79,6 +84,7 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   set(${url_var} ${git_url} PARENT_SCOPE)
   set(${tag_var} ${git_tag} PARENT_SCOPE)
   set(${shallow_var} ${git_shallow} PARENT_SCOPE)
+  set(${exclude_from_all_var} ${exclude_from_all} PARENT_SCOPE)
   if(DEFINED always_download)
     set(CPM_DOWNLOAD_ALL ${always_download} PARENT_SCOPE)
   endif()

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -30,6 +30,7 @@ rapids_cpm_package_details
                              )
 
 #]=======================================================================]
+# cmake-lint: disable=R0913
 function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var
          exclude_from_all_var)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_details")

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -57,7 +57,7 @@ function(rapids_cpm_gtest)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(GTest version repository tag shallow)
+  rapids_cpm_package_details(GTest version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(GTest ${version} ${ARGN}
@@ -66,6 +66,7 @@ function(rapids_cpm_gtest)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "INSTALL_GTEST ${to_install}")
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -62,7 +62,7 @@ function(rapids_cpm_libcudacxx)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(libcudacxx version repository tag shallow)
+  rapids_cpm_package_details(libcudacxx version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(libcudacxx ${version} ${RAPIDS_UNPARSED_ARGUMENTS}
@@ -71,6 +71,7 @@ function(rapids_cpm_libcudacxx)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   DOWNLOAD_ONLY TRUE)
 
   if(RAPIDS_BUILD_EXPORT_SET)

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -64,7 +64,7 @@ function(rapids_cpm_nvbench)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(nvbench version repository tag shallow)
+  rapids_cpm_package_details(nvbench version repository tag shallow exclude)
 
   # CUDA::nvml is an optional package and might not be installed ( aka conda )
   find_package(CUDAToolkit REQUIRED)
@@ -80,6 +80,7 @@ function(rapids_cpm_nvbench)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}" "NVBench_ENABLE_EXAMPLES OFF"
                           "NVBench_ENABLE_TESTING OFF")
 

--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -66,7 +66,7 @@ function(rapids_cpm_rmm)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(rmm version repository tag shallow)
+  rapids_cpm_package_details(rmm version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   # Once we can require CMake 3.22 this can use `only_major_minor` for version searches
@@ -76,6 +76,7 @@ function(rapids_cpm_rmm)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF")
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -66,7 +66,7 @@ function(rapids_cpm_spdlog)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(spdlog version repository tag shallow)
+  rapids_cpm_package_details(spdlog version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(spdlog ${version} ${ARGN}
@@ -75,6 +75,7 @@ function(rapids_cpm_spdlog)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "SPDLOG_INSTALL ${to_install}")
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -107,8 +107,8 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     set_target_properties(${target_name} PROPERTIES GLOBAL_TARGETS "${global_targets}")
   endif()
 
-  if(Thrust_SOURCE_DIR AND RAPIDS_INSTALL_EXPORT_SET) # only install thrust when we have an
-                                                      # in-source version
+  # only install thrust when we have an in-source version
+  if(Thrust_SOURCE_DIR AND RAPIDS_INSTALL_EXPORT_SET)
     #[==[
     Projects such as cudf, and rmm require a newer versions of thrust than can be found in the oldest supported CUDA toolkit.
     This requires these components to install/packaged so that consumers use the same version. To make sure that the custom

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -66,7 +66,7 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.thrust")
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(Thrust version repository tag shallow)
+  rapids_cpm_package_details(Thrust version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(Thrust ${version} ${ARGN}
@@ -75,6 +75,7 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "THRUST_ENABLE_INSTALL_RULES OFF")
 
   if(NOT TARGET ${namespaces_name}::Thrust)

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -19,8 +19,8 @@ rapids_cpm_init()
 
 # Load the default values for nvbench and GTest projects
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-rapids_cpm_package_details(nvbench nvbench_version nvbench_repository nvbench_tag nvbench_shallow)
-rapids_cpm_package_details(GTest GTest_version GTest_repository GTest_tag GTest_shallow)
+rapids_cpm_package_details(nvbench nvbench_version nvbench_repository nvbench_tag nvbench_shallow nvbench_exclude)
+rapids_cpm_package_details(GTest GTest_version GTest_repository GTest_tag GTest_shallow GTest_exclude)
 
 
 # Need to write out an override file
@@ -42,7 +42,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
 rapids_cpm_init(OVERRIDE "${CMAKE_CURRENT_BINARY_DIR}/override.json")
 
 # Verify that the override works
-rapids_cpm_package_details(nvbench version repository tag shallow)
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
 if(NOT version STREQUAL nvbench_version)
   message(FATAL_ERROR "default version field was removed.")
 endif()
@@ -56,7 +56,7 @@ if(CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false since the nvbench override explicitly sets it to 'false'")
 endif()
 
-rapids_cpm_package_details(GTest version repository tag shallow)
+rapids_cpm_package_details(GTest version repository tag shallow exclude)
 if(NOT version STREQUAL "2.99")
   message(FATAL_ERROR "custom version field was removed. ${version} was found instead")
 endif()

--- a/testing/cpm/cpm_init-override-simple.cmake
+++ b/testing/cpm/cpm_init-override-simple.cmake
@@ -33,7 +33,7 @@ rapids_cpm_init(OVERRIDE "${CMAKE_CURRENT_BINARY_DIR}/override.json")
 
 # Verify that the override works
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-rapids_cpm_package_details(nvbench version repository tag shallow)
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
 
 if(NOT version STREQUAL "custom_version")
   message(FATAL_ERROR "custom version field was ignored. ${version} found instead of custom_version")

--- a/testing/cpm/cpm_libcudacxx-after_cpmfind.cmake
+++ b/testing/cpm/cpm_libcudacxx-after_cpmfind.cmake
@@ -18,7 +18,7 @@ include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
 
 rapids_cpm_init()
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-rapids_cpm_package_details(libcudacxx version repository tag shallow)
+rapids_cpm_package_details(libcudacxx version repository tag shallow exclude)
 
 include("${rapids-cmake-dir}/cpm/find.cmake")
 rapids_cpm_find(libcudacxx ${version}
@@ -26,6 +26,7 @@ rapids_cpm_find(libcudacxx ${version}
                 GIT_REPOSITORY ${repository}
                 GIT_TAG ${tag}
                 GIT_SHALLOW ${shallow}
+                EXCLUDE_FROM_ALL ${exclude}
                 DOWNLOAD_ONLY TRUE)
 
                 

--- a/testing/cpm/cpm_package_override-before-init.cmake
+++ b/testing/cpm/cpm_package_override-before-init.cmake
@@ -35,7 +35,7 @@ rapids_cpm_init()
 
 # Verify that the override works
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-rapids_cpm_package_details(nvbench version repository tag shallow)
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
 
 if(NOT version STREQUAL "custom_version")
   message(FATAL_ERROR "custom version field was ignored. ${version} found instead of custom_version")

--- a/testing/cpm/cpm_package_override-multiple.cmake
+++ b/testing/cpm/cpm_package_override-multiple.cmake
@@ -20,9 +20,9 @@ rapids_cpm_init()
 
 # Load the default values for nvbench and GTest projects
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-rapids_cpm_package_details(nvbench nvbench_version nvbench_repository nvbench_tag nvbench_shallow)
-rapids_cpm_package_details(GTest GTest_version GTest_repository GTest_tag GTest_shallow)
-rapids_cpm_package_details(rmm rmm_version rmm_repository rmm_tag rmm_shallow)
+rapids_cpm_package_details(nvbench nvbench_version nvbench_repository nvbench_tag nvbench_shallow nvbench_exclude)
+rapids_cpm_package_details(GTest GTest_version GTest_repository GTest_tag GTest_shallow GTest_exclude)
+rapids_cpm_package_details(rmm rmm_version rmm_repository rmm_tag rmm_shallow rmm_exclude)
 
 # Need to write out an override file
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override1.json
@@ -57,7 +57,7 @@ rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override1.json)
 rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override2.json)
 
 # Verify that the override works
-rapids_cpm_package_details(nvbench version repository tag shallow)
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
 if(NOT version STREQUAL nvbench_version)
   message(FATAL_ERROR "default version field was removed.")
 endif()
@@ -68,7 +68,7 @@ if(NOT tag STREQUAL "my_tag")
   message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_url")
 endif()
 
-rapids_cpm_package_details(GTest version repository tag shallow)
+rapids_cpm_package_details(GTest version repository tag shallow exclude)
 if(NOT version STREQUAL "3.99")
   message(FATAL_ERROR "custom version field was removed. ${version} was found instead")
 endif()
@@ -76,7 +76,7 @@ if(NOT tag MATCHES "3.99")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
 endif()
 
-rapids_cpm_package_details(rmm version repository tag shallow)
+rapids_cpm_package_details(rmm version repository tag shallow exclude)
 if(NOT tag MATCHES "new_rmm_tag")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
 endif()

--- a/testing/cpm/cpm_package_override-simple.cmake
+++ b/testing/cpm/cpm_package_override-simple.cmake
@@ -25,7 +25,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   "packages" : {
     "rmm" : {
       "git_tag" : "new_rmm_tag",
-      "git_shallow" : "OFF"
+      "git_shallow" : "OFF",
+      "exclude_from_all" : "ON"
     },
     "GTest" : {
       "version" : "3.00.A1"
@@ -39,23 +40,29 @@ rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 # Verify that the override works
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
 
-rapids_cpm_package_details(GTest version repository tag shallow)
+rapids_cpm_package_details(GTest version repository tag shallow exclude)
 if(NOT version STREQUAL "3.00.A1")
   message(FATAL_ERROR "custom version field was removed. ${version} was found instead")
 endif()
 if(NOT tag MATCHES "3.00.A1")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
 endif()
+if(NOT exclude MATCHES "OFF")
+  message(FATAL_ERROR "default value of exclude not found. ${exclude} was found instead")
+endif()
 if(NOT CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")
 endif()
 
-rapids_cpm_package_details(rmm version repository tag shallow)
+rapids_cpm_package_details(rmm version repository tag shallow exclude)
 if(NOT tag MATCHES "new_rmm_tag")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
 endif()
 if(NOT shallow MATCHES "OFF")
-  message(FATAL_ERROR "custom version field not used when computing git_shallow value. ${shallow} was found instead")
+  message(FATAL_ERROR "override should not change git_shallow value. ${shallow} was found instead")
+endif()
+if(NOT exclude MATCHES "ON")
+  message(FATAL_ERROR "override should have changed exclude value. ${exclude} was found instead")
 endif()
 if(NOT CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")


### PR DESCRIPTION
Allow overrides of rapids-cmake cpm projects to specify if the project should be excluded from the global `all` CMake build project via the `exclude_from_all` property.