### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -59,10 +59,17 @@ function(rapids_cpm_gtest)
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(GTest version repository tag shallow exclude)
 
+  set(EXTRA_CPM_ARGS)
+  if(CMAKE_VERSION VERSION_LESS 3.23)
+    # CMake 3.23+ built-in FindGTest is required to have the GTest::gmock_main and GTest::gmock
+    # targets so always use gtest-config.cmake for now
+    string(APPEND EXTRA_CPM_ARGS "NO_MODULE")
+  endif()
+
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(GTest ${version} ${ARGN}
                   GLOBAL_TARGETS GTest::gtest GTest::gmock GTest::gtest_main GTest::gmock_main
-                  CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
+                  CPM_ARGS FIND_PACKAGE_ARGUMENTS "EXACT ${EXTRA_CPM_ARGS}"
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -2,9 +2,9 @@
 {
   "packages" : {
     "GTest" : {
-      "version" : "1.10",
+      "version" : "1.10.0",
       "git_url" : "https://github.com/google/googletest.git",
-      "git_tag" : "release-${version}.0"
+      "git_tag" : "release-${version}"
     },
     "nvbench" : {
       "version" : "0.0",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.