### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -28,7 +28,7 @@
       "git_tag" : "${version}"
     },
     "libcudacxx" : {
-      "version" : "1.6.0",
+      "version" : "1.7.0",
       "git_url" : "https://github.com/NVIDIA/libcudacxx.git",
       "git_tag" : "${version}"
     }


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.