### PR TITLE
Tracked package versions are now not required, but preferred.

### DIFF
--- a/rapids-cmake/export/package.cmake
+++ b/rapids-cmake/export/package.cmake
@@ -72,10 +72,17 @@ function(rapids_export_package type name export_set)
     endif()
   endif()
 
-  set(version ${RAPIDS_VERSION})
-  configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/${type}_package.cmake.in"
-                 "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/package_${name}.cmake"
-                 @ONLY)
+  if(RAPIDS_VERSION)
+    set(version ${RAPIDS_VERSION})
+    configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/${type}_package_versioned.cmake.in"
+                   "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/package_${name}.cmake"
+                   @ONLY)
+  else()
+    message(STATUS "NO RAPIDS_VERSION for ${name}")
+    configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/${type}_package.cmake.in"
+                   "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/package_${name}.cmake"
+                   @ONLY)
+  endif()
 
   if(NOT TARGET rapids_export_${type}_${export_set})
     add_library(rapids_export_${type}_${export_set} INTERFACE)

--- a/rapids-cmake/export/template/build_package_versioned.cmake.in
+++ b/rapids-cmake/export/template/build_package_versioned.cmake.in
@@ -7,6 +7,7 @@ if(possible_package_dir AND NOT DEFINED @name@_DIR)
   set(@name@_DIR "${possible_package_dir}")
 endif()
 
+find_package(@name@ @version@ QUIET)
 find_dependency(@name@)
 
 if(possible_package_dir)

--- a/rapids-cmake/export/template/install_package.cmake.in
+++ b/rapids-cmake/export/template/install_package.cmake.in
@@ -1,1 +1,1 @@
-find_dependency(@name@ @version@)
+find_dependency(@name@)

--- a/rapids-cmake/export/template/install_package_versioned.cmake.in
+++ b/rapids-cmake/export/template/install_package_versioned.cmake.in
@@ -1,0 +1,2 @@
+find_package(@name@ @version@ QUIET)
+find_dependency(@name@)

--- a/testing/export/export_package-build-with-version.cmake
+++ b/testing/export/export_package-build-with-version.cmake
@@ -24,7 +24,7 @@ if(NOT EXISTS "${path}")
 endif()
 
 # verify that the expected version is in FAKE_PACKAGE.cmake
-set(to_match_string [=[22.08)]=])
+set(to_match_string [=[22.08 QUIET)]=])
 file(READ "${path}" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)
 if(is_found EQUAL -1)

--- a/testing/export/export_package-install-with-version.cmake
+++ b/testing/export/export_package-install-with-version.cmake
@@ -24,7 +24,7 @@ if(NOT EXISTS "${path}")
 endif()
 
 # verify that the expected version exists in FAKE_PACKAGE.cmake
-set(to_match_string [=[14.7.2)]=])
+set(to_match_string [=[14.7.2 QUIET)]=])
 file(READ "${path}" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)
 if(is_found EQUAL -1)

--- a/testing/find/find_package-version-explicit.cmake
+++ b/testing/find/find_package-version-explicit.cmake
@@ -36,7 +36,7 @@ rapids_find_package(CUDAToolkit 11 REQUIRED
 										INSTALL_EXPORT_SET test_export_set
 					          BUILD_EXPORT_SET test_export_set)
 
-set(to_match_string "find_dependency(CUDAToolkit 11)")
+set(to_match_string "find_package(CUDAToolkit 11 QUIET)")
 
 set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_CUDAToolkit.cmake")
 file(READ "${path}" contents)

--- a/testing/find/find_package-version-none.cmake
+++ b/testing/find/find_package-version-none.cmake
@@ -38,7 +38,7 @@ rapids_find_package(CUDAToolkit REQUIRED
 
 # no version specified at find time, verify none recorded
 # If we record the found version we break things like CUDA backwards runtime compat
-set(to_match_string "find_dependency(CUDAToolkit )")
+set(to_match_string "find_dependency(CUDAToolkit)")
 
 set(path "${CMAKE_BINARY_DIR}/rapids-cmake/test_export_set/build/package_CUDAToolkit.cmake")
 file(READ "${path}" contents)


### PR DESCRIPTION
Instead of generating `find_dependency(<pkg> <version>)` we
now generate:
  find_package(<pkg> <version>)
  find_dependency(<pkg>)

This allows us to search for the versioned type, but if it
doesn't exist fall back to an unversioned one. Since
find_dependency propagates the `REQUIRED` keyword we need
to use `find_package` to properly handle this optional search.

This is needed since `rapids_cpm_find` always records a version
value, but the project might not actually generate the correct
CMake infrastructure to support versioned `find_package` calls
