### PR TITLE
Ensure that nvbench doesn't require nvml when `CUDA::nvml` doesn't exist

### DIFF
--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -66,6 +66,13 @@ function(rapids_cpm_nvbench)
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(nvbench version repository tag shallow)
 
+  # CUDA::nvml is an optional package and might not be installed ( aka conda )
+  find_package(CUDAToolkit REQUIRED)
+  set(nvbench_with_nvml "OFF")
+  if(TARGET CUDA::nvml)
+    set(nvbench_with_nvml "ON")
+  endif()
+
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(nvbench ${version} ${ARGN}
                   GLOBAL_TARGETS nvbench::nvbench nvbench::main
@@ -73,7 +80,8 @@ function(rapids_cpm_nvbench)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  OPTIONS "NVBench_ENABLE_EXAMPLES OFF" "NVBench_ENABLE_TESTING OFF")
+                  OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}" "NVBench_ENABLE_EXAMPLES OFF"
+                          "NVBench_ENABLE_TESTING OFF")
 
   # Propagate up variables that CPMFindPackage provide
   set(nvbench_SOURCE_DIR "${nvbench_SOURCE_DIR}" PARENT_SCOPE)


### PR DESCRIPTION
Currently NVBench doesn't verify that the `CUDAToolkit` found `nvml` support beforing depending on it.

This causes CMake configuration issues on conda env's that haven't installed the `nvidia-nvml` package