### PR TITLE
Use target name variable.

### DIFF
--- a/rapids-cmake/cmake/write_git_revision_file.cmake
+++ b/rapids-cmake/cmake/write_git_revision_file.cmake
@@ -98,7 +98,7 @@ function(rapids_cmake_write_git_revision_file target file_path)
 
   add_custom_target(${target}_compute_git_info ALL
                     BYPRODUCTS "${file_path}"
-                    COMMENT "Generate git revision file for {target}"
+                    COMMENT "Generate git revision file for ${target}"
                     COMMAND ${CMAKE_COMMAND} -DWORKING_DIRECTORY=${CMAKE_CURRENT_SOURCE_DIR}
                             -DGIT_EXECUTABLE=${GIT_EXECUTABLE} -DRAPIDS_GIT_PREFIX=${RAPIDS_PREFIX}
                             -DTEMPLATE_FILE=${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/git_revision.hpp.in


### PR DESCRIPTION
When building libcudf, I see a message `Generate git revision file for {target}` before the build begins. I think this is intended to say `${target}` and insert the variable name.

Also, I notice this message because this stage takes a long time (something like 10 seconds) for most of my builds, even partial builds. What does this command actually do, and why does it take so long? Can it be cached / accelerated / disabled?