### PR TITLE
Update rapids-cmake packages to Thrust 1.15

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -23,7 +23,7 @@
       "git_tag" : "v${version}"
     },
     "Thrust" : {
-      "version" : "1.12.0",
+      "version" : "1.15.0",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
       "git_tag" : "${version}"
     },


### PR DESCRIPTION
Starting with 22.02, all of RAPIDS is using Thrust 1.15
