### PR TITLE
rapids_export now handles explicit version values of 0 correctly

### DIFF
--- a/rapids-cmake/export/detail/parse_version.cmake
+++ b/rapids-cmake/export/detail/parse_version.cmake
@@ -27,18 +27,18 @@ function(rapids_export_parse_version rapids_version orig_prefix ver_value)
   # Generate an explicit VERSION string without zeroes to work around:
   # https://gitlab.kitware.com/cmake/cmake/-/issues/22207
   set(version_compat SameMajorVersion)
-  if(orig_major_version)
+  if(DEFINED orig_major_version)
     math(EXPR rapids_major_version "${orig_major_version} + 0" OUTPUT_FORMAT DECIMAL)
     string(APPEND rapids_project_version "${rapids_major_version}")
   endif()
 
-  if(orig_minor_version)
+  if(DEFINED orig_minor_version)
     math(EXPR rapids_minor_version "${orig_minor_version} + 0" OUTPUT_FORMAT DECIMAL)
     string(APPEND rapids_project_version ".${rapids_minor_version}")
     set(version_compat SameMinorVersion)
   endif()
 
-  if(orig_patch_version)
+  if(DEFINED orig_patch_version)
     math(EXPR rapids_patch_version "${orig_patch_version} + 0" OUTPUT_FORMAT DECIMAL)
     string(APPEND rapids_project_version ".${rapids_patch_version}")
     set(version_compat SameMinorVersion)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -30,6 +30,7 @@ add_cmake_config_test( export-verify-bad-doc-var.cmake SHOULD_FAIL "DOCUMENTATIO
 add_cmake_config_test( export-verify-calendar-version-matching.cmake )
 add_cmake_config_test( export-verify-explicit-disabled-version.cmake )
 add_cmake_config_test( export-verify-explicit-major-version-only-matching.cmake )
+add_cmake_config_test( export-verify-explicit-patch-version-value-of-zero.cmake )
 add_cmake_config_test( export-verify-explicit-version-value.cmake )
 add_cmake_config_test( export-verify-file-names.cmake )
 add_cmake_config_test( export-verify-implicit-disabled-version.cmake )

--- a/testing/export/export-verify-explicit-patch-version-value-of-zero.cmake
+++ b/testing/export/export-verify-explicit-patch-version-value-of-zero.cmake
@@ -1,0 +1,81 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/export.cmake)
+
+project(test LANGUAGES CXX VERSION 08.06.04)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+rapids_export(BUILD test
+  VERSION 21.09.0
+  EXPORT_SET fake_set
+  LANGUAGES CXX
+  )
+
+# Verify that build files have correct names
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/test-config.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate correct config file name")
+endif()
+
+# Verify that the version.cmake file exists with an explicit version arg
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/test-config-version.cmake")
+  message(FATAL_ERROR "rapids_export failed to generate a version file")
+endif()
+
+set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
+find_package(test 21.9 REQUIRED)
+if(NOT TEST_VERSION STREQUAL "21.09.0")
+  message(FATAL_ERROR "rapids_export failed to export version information")
+endif()
+
+if(NOT TEST_VERSION_MAJOR STREQUAL "21")
+  message(FATAL_ERROR "rapids_export failed to export major version value")
+endif()
+
+if(NOT TEST_VERSION_MINOR STREQUAL "09")
+  message(FATAL_ERROR "rapids_export failed to export minor version value")
+endif()
+
+if(NOT TEST_VERSION_PATCH STREQUAL "0")
+  message(FATAL_ERROR "rapids_export failed to export patch version value")
+endif()
+
+if(NOT "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}" VERSION_EQUAL 21.09)
+  message(FATAL_ERROR "rapids_export failed to export version major/minor information")
+endif()
+
+find_package(test 21.9.0 EXACT REQUIRED)
+if(NOT TEST_VERSION STREQUAL "21.09.0")
+  message(FATAL_ERROR "rapids_export failed to export version information")
+endif()
+
+if(NOT TEST_VERSION_MAJOR STREQUAL "21")
+  message(FATAL_ERROR "rapids_export failed to export major version value")
+endif()
+
+if(NOT TEST_VERSION_MINOR STREQUAL "09")
+  message(FATAL_ERROR "rapids_export failed to export minor version value")
+endif()
+
+if(NOT TEST_VERSION_PATCH STREQUAL "0")
+  message(FATAL_ERROR "rapids_export failed to export patch version value")
+endif()
+
+if(NOT "${TEST_VERSION_MAJOR}.${TEST_VERSION_MINOR}" VERSION_EQUAL 21.09)
+  message(FATAL_ERROR "rapids_export failed to export version major/minor information")
+endif()


### PR DESCRIPTION
The previous logic didn't work as CMake evaluates `0` as FALSE when it comes to `if` statements, and therefore we didn't
build the correct version strings when a value was just `0`.
