### PR TITLE
rapids_cpm_gtest will properly find GTest 1.10 packages

### DIFF
--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -61,9 +61,9 @@ function(rapids_cpm_gtest)
 
   set(EXTRA_CPM_ARGS)
   if(CMAKE_VERSION VERSION_LESS 3.23)
-    # CMake 3.23+ built-in FindGTest is required to have the GTest::gmock_main and GTest::gmock targets
-    # so always use gtest-config.cmake for now
-    string(APPEND EXTRA_CPM_ARGS  "NO_MODULE")
+    # CMake 3.23+ built-in FindGTest is required to have the GTest::gmock_main and GTest::gmock
+    # targets so always use gtest-config.cmake for now
+    string(APPEND EXTRA_CPM_ARGS "NO_MODULE")
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -59,10 +59,17 @@ function(rapids_cpm_gtest)
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(GTest version repository tag shallow exclude)
 
+  set(EXTRA_CPM_ARGS)
+  if(CMAKE_VERSION VERSION_LESS 3.23)
+    # CMake 3.23+ built-in FindGTest is required to have the GTest::gmock_main and GTest::gmock targets
+    # so always use gtest-config.cmake for now
+    string(APPEND EXTRA_CPM_ARGS  "NO_MODULE")
+  endif()
+
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(GTest ${version} ${ARGN}
                   GLOBAL_TARGETS GTest::gtest GTest::gmock GTest::gtest_main GTest::gmock_main
-                  CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
+                  CPM_ARGS FIND_PACKAGE_ARGUMENTS "EXACT ${EXTRA_CPM_ARGS}"
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -2,9 +2,9 @@
 {
   "packages" : {
     "GTest" : {
-      "version" : "1.10",
+      "version" : "1.10.0",
       "git_url" : "https://github.com/google/googletest.git",
-      "git_tag" : "release-${version}.0"
+      "git_tag" : "release-${version}"
     },
     "nvbench" : {
       "version" : "0.0",


### PR DESCRIPTION
Previously if CMake < 3.23 was installed the provided FindGTest
would be used which doesn't provide the GMock targets.

In addition in those cases, since we pass EXACT we need to ensure we also exactly match the patch version of GTest.
