### PR TITLE
rapids_cpm_thrust: Correctly find version 1.15.0 

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -23,9 +23,9 @@
       "git_tag" : "v${version}"
     },
     "Thrust" : {
-      "version" : "1.15.0",
+      "version" : "1.15.0.0",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "${version}"
+      "git_tag" : "1.15.0"
     },
     "libcudacxx" : {
       "version" : "1.7.0",


### PR DESCRIPTION
Since Thrust 1.15.0 reports it self as `1.15.0.0` we need to also search with the patch version added.

Starting in Thrust 1.16, the tweak version can be dropped.

Corrects issue in https://github.com/rapidsai/rapids-cmake/pull/180 where git_tag was computed wrong.
