### PR TITLE
rapids_export generated config.cmake no longer leaks variables

### DIFF
--- a/rapids-cmake/export/template/config.cmake.in
+++ b/rapids-cmake/export/template/config.cmake.in
@@ -38,6 +38,7 @@ set(rapids_global_languages @RAPIDS_LANGUAGES@)
 foreach(lang IN LISTS rapids_global_languages)
   include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-${lang}-language.cmake")
 endforeach()
+unset(rapids_global_languages)
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@project_name@-dependencies.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/@project_name@-dependencies.cmake")


### PR DESCRIPTION
Previously it leaked  `rapids_global_languages`