### PR TITLE
Add rapids_cpm_nvcomp with prebuilt binary support

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -103,6 +103,16 @@
           "BUILD_EXPORT_SET": 1
         }
       },
+      "rapids_cpm_nvcomp": {
+        "pargs": {
+          "nargs": 0
+        },
+        "kwargs": {
+          "BUILD_EXPORT_SET": 1,
+          "INSTALL_EXPORT_SET": 1,
+          "USE_PROPRIETARY_BINARY": 1
+        }
+      },
       "rapids_cpm_rmm": {
         "pargs": {
           "nargs": 0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,6 +47,7 @@ package uses :ref:`can be found here. <cpm_versions>`
    /packages/rapids_cpm_gtest
    /packages/rapids_cpm_libcudacxx
    /packages/rapids_cpm_nvbench
+   /packages/rapids_cpm_nvcomp
    /packages/rapids_cpm_rmm
    /packages/rapids_cpm_spdlog
    /packages/rapids_cpm_thrust

--- a/docs/packages/proprietary_binary.json
+++ b/docs/packages/proprietary_binary.json
@@ -1,0 +1,7 @@
+
+{
+  "proprietary_binary" : {
+    "aarch64-linux" : "<url>",
+    "x86_64-linux" : "<url>"
+  }
+}

--- a/docs/packages/rapids_cpm_nvcomp.rst
+++ b/docs/packages/rapids_cpm_nvcomp.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cpm/nvcomp.cmake

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -77,7 +77,7 @@ as needed.
 
 ``proprietary_binary``
 
-    An optional dictonary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library.
+    An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library.
     If a matching key exists the binary will be used instead of the specified git url and tag.
     To determine the correct key, CMake will query for a key that matches the lower case value of `<arch>-<os>` where `arch` maps to :cmake:variable:`CMAKE_SYSTEM_PROCESSOR` and `os` maps to :cmake:variable:`CMAKE_SYSTEM_NAME`.
 

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -75,6 +75,31 @@ as needed.
 
     If no such field exists the default is `false` for default packages, and `true` for any package that has an override.
 
+``proprietary_binary``
+
+    An optional dictonary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library.
+    If a matching key exists the binary will be used instead of the specified git url and tag.
+    To determine the correct key, CMake will query for a key that matches the lower case value of `<arch>-<os>` where `arch` maps to :cmake:variable:`CMAKE_SYSTEM_PROCESSOR` and `os` maps to :cmake:variable:`CMAKE_SYSTEM_NAME`.
+
+    If no such key exists the request to use a `proprietary_binary` will be ignored.
+
+    .. literalinclude:: /packages/proprietary_binary.json
+        :language: json
+
+    As this represents a proprietary binary only the following packages support this command:
+        - nvcomp
+
+    Due to requirements of proprietary binarues, explicit opt-in by the user on usage is required.
+    Therefore for this binary to be used the caller must call the associated `rapids_cpm` command
+    with the `USE_PROPRIETARY_BLOB` set to `ON`.
+
+    Supports the following placeholders:
+        - ``${rapids-cmake-version}`` will be evulated to 'major.minor' of the current rapids-cmake cal-ver value.
+        - ``${version}`` will be evulated to the contents of the ``version`` field.
+
+    If this field exists in the default package, the value will be ignored when an override file
+    entry exists for the package. This ensures that the git url or `proprietary_binary` entry in the override will be used.
+
 rapids-cmake package versions
 #############################
 

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -89,7 +89,7 @@ as needed.
     As this represents a proprietary binary only the following packages support this command:
         - nvcomp
 
-    Due to requirements of proprietary binarues, explicit opt-in by the user on usage is required.
+    Due to requirements of proprietary binaries, explicit opt-in by the user on usage is required.
     Therefore for this binary to be used the caller must call the associated `rapids_cpm` command
     with the `USE_PROPRIETARY_BLOB` set to `ON`.
 

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -95,7 +95,7 @@ as needed.
 
     Supports the following placeholders:
         - ``${rapids-cmake-version}`` will be evulated to 'major.minor' of the current rapids-cmake cal-ver value.
-        - ``${version}`` will be evulated to the contents of the ``version`` field.
+        - ``${version}`` will be evaluated to the contents of the ``version`` field.
 
     If this field exists in the default package, the value will be ignored when an override file
     entry exists for the package. This ensures that the git url or `proprietary_binary` entry in the override will be used.

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -94,7 +94,7 @@ as needed.
     with the `USE_PROPRIETARY_BLOB` set to `ON`.
 
     Supports the following placeholders:
-        - ``${rapids-cmake-version}`` will be evulated to 'major.minor' of the current rapids-cmake cal-ver value.
+        - ``${rapids-cmake-version}`` will be evaluated to 'major.minor' of the current rapids-cmake cal-ver value.
         - ``${version}`` will be evaluated to the contents of the ``version`` field.
 
     If this field exists in the default package, the value will be ignored when an override file

--- a/rapids-cmake/cpm/detail/get_default_json.cmake
+++ b/rapids-cmake/cpm/detail/get_default_json.cmake
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+get_default_json
+--------------------------
+
+. code-block:: cmake
+
+  get_default_json(package_name output_variable)
+
+#]=======================================================================]
+function(get_default_json package_name output_variable)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.get_default_json")
+  get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_json)
+  set(${output_variable} "${json_data}" PARENT_SCOPE)
+endfunction()

--- a/rapids-cmake/cpm/detail/get_override_json.cmake
+++ b/rapids-cmake/cpm/detail/get_override_json.cmake
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+get_override_json
+--------------------------
+
+. code-block:: cmake
+
+  get_override_json(package_name output_variable)
+
+#]=======================================================================]
+function(get_override_json package_name output_variable)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.get_override_json")
+  get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_override_json)
+  set(${output_variable} "${json_data}" PARENT_SCOPE)
+endfunction()

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -33,7 +33,7 @@ the current CPU target architecture ( x86_64, aarch64, etc )
 function(rapids_cpm_get_proprietary_binary package_name version)
 
   get_property(override_json_data GLOBAL PROPERTY rapids_cpm_${package_name}_override_json)
-  # need to search the `proprietary_binary` dictonary for a key with the same name as
+  # need to search the `proprietary_binary` dictionary for a key with the same name as
   # lower_case(`CMAKE_SYSTEM_PROCESSOR-CMAKE_SYSTEM_NAME`).
   set(key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
   string(TOLOWER ${key} key)

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -1,0 +1,77 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+get_proprietary_binary
+-------------------
+
+.. versionadded:: v22.06.00
+
+Download the associated proprietary binary for the given project based on
+the current CPU target architecture ( x86_64, aarch64, etc )
+
+ .. note::
+  if override => the proprietary entry only in the override will be evaluated
+  if no override => the proprietary entry only in the default will be evaluated
+
+
+#]=======================================================================]
+function(rapids_cpm_get_proprietary_binary package_name version)
+
+  get_property(override_json_data GLOBAL PROPERTY rapids_cpm_${package_name}_override_json)
+  # need to search the `proprietary_binary` dictonary for a key with the same name as
+  # lower_case(`CMAKE_SYSTEM_PROCESSOR-CMAKE_SYSTEM_NAME`).
+  set(key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
+  string(TOLOWER ${key} key)
+
+  if(override_json_data)
+    string(JSON value ERROR_VARIABLE have_error GET "${override_json_data}" "proprietary_binary"
+           "${key}")
+  else()
+    get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_json)
+    string(JSON value ERROR_VARIABLE have_error GET "${json_data}" "proprietary_binary" "${key}")
+  endif()
+
+  if(have_error)
+    message(VERBOSE
+            "${package_name} requested usage of a proprietary_binary but none exist for ${CMAKE_SYSTEM_PROCESSOR}"
+    )
+    return()
+  endif()
+
+  # proprietary_binary now is the url that we need to download
+  set(proprietary_binary ${value})
+
+  if(NOT DEFINED rapids-cmake-version)
+    include("${rapids-cmake-dir}/rapids-version.cmake")
+  endif()
+
+  # Evaluate any magic placeholders in the proprietary_binary value including the
+  # `rapids-cmake-version` value
+  cmake_language(EVAL CODE "set(proprietary_binary ${proprietary_binary})")
+
+  if(proprietary_binary)
+    # download and extract the binaries since they don't exist on the machine
+    include(FetchContent)
+    set(pkg_name "${package_name}_proprietary_binary")
+    FetchContent_Declare(${pkg_name} URL ${proprietary_binary})
+    FetchContent_MakeAvailable(${pkg_name})
+
+    # Tell the subsequent rapids_cpm_find where to search so that it uses this binary
+    set(${package_name}_ROOT "${${pkg_name}_SOURCE_DIR}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -39,11 +39,12 @@ function(rapids_cpm_get_proprietary_binary package_name version)
   string(TOLOWER ${key} key)
 
   if(override_json_data)
-    string(JSON value ERROR_VARIABLE have_error GET "${override_json_data}" "proprietary_binary"
-           "${key}")
+    string(JSON proprietary_binary ERROR_VARIABLE have_error GET "${override_json_data}"
+           "proprietary_binary" "${key}")
   else()
     get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_json)
-    string(JSON value ERROR_VARIABLE have_error GET "${json_data}" "proprietary_binary" "${key}")
+    string(JSON proprietary_binary ERROR_VARIABLE have_error GET "${json_data}"
+           "proprietary_binary" "${key}")
   endif()
 
   if(have_error)
@@ -52,9 +53,6 @@ function(rapids_cpm_get_proprietary_binary package_name version)
     )
     return()
   endif()
-
-  # proprietary_binary now is the url that we need to download
-  set(proprietary_binary ${value})
 
   if(NOT DEFINED rapids-cmake-version)
     include("${rapids-cmake-dir}/rapids-version.cmake")

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -31,18 +31,21 @@ the current CPU target architecture ( x86_64, aarch64, etc )
 
 #]=======================================================================]
 function(rapids_cpm_get_proprietary_binary package_name version)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_get_proprietary_binary")
 
-  get_property(override_json_data GLOBAL PROPERTY rapids_cpm_${package_name}_override_json)
+  include("${rapids-cmake-dir}/cpm/detail/get_default_json.cmake")
+  include("${rapids-cmake-dir}/cpm/detail/get_override_json.cmake")
+  get_default_json(${package_name} json_data)
+  get_override_json(${package_name} override_json_data)
+
   # need to search the `proprietary_binary` dictionary for a key with the same name as
   # lower_case(`CMAKE_SYSTEM_PROCESSOR-CMAKE_SYSTEM_NAME`).
   set(key "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
   string(TOLOWER ${key} key)
-
   if(override_json_data)
     string(JSON proprietary_binary ERROR_VARIABLE have_error GET "${override_json_data}"
            "proprietary_binary" "${key}")
   else()
-    get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_json)
     string(JSON proprietary_binary ERROR_VARIABLE have_error GET "${json_data}"
            "proprietary_binary" "${key}")
   endif()

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -73,5 +73,6 @@ function(rapids_cpm_get_proprietary_binary package_name version)
 
     # Tell the subsequent rapids_cpm_find where to search so that it uses this binary
     set(${package_name}_ROOT "${${pkg_name}_SOURCE_DIR}" PARENT_SCOPE)
+    set(${package_name}_proprietary_binary ON PARENT_SCOPE)
   endif()
 endfunction()

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -38,8 +38,10 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
   rapids_cpm_load_preset_versions()
 
-  get_property(override_json_data GLOBAL PROPERTY rapids_cpm_${package_name}_override_json)
-  get_property(json_data GLOBAL PROPERTY rapids_cpm_${package_name}_json)
+  include("${rapids-cmake-dir}/cpm/detail/get_default_json.cmake")
+  include("${rapids-cmake-dir}/cpm/detail/get_override_json.cmake")
+  get_default_json(${package_name} json_data)
+  get_override_json(${package_name} override_json_data)
 
   # Parse required fields
   function(rapids_cpm_json_get_value name)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -71,7 +71,7 @@ function(rapids_cpm_nvcomp)
   set(multi_value)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  # Fix up RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS As this is need for rapids_cpm_find
+  # Fix up RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS as this is need for rapids_cpm_find
   if(RAPIDS_INSTALL_EXPORT_SET)
     list(APPEND RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${RAPIDS_INSTALL_EXPORT_SET})
   endif()

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -50,6 +50,16 @@ across all RAPIDS projects.
   By enabling this flag and using the software, you agree to fully comply with the terms and conditions of
   nvcomp's NVIDIA Software License Agreement. Found at https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
 
+  NVComp offers pre-built proprietary version of the library ( for x86_64 only ) that offer more features compared to the
+  open source version. Since NVComp currently doesn't offer pre-built versions for all platforms, callers should verify
+  the the request for a proprietary binary was fulfilled by checking the :cmake:variable:`nvcomp_proprietary_binary`
+  variable after calling :cmake:command:`rapids_cpm_nvcomp`.
+
+.. note::
+  If an override entry exists for the nvcomp package it MUST have a proprietary_binary entry for this to
+  flag to do anything. Any override without this entry is considered to invalidate the existin proprietary
+  binary entry.
+
 Result Targets
 ^^^^^^^^^^^^^^
   nvcomp::nvcomp target will be created

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -79,13 +79,12 @@ function(rapids_cpm_nvcomp)
     list(APPEND RAPIDS_UNPARSED_ARGUMENTS BUILD_EXPORT_SET ${RAPIDS_BUILD_EXPORT_SET})
   endif()
 
+  include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+  rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
   set(to_exclude OFF)
   if(NOT RAPIDS_INSTALL_EXPORT_SET OR exclude)
     set(to_exclude ON)
   endif()
-
-  include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
 
   # first see if we have a proprietary pre-built binary listed in versions.json and it if requested.
   set(nvcomp_proprietary_binary OFF) # will be set to true by rapids_cpm_get_proprietary_binary

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -88,7 +88,6 @@ function(rapids_cpm_nvcomp)
   rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
 
   # first see if we have a proprietary pre-built binary listed in versions.json and it if requested.
-  #
   set(nvcomp_proprietary_binary OFF) # will be set to true by rapids_cpm_get_proprietary_binary
   if(RAPIDS_USE_PROPRIETARY_BINARY)
     include("${rapids-cmake-dir}/cpm/detail/get_proprietary_binary.cmake")

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -132,9 +132,6 @@ function(rapids_cpm_nvcomp)
   if(RAPIDS_BUILD_EXPORT_SET AND nvcomp_proprietary_binary)
     # point our consumers to where they can find the pre-built version
     rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}" ${RAPIDS_BUILD_EXPORT_SET})
-  elseif(RAPIDS_BUILD_EXPORT_SET)
-    # point our consumers to where they can find the source version
-    rapids_export_find_package_root(BUILD nvcomp "${nvcomp_BINARY_DIR}" ${RAPIDS_BUILD_EXPORT_SET})
   endif()
 
 endfunction()

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -125,8 +125,8 @@ function(rapids_cpm_nvcomp)
     install(DIRECTORY "${nvcomp_ROOT}/lib/" DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(DIRECTORY "${nvcomp_ROOT}/include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     # place the license information in the location that conda uses
-    install(FILES "${nvcomp_ROOT}/NOTICE" DESTINATION info/licenses/ RENAME NVCOMP_NOTICE)
-    install(FILES "${nvcomp_ROOT}/LICENSE" DESTINATION info/licenses/ RENAME NVCOMP_LICENSE)
+    install(FILES "${nvcomp_ROOT}/NOTICE" DESTINATION info/ RENAME NVCOMP_NOTICE)
+    install(FILES "${nvcomp_ROOT}/LICENSE" DESTINATION info/ RENAME NVCOMP_LICENSE)
   endif()
 
   if(RAPIDS_BUILD_EXPORT_SET AND nvcomp_proprietary_binary)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -57,48 +57,85 @@ Result Targets
 Result Variables
 ^^^^^^^^^^^^^^^^
   :cmake:variable:`nvcomp_SOURCE_DIR` is set to the path to the source directory of nvcomp.
-  :cmake:variable:`nvcomp_BINARY_DIR` is set to the path to the build directory of  nvcomp.
+  :cmake:variable:`nvcomp_BINARY_DIR` is set to the path to the build directory of nvcomp.
   :cmake:variable:`nvcomp_ADDED`      is set to a true value if nvcomp has not been added before.
   :cmake:variable:`nvcomp_VERSION`    is set to the version of nvcomp specified by the versions.json.
+  :cmake:variable:`nvcomp_proprietary_binary` is set to ON if the proprietary binary is being used
 
 #]=======================================================================]
 function(rapids_cpm_nvcomp)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.nvcomp")
 
   set(options)
-  set(one_value USE_PROPRIETARY_BINARY)
+  set(one_value USE_PROPRIETARY_BINARY BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(multi_value)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  #Fix up RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS
+  #As this is need for rapids_cpm_find
+  if(RAPIDS_INSTALL_EXPORT_SET)
+    list(APPEND RAPIDS_UNPARSED_ARGUMENTS  INSTALL_EXPORT_SET ${RAPIDS_INSTALL_EXPORT_SET})
+  endif()
+  if(RAPIDS_BUILD_EXPORT_SET)
+    list(APPEND RAPIDS_UNPARSED_ARGUMENTS  BUILD_EXPORT_SET ${RAPIDS_BUILD_EXPORT_SET})
+  endif()
+
+  set(to_exclude OFF)
+  if(NOT RAPIDS_INSTALL_EXPORT_SET OR exclude)
+    set(to_exclude ON)
+  endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
 
   # first see if we have a proprietary pre-built binary listed in versions.json and it if requested.
   #
+  set(nvcomp_proprietary_binary OFF) # will be set to true by rapids_cpm_get_proprietary_binary
   if(RAPIDS_USE_PROPRIETARY_BINARY)
     include("${rapids-cmake-dir}/cpm/detail/get_proprietary_binary.cmake")
     rapids_cpm_get_proprietary_binary(nvcomp ${version})
   endif()
 
-  set(to_exclude OFF)
-  if(NOT INSTALL_EXPORT_SET IN_LIST ARGN OR exclude)
-    set(to_exclude ON)
-  endif()
-
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(nvcomp ${version} ${ARGN}
+  rapids_cpm_find(nvcomp ${version} ${RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS nvcomp::nvcomp
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  EXCLUDE_FROM_ALL ${to_exclude})
+                  EXCLUDE_FROM_ALL ${to_exclude}
+                  OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF")
+
+  # nvcomp creates the correct namespace aliases
+  if(NOT TARGET nvcomp::nvcomp AND TARGET nvcomp)
+    add_library(nvcomp::nvcomp ALIAS nvcomp)
+  endif()
 
   # Propagate up variables that CPMFindPackage provide
   set(nvcomp_SOURCE_DIR "${nvcomp_SOURCE_DIR}" PARENT_SCOPE)
   set(nvcomp_BINARY_DIR "${nvcomp_BINARY_DIR}" PARENT_SCOPE)
   set(nvcomp_ADDED "${nvcomp_ADDED}" PARENT_SCOPE)
   set(nvcomp_VERSION ${version} PARENT_SCOPE)
+  set(nvcomp_proprietary_binary ${nvcomp_proprietary_binary} PARENT_SCOPE)
 
-  # nvcomp creates the correct namespace aliases
+  # Setup up install rules when using the proprietary_binary
+  # When building from source, nvcomp will set the correct install rules
+  include("${rapids-cmake-dir}/export/find_package_root.cmake")
+  if(RAPIDS_INSTALL_EXPORT_SET AND nvcomp_proprietary_binary)
+    include(GNUInstallDirs)
+    install(DIRECTORY "${nvcomp_ROOT}/lib/" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY "${nvcomp_ROOT}/include/" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    # place the license information in the location that conda uses
+    install(FILES "${nvcomp_ROOT}/NOTICE" DESTINATION info/licenses/ RENAME NVCOMP_NOTICE)
+    install(FILES "${nvcomp_ROOT}/LICENSE" DESTINATION info/licenses/ RENAME NVCOMP_LICENSE)
+  endif()
+
+  if(RAPIDS_BUILD_EXPORT_SET AND nvcomp_proprietary_binary)
+    # point our consumers to where they can find the pre-built version
+    rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}" ${RAPIDS_BUILD_EXPORT_SET})
+  elseif(RAPIDS_BUILD_EXPORT_SET)
+    # point our consumers to where they can find the source version
+    rapids_export_find_package_root(BUILD nvcomp "${nvcomp_BINARY_DIR}" ${RAPIDS_BUILD_EXPORT_SET})
+  endif()
+
 endfunction()

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -1,0 +1,104 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+rapids_cpm_nvcomp
+-----------------
+
+.. versionadded:: v22.06.00
+
+Allow projects to find or build `nvComp` via `CPM` with built-in
+tracking of these dependencies for correct export support.
+
+Uses the version of nvComp :ref:`specified in the version file <cpm_versions>` for consistency
+across all RAPIDS projects.
+
+.. code-block:: cmake
+
+  rapids_cpm_nvcomp( [BUILD_EXPORT_SET <export-name>]
+                     [INSTALL_EXPORT_SET <export-name>]
+                     [USE_PROPRIETARY_BINARY <ON|OFF>]
+                   )
+
+``BUILD_EXPORT_SET``
+  Record that a :cmake:command:`CPMFindPackage(<PackageName> ...)` call needs to occur as part of
+  our build directory export set.
+
+``INSTALL_EXPORT_SET``
+  Record a :cmake:command:`find_dependency(<PackageName> ...) <cmake:module:CMakeFindDependencyMacro>` call needs to occur as part of
+  our build directory export set.
+
+.. note::
+  Installation of nvcomp will occur if an INSTALL_EXPORT_SET is provided, and nvcomp
+  is added to the project via :cmake:command:`add_subdirectory <cmake:command:add_subdirectory>` by CPM.
+
+``USE_PROPRIETARY_BINARY``
+  By enabling this flag you and using the software, you agree to fully comply with the terms and conditions of
+  nvcomp's NVIDIA Software License Agreement. Found at https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
+
+Result Targets
+^^^^^^^^^^^^^^
+  nvcomp::nvcomp target will be created
+
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`nvcomp_SOURCE_DIR` is set to the path to the source directory of nvcomp.
+  :cmake:variable:`nvcomp_BINARY_DIR` is set to the path to the build directory of  nvcomp.
+  :cmake:variable:`nvcomp_ADDED`      is set to a true value if nvcomp has not been added before.
+  :cmake:variable:`nvcomp_VERSION`    is set to the version of nvcomp specified by the versions.json.
+
+#]=======================================================================]
+function(rapids_cpm_nvcomp)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.nvcomp")
+
+  set(options)
+  set(one_value USE_PROPRIETARY_BINARY)
+  set(multi_value)
+  cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+  rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
+
+  # first see if we have a proprietary pre-built binary listed in versions.json and it if requested.
+  #
+  if(RAPIDS_USE_PROPRIETARY_BINARY)
+    include("${rapids-cmake-dir}/cpm/detail/get_proprietary_binary.cmake")
+    rapids_cpm_get_proprietary_binary(nvcomp ${version})
+  endif()
+
+  set(to_exclude OFF)
+  if(NOT INSTALL_EXPORT_SET IN_LIST ARGN OR exclude)
+    set(to_exclude ON)
+  endif()
+
+  include("${rapids-cmake-dir}/cpm/find.cmake")
+  rapids_cpm_find(nvcomp ${version} ${ARGN}
+                  GLOBAL_TARGETS nvcomp::nvcomp
+                  CPM_ARGS
+                  GIT_REPOSITORY ${repository}
+                  GIT_TAG ${tag}
+                  GIT_SHALLOW ${shallow}
+                  EXCLUDE_FROM_ALL ${to_exclude})
+
+  # Propagate up variables that CPMFindPackage provide
+  set(nvcomp_SOURCE_DIR "${nvcomp_SOURCE_DIR}" PARENT_SCOPE)
+  set(nvcomp_BINARY_DIR "${nvcomp_BINARY_DIR}" PARENT_SCOPE)
+  set(nvcomp_ADDED "${nvcomp_ADDED}" PARENT_SCOPE)
+  set(nvcomp_VERSION ${version} PARENT_SCOPE)
+
+  # nvcomp creates the correct namespace aliases
+endfunction()

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -47,7 +47,7 @@ across all RAPIDS projects.
   is added to the project via :cmake:command:`add_subdirectory <cmake:command:add_subdirectory>` by CPM.
 
 ``USE_PROPRIETARY_BINARY``
-  By enabling this flag you and using the software, you agree to fully comply with the terms and conditions of
+  By enabling this flag and using the software, you agree to fully comply with the terms and conditions of
   nvcomp's NVIDIA Software License Agreement. Found at https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
 
 Result Targets

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -114,8 +114,7 @@ function(rapids_cpm_nvcomp)
                   OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
                           "BUILD_EXAMPLES OFF")
 
-  # provice consistent targets between a found nvcomp
-  # and one building from source
+  # provice consistent targets between a found nvcomp and one building from source
   if(NOT TARGET nvcomp::nvcomp AND TARGET nvcomp)
     add_library(nvcomp::nvcomp ALIAS nvcomp)
   endif()
@@ -127,8 +126,8 @@ function(rapids_cpm_nvcomp)
   set(nvcomp_VERSION ${version} PARENT_SCOPE)
   set(nvcomp_proprietary_binary ${nvcomp_proprietary_binary} PARENT_SCOPE)
 
-  # Set up up install rules when using the proprietary_binary. When building from source, nvcomp will
-  # set the correct install rules
+  # Set up up install rules when using the proprietary_binary. When building from source, nvcomp
+  # will set the correct install rules
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   if(RAPIDS_INSTALL_EXPORT_SET AND nvcomp_proprietary_binary)
     include(GNUInstallDirs)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -71,13 +71,12 @@ function(rapids_cpm_nvcomp)
   set(multi_value)
   cmake_parse_arguments(RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  #Fix up RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS
-  #As this is need for rapids_cpm_find
+  # Fix up RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS As this is need for rapids_cpm_find
   if(RAPIDS_INSTALL_EXPORT_SET)
-    list(APPEND RAPIDS_UNPARSED_ARGUMENTS  INSTALL_EXPORT_SET ${RAPIDS_INSTALL_EXPORT_SET})
+    list(APPEND RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${RAPIDS_INSTALL_EXPORT_SET})
   endif()
   if(RAPIDS_BUILD_EXPORT_SET)
-    list(APPEND RAPIDS_UNPARSED_ARGUMENTS  BUILD_EXPORT_SET ${RAPIDS_BUILD_EXPORT_SET})
+    list(APPEND RAPIDS_UNPARSED_ARGUMENTS BUILD_EXPORT_SET ${RAPIDS_BUILD_EXPORT_SET})
   endif()
 
   set(to_exclude OFF)
@@ -104,7 +103,8 @@ function(rapids_cpm_nvcomp)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   EXCLUDE_FROM_ALL ${to_exclude}
-                  OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF")
+                  OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
+                          "BUILD_EXAMPLES OFF")
 
   # nvcomp creates the correct namespace aliases
   if(NOT TARGET nvcomp::nvcomp AND TARGET nvcomp)
@@ -118,8 +118,8 @@ function(rapids_cpm_nvcomp)
   set(nvcomp_VERSION ${version} PARENT_SCOPE)
   set(nvcomp_proprietary_binary ${nvcomp_proprietary_binary} PARENT_SCOPE)
 
-  # Setup up install rules when using the proprietary_binary
-  # When building from source, nvcomp will set the correct install rules
+  # Setup up install rules when using the proprietary_binary When building from source, nvcomp will
+  # set the correct install rules
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   if(RAPIDS_INSTALL_EXPORT_SET AND nvcomp_proprietary_binary)
     include(GNUInstallDirs)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -118,7 +118,7 @@ function(rapids_cpm_nvcomp)
   set(nvcomp_VERSION ${version} PARENT_SCOPE)
   set(nvcomp_proprietary_binary ${nvcomp_proprietary_binary} PARENT_SCOPE)
 
-  # Setup up install rules when using the proprietary_binary When building from source, nvcomp will
+  # Set up up install rules when using the proprietary_binary. When building from source, nvcomp will
   # set the correct install rules
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   if(RAPIDS_INSTALL_EXPORT_SET AND nvcomp_proprietary_binary)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -105,7 +105,8 @@ function(rapids_cpm_nvcomp)
                   OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
                           "BUILD_EXAMPLES OFF")
 
-  # nvcomp creates the correct namespace aliases
+  # provice consistent targets between a found nvcomp
+  # and one building from source
   if(NOT TARGET nvcomp::nvcomp AND TARGET nvcomp)
     add_library(nvcomp::nvcomp ALIAS nvcomp)
   endif()

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -12,6 +12,14 @@
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
       "git_tag" : "a72f248af6323915419e03c0d7d56a35c9b4819a"
     },
+    "nvcomp" : {
+      "version" : "2.3",
+      "git_url" : "https://github.com/NVIDIA/nvcomp.git",
+      "git_tag" : "v2.2.0",
+      "proprietary_binary" : {
+        "x86_64-linux" : "http://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_Linux_CUDA_11.x.tgz"
+      }
+    },
     "rmm" : {
       "version" : "${rapids-cmake-version}",
       "git_url" : "https://github.com/rapidsai/rmm.git",

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -44,6 +44,13 @@ add_cmake_config_test( cpm_libcudacxx-simple.cmake )
 add_cmake_config_test( cpm_nvbench-export.cmake )
 add_cmake_config_test( cpm_nvbench-simple.cmake )
 
+add_cmake_config_test( cpm_nvcomp-export.cmake )
+add_cmake_config_test( cpm_nvcomp-proprietary-off.cmake )
+add_cmake_config_test( cpm_nvcomp-proprietary-on.cmake )
+add_cmake_config_test( cpm_nvcomp-simple.cmake )
+add_cmake_config_test( cpm_nvcomp-invalid-arch.cmake )
+add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake )
+
 add_cmake_config_test( cpm_rmm-export.cmake )
 add_cmake_config_test( cpm_rmm-simple.cmake )
 

--- a/testing/cpm/cpm_nvcomp-export.cmake
+++ b/testing/cpm/cpm_nvcomp-export.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_nvcomp-export.cmake
+++ b/testing/cpm/cpm_nvcomp-export.cmake
@@ -17,7 +17,6 @@ include(${rapids-cmake-dir}/cpm/init.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
 
 rapids_cpm_init()
-set(CMAKE_CUDA_ARCHITECTURES OFF)
 rapids_cpm_nvcomp(BUILD_EXPORT_SET test)
 rapids_cpm_nvcomp(BUILD_EXPORT_SET test2)
 

--- a/testing/cpm/cpm_nvcomp-export.cmake
+++ b/testing/cpm/cpm_nvcomp-export.cmake
@@ -13,32 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
 rapids_cpm_init()
+set(CMAKE_CUDA_ARCHITECTURES OFF)
+rapids_cpm_nvcomp(BUILD_EXPORT_SET test)
+rapids_cpm_nvcomp(BUILD_EXPORT_SET test2)
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+get_target_property(packages rapids_export_build_test PACKAGE_NAMES)
+if(NOT nvcomp IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_nvcomp failed to record nvcomp needs to be exported")
+endif()
+
+get_target_property(packages rapids_export_build_test2 PACKAGE_NAMES)
+if(NOT nvcomp IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_nvcomp failed to record nvcomp needs to be exported")
+endif()

--- a/testing/cpm/cpm_nvcomp-invalid-arch.cmake
+++ b/testing/cpm/cpm_nvcomp-invalid-arch.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_nvcomp-invalid-arch.cmake
+++ b/testing/cpm/cpm_nvcomp-invalid-arch.cmake
@@ -25,6 +25,6 @@ endif()
 set(CMAKE_SYSTEM_PROCESSOR "i686") # Don't do this outside of tests
 rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
 
-if(TARGET nvcomp::nvcomp)
+if(nvcomp_proprietary_binary)
   message(FATAL_ERROR "Shouldn't have found a pre-built version of nvcomp for a non-existent CMAKE_SYSTEM_PROCESSOR key")
 endif()

--- a/testing/cpm/cpm_nvcomp-invalid-arch.cmake
+++ b/testing/cpm/cpm_nvcomp-invalid-arch.cmake
@@ -13,32 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
 rapids_cpm_init()
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp expected to not exist")
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR "i686") # Don't do this outside of tests
+rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
+
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Shouldn't have found a pre-built version of nvcomp for a non-existent CMAKE_SYSTEM_PROCESSOR key")
+endif()

--- a/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
@@ -13,32 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
 
 rapids_cpm_init()
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp expected to not exist")
+endif()
+
+# Need to write out an nvcomp override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages" : {
+    "nvcomp" : {
+      "version" : "224",
+      "git_url" : "https://github.com/NVIDIA/nvcomp.git",
+    }
+  }
+}
+]=])
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+#
+rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
+
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Ignored nvcomp override file and brought in the binary version")
+endif()

--- a/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
@@ -41,6 +41,6 @@ rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 #
 rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
 
-if(TARGET nvcomp::nvcomp)
+if(nvcomp_proprietary_binary)
   message(FATAL_ERROR "Ignored nvcomp override file and brought in the binary version")
 endif()

--- a/testing/cpm/cpm_nvcomp-proprietary-off.cmake
+++ b/testing/cpm/cpm_nvcomp-proprietary-off.cmake
@@ -13,32 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
 rapids_cpm_init()
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp expected to not exist")
+endif()
+
+rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY OFF)
+
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Ignored `USE_PROPRIETARY_BINARY OFF` and brought in the binary version")
+endif()
+
+# Make sure we can be called multiple times
+rapids_cpm_nvcomp()

--- a/testing/cpm/cpm_nvcomp-proprietary-off.cmake
+++ b/testing/cpm/cpm_nvcomp-proprietary-off.cmake
@@ -24,7 +24,7 @@ endif()
 
 rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY OFF)
 
-if(TARGET nvcomp::nvcomp)
+if(nvcomp_proprietary_binary)
   message(FATAL_ERROR "Ignored `USE_PROPRIETARY_BINARY OFF` and brought in the binary version")
 endif()
 

--- a/testing/cpm/cpm_nvcomp-proprietary-on.cmake
+++ b/testing/cpm/cpm_nvcomp-proprietary-on.cmake
@@ -24,7 +24,7 @@ endif()
 
 rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
 
-if(NOT TARGET nvcomp::nvcomp)
+if(NOT nvcomp_proprietary_binary)
   message(FATAL_ERROR "Expected nvcomp::nvcomp target to exist")
 endif()
 

--- a/testing/cpm/cpm_nvcomp-proprietary-on.cmake
+++ b/testing/cpm/cpm_nvcomp-proprietary-on.cmake
@@ -13,32 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
 rapids_cpm_init()
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp expected to not exist")
+endif()
+
+rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
+
+if(NOT TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp target to exist")
+endif()
+
+# Make sure we can be called multiple times
+rapids_cpm_nvcomp()

--- a/testing/cpm/cpm_nvcomp-simple.cmake
+++ b/testing/cpm/cpm_nvcomp-simple.cmake
@@ -24,7 +24,7 @@ endif()
 
 rapids_cpm_nvcomp()
 
-if(TARGET nvcomp::nvcomp)
+if(nvcomp_proprietary_binary)
   message(FATAL_ERROR "Ignored no explicit enabling of `USE_PROPRIETARY_BINARY` and brought in the binary version")
 endif()
 

--- a/testing/cpm/cpm_nvcomp-simple.cmake
+++ b/testing/cpm/cpm_nvcomp-simple.cmake
@@ -13,32 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.20)
-
-project(fill_cache LANGUAGES CXX)
-
 include(${rapids-cmake-dir}/cpm/init.cmake)
-
-include(${rapids-cmake-dir}/cpm/gtest.cmake)
-include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
-include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
-include(${rapids-cmake-dir}/cpm/spdlog.cmake)
-include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
 rapids_cpm_init()
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-set(CPM_DOWNLOAD_ALL "ON")
-rapids_cpm_gtest(DOWNLOAD_ONLY ON)
-rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
-rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
-rapids_cpm_nvcomp(DOWNLOAD_ONLY ON)
-rapids_cpm_rmm(DOWNLOAD_ONLY ON)
-rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
-rapids_cpm_find(skbuild 0.14.1
-                GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
-                GIT_TAG 0.14.1
-                )
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp expected to not exist")
+endif()
+
+rapids_cpm_nvcomp()
+
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Ignored no explicit enabling of `USE_PROPRIETARY_BINARY` and brought in the binary version")
+endif()
+
+# Make sure we can be called multiple times
+rapids_cpm_nvcomp()


### PR DESCRIPTION
Expands the versions.json support to include the concept of per cpu architecture pre-built proprietary binary files that are used instead of building from source.

Currently the only package that supports this json entry is `nvcomp` which has also been added to `rapids_cpm`.

