### PR TITLE
Default Cython module RUNPATH to $ORIGIN and return the list of created targets

### DIFF
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -21,8 +21,8 @@ set(rapids-cmake-version 22.06)
 include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
-  GIT_REPOSITORY https://github.com/vyasr/rapids-cmake.git
-  GIT_TAG        fix/cython_rpath_origin
+  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
+  GIT_TAG        branch-${rapids-cmake-version}
 )
 FetchContent_GetProperties(rapids-cmake)
 if(rapids-cmake_POPULATED)

--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -21,8 +21,8 @@ set(rapids-cmake-version 22.06)
 include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
-  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        branch-${rapids-cmake-version}
+  GIT_REPOSITORY https://github.com/vyasr/rapids-cmake.git
+  GIT_TAG        fix/cython_rpath_origin
 )
 FetchContent_GetProperties(rapids-cmake)
 if(rapids-cmake_POPULATED)

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -51,6 +51,11 @@ extension module.
   an absolute path in a relocatable way. If not provided, defaults to the path
   to CMAKE_CURRENT_SOURCE_DIR relative to PROJECT_SOURCE_DIR.
 
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`RAPIDS_CYTHON_CREATED_TARGETS` will be set to a list of
+  targets created by this function.
+
 #]=======================================================================]
 function(rapids_cython_create_modules)
   include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/detail/verify_init.cmake)
@@ -68,6 +73,8 @@ function(rapids_cython_create_modules)
   if(RAPIDS_CYTHON_CXX)
     set(language "CXX")
   endif()
+
+  set(CREATED_TARGETS "")
 
   foreach(cython_filename IN LISTS RAPIDS_CYTHON_SOURCE_FILES)
     # Generate a reasonable module name.
@@ -95,5 +102,9 @@ function(rapids_cython_create_modules)
                  OUTPUT_VARIABLE RAPIDS_CYTHON_INSTALL_DIR)
     endif()
     install(TARGETS ${cython_module} DESTINATION ${RAPIDS_CYTHON_INSTALL_DIR})
+
+    list(APPEND CREATED_TARGETS "${cython_module}")
   endforeach()
+
+  set(RAPIDS_CYTHON_CREATED_TARGETS ${CREATED_TARGETS} PARENT_SCOPE)
 endfunction()

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -74,13 +74,16 @@ function(rapids_cython_create_modules)
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
 
+    # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR
                       cythonized_file)
     add_library(${cython_module} MODULE ${cythonized_file})
     python_extension_module(${cython_module})
 
-    # To avoid libraries being prefixed with "lib".
+    # Avoid libraries being prefixed with "lib".
     set_target_properties(${cython_module} PROPERTIES PREFIX "")
+
+    # Link the module to the requested libraries
     if(DEFINED RAPIDS_CYTHON_LINKED_LIBRARIES)
       target_link_libraries(${cython_module} ${RAPIDS_CYTHON_LINKED_LIBRARIES})
     endif()

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -103,6 +103,9 @@ function(rapids_cython_create_modules)
     endif()
     install(TARGETS ${cython_module} DESTINATION ${RAPIDS_CYTHON_INSTALL_DIR})
 
+    # Default the INSTALL_RPATH for all modules to $ORIGIN.
+    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN")
+
     list(APPEND CREATED_TARGETS "${cython_module}")
   endforeach()
 

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -26,8 +26,9 @@ Generate C(++) from Cython and create Python modules.
 
   rapids_cython_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )
 
-Creates a Cython target for a module, then adds a corresponding Python
-extension module.
+Creates a Cython target for each provided source file, then adds a
+corresponding Python extension module. Each built library has its RPATH set to
+$ORIGIN.
 
 .. note::
   Requires :cmake:command:`rapids_cython_init` to be called before usage.


### PR DESCRIPTION
<!--

Thank you for contributing to rapids-cmake :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have followed the following guidelines for the changes made/features
   added.

   - Each function should follow the `rapids_<component>_<file_name>` naming pattern
   - Each function should go into a separate `.cmake` file in the appropriate directory
   - Each user facing `.cmake` file should have include guards (`include_guard(GLOBAL)`)
   - Each user facing `.cmake` file should be documented using the rst structure
   - Each user facing function should be added to the `cmake-format.json` document
    - Run `cmake-genparsers -f json` on the `.cmake` file as a starting point
   - Each function first line should be `list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.<component>.<function>")`

   - A file should not modify any state simply by being included. State modification should
     only occur inside functions unless absolutely necessary due to restrictions of the CMake
     language.
      - Any files that do need to break this rule can't be part of `rapids-<component>.cmake`.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   CMake code of a feature is complete but downstream testing is still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
This PR sets the default RPATH for Cython-generated Python extension modules to $ORIGIN so that they will default to finding libraries within the same directory. If rapids-cmake users want to enforce a different directory layout in their library, they are responsible for overriding the RPATHs themselves. To facilitate this as well as other potential downstream modifications, `rapids_cython_create_modules` now also returns the set of created targets in the `RAPIDS_CYTHON_CREATED_TARGETS` variable.