### PR TITLE
Add rapids_cython to the html docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ The most commonly used function are:
 - `rapids_cuda_init_architectures(<project_name>)` handles initialization of `CMAKE_CUDA_ARCHITECTURE`. MUST BE CALLED BEFORE `PROJECT()`
 - `rapids_cuda_init_runtime(<mode>)` handles initialization of `CMAKE_CUDA_RUNTIME_LIBRARY`.
 
+### cython
+
+The `rapids_cython` functions allow projects to easily build cython modules using
+scikit-build.
+
+- `raipds_cython_init()` handles initialization of scikit-build and cython.
+- `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )` Will create cython modules for each provided source file
+
+
 ### export
 
 The `rapids-export` module contains core functionality to allow projects to easily record and write out

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The most commonly used function are:
 ### cython
 
 The `rapids_cython` functions allow projects to easily build cython modules using
-scikit-build.
+[scikit-build](https://scikit-build.readthedocs.io/en/latest/).
 
 - `rapids_cython_init()` handles initialization of scikit-build and cython.
 - `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )` will create cython modules for each provided source file

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ The most commonly used function are:
 The `rapids_cython` functions allow projects to easily build cython modules using
 scikit-build.
 
-- `raipds_cython_init()` handles initialization of scikit-build and cython.
-- `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )` Will create cython modules for each provided source file
+- `rapids_cython_init()` handles initialization of scikit-build and cython.
+- `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )` will create cython modules for each provided source file
 
 
 ### export

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,7 +57,7 @@ Cython
 ****
 
 The `rapids_cython` functions allow projects to easily build cython modules using
-scikit-build.
+`scikit-build <https://scikit-build.readthedocs.io/en/latest/>`_.
 
 .. toctree::
    :titlesonly:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,10 @@ Cython
 The `rapids_cython` functions allow projects to easily build cython modules using
 `scikit-build <https://scikit-build.readthedocs.io/en/latest/>`_.
 
+.. note::
+  Use of the rapids-cython component of rapids-cmake requires scikit-build. The behavior of the functions provided by
+  this component is undefined if they are invoked outside of a build managed by scikit-build.
+
 .. toctree::
    :titlesonly:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,17 @@ package uses :ref:`can be found here. <cpm_versions>`
    /packages/rapids_cpm_thrust
    /command/rapids_cpm_package_override
 
+Cython
+****
+
+The `rapids_cython` functions allow projects to easily build cython modules using
+scikit-build.
+
+.. toctree::
+   :titlesonly:
+
+   /command/rapids_cython_init
+   /command/rapids_cython_create_modules
 
 
 Find

--- a/docs/command/rapids_cython_create_modules.rst
+++ b/docs/command/rapids_cython_create_modules.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cython/create_modules.cmake

--- a/docs/command/rapids_cython_init.rst
+++ b/docs/command/rapids_cython_init.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cython/init.cmake

--- a/rapids-cmake/cython/init.cmake
+++ b/rapids-cmake/cython/init.cmake
@@ -26,6 +26,10 @@ Perform standard initialization of any CMake build using scikit-build to create 
 
   rapids_cython_init()
 
+.. note::
+  Use of the rapids-cython component of rapids-cmake requires scikit-build. The behavior of the functions provided by
+  this component is undefined if they are invoked outside of a build managed by scikit-build.
+
 Result Variables
 ^^^^^^^^^^^^^^^^
   :cmake:variable:`RAPIDS_CYTHON_INITIALIZED` will be set to TRUE.


### PR DESCRIPTION
We forgot to add the rapids_cython function to the API doc page