### PR TITLE
Add support for a prefix in Cython module targets

### DIFF
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -21,8 +21,8 @@ set(rapids-cmake-version 22.08)
 include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
-  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
-  GIT_TAG        branch-${rapids-cmake-version}
+  GIT_REPOSITORY https://github.com/vyasr/rapids-cmake.git
+  GIT_TAG        feature/rapids_cython_prefix
 )
 FetchContent_GetProperties(rapids-cmake)
 if(rapids-cmake_POPULATED)

--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -21,8 +21,8 @@ set(rapids-cmake-version 22.08)
 include(FetchContent)
 FetchContent_Declare(
   rapids-cmake
-  GIT_REPOSITORY https://github.com/vyasr/rapids-cmake.git
-  GIT_TAG        feature/rapids_cython_prefix
+  GIT_REPOSITORY https://github.com/rapidsai/rapids-cmake.git
+  GIT_TAG        branch-${rapids-cmake-version}
 )
 FetchContent_GetProperties(rapids-cmake)
 if(rapids-cmake_POPULATED)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The `rapids_cython` functions allow projects to easily build cython modules usin
 [scikit-build](https://scikit-build.readthedocs.io/en/latest/).
 
 - `rapids_cython_init()` handles initialization of scikit-build and cython.
-- `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )` will create cython modules for each provided source file
+- `rapids_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path>] [MODULE_PREFIX <module_prefix>] )` will create cython modules for each provided source file
 
 
 ### export

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -65,7 +65,7 @@ function(rapids_cython_create_modules)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cython.create_modules")
 
   set(_rapids_cython_options CXX)
-  set(_rapids_cython_one_value INSTALL_DIR)
+  set(_rapids_cython_one_value INSTALL_DIR PREFIX)
   set(_rapids_cython_multi_value SOURCE_FILES LINKED_LIBRARIES)
   cmake_parse_arguments(RAPIDS_CYTHON "${_rapids_cython_options}" "${_rapids_cython_one_value}"
                         "${_rapids_cython_multi_value}" ${ARGN})
@@ -77,10 +77,15 @@ function(rapids_cython_create_modules)
 
   set(CREATED_TARGETS "")
 
+  if(NOT DEFINED RAPIDS_CYTHON_PREFIX)
+    set(RAPIDS_CYTHON_PREFIX "")
+  endif()
+
   foreach(cython_filename IN LISTS RAPIDS_CYTHON_SOURCE_FILES)
     # Generate a reasonable module name.
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
+    string(PREPEND cython_module RAPIDS_CYTHON_PREFIX)
 
     # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -65,7 +65,7 @@ function(rapids_cython_create_modules)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cython.create_modules")
 
   set(_rapids_cython_options CXX)
-  set(_rapids_cython_one_value INSTALL_DIR PREFIX)
+  set(_rapids_cython_one_value INSTALL_DIR MODULE_PREFIX)
   set(_rapids_cython_multi_value SOURCE_FILES LINKED_LIBRARIES)
   cmake_parse_arguments(RAPIDS_CYTHON "${_rapids_cython_options}" "${_rapids_cython_one_value}"
                         "${_rapids_cython_multi_value}" ${ARGN})
@@ -77,15 +77,15 @@ function(rapids_cython_create_modules)
 
   set(CREATED_TARGETS "")
 
-  if(NOT DEFINED RAPIDS_CYTHON_PREFIX)
-    set(RAPIDS_CYTHON_PREFIX "")
+  if(NOT DEFINED RAPIDS_CYTHON_MODULE_PREFIX)
+      set(RAPIDS_CYTHON_MODULE_PREFIX "")
   endif()
 
   foreach(cython_filename IN LISTS RAPIDS_CYTHON_SOURCE_FILES)
     # Generate a reasonable module name.
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
-    string(PREPEND cython_module RAPIDS_CYTHON_PREFIX)
+    string(PREPEND cython_module RAPIDS_CYTHON_MODULE_PREFIX)
 
     # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -85,7 +85,7 @@ function(rapids_cython_create_modules)
     # Generate a reasonable module name.
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
-    string(PREPEND cython_module RAPIDS_CYTHON_MODULE_PREFIX)
+    string(PREPEND cython_module ${RAPIDS_CYTHON_MODULE_PREFIX})
 
     # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -24,7 +24,7 @@ Generate C(++) from Cython and create Python modules.
 
 .. code-block:: cmake
 
-  rapids_cython_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path> )
+  rapids_cython_create_modules([CXX] [SOURCE_FILES <src1> <src2> ...] [LINKED_LIBRARIES <lib1> <lib2> ... ]  [INSTALL_DIR <install_path>] [MODULE_PREFIX <module_prefix>] )
 
 Creates a Cython target for each provided source file, then adds a
 corresponding Python extension module. Each built library has its RPATH set to
@@ -51,6 +51,11 @@ $ORIGIN.
   The path relative to the installation prefix so that it can be converted to
   an absolute path in a relocatable way. If not provided, defaults to the path
   to CMAKE_CURRENT_SOURCE_DIR relative to PROJECT_SOURCE_DIR.
+
+``MODULE_PREFIX``
+  A prefix used to name the generated library targets. This functionality is
+  useful when multiple Cython modules in different subpackages of the the same
+  project have the same name. The default prefix is the empty string.
 
 Result Variables
 ^^^^^^^^^^^^^^^^

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -89,9 +89,10 @@ function(rapids_cython_create_modules)
     # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR
                       cythonized_file)
-    string(PREPEND cython_module ${RAPIDS_CYTHON_MODULE_PREFIX})
-    add_library(${cython_module} MODULE ${cythonized_file})
-    python_extension_module(${cython_module})
+    set(cython_module_library_name "${RAPIDS_CYTHON_MODULE_PREFIX}${cython_module}")
+    add_library(${cython_module_library_name} MODULE ${cythonized_file})
+    python_extension_module(${cython_module_library_name})
+    set_target_properties(${cython_module_library_name} PROPERTIES library_output_name ${cython_module})
 
     # Avoid libraries being prefixed with "lib".
     set_target_properties(${cython_module} PROPERTIES PREFIX "")

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -85,11 +85,11 @@ function(rapids_cython_create_modules)
     # Generate a reasonable module name.
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
-    string(PREPEND cython_module ${RAPIDS_CYTHON_MODULE_PREFIX})
 
     # Generate C++ from Cython and create a library for the resulting extension module to compile.
     add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR
                       cythonized_file)
+    string(PREPEND cython_module ${RAPIDS_CYTHON_MODULE_PREFIX})
     add_library(${cython_module} MODULE ${cythonized_file})
     python_extension_module(${cython_module})
 

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -86,16 +86,18 @@ function(rapids_cython_create_modules)
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REMOVE_EXTENSION cython_module)
 
-    # Generate C++ from Cython and create a library for the resulting extension module to compile.
-    add_cython_target(${cython_module} "${cython_filename}" ${language} PY3 OUTPUT_VAR
-                      cythonized_file)
-    set(cython_module_library_name "${RAPIDS_CYTHON_MODULE_PREFIX}${cython_module}")
-    add_library(${cython_module_library_name} MODULE ${cythonized_file})
-    python_extension_module(${cython_module_library_name})
-    set_target_properties(${cython_module_library_name} PROPERTIES library_output_name ${cython_module})
+    # Save the name of the module without the provided prefix so that we can control the output.
+    set(cython_module_filename "${cython_module}")
+    string(PREPEND cython_module ${RAPIDS_CYTHON_MODULE_PREFIX})
 
-    # Avoid libraries being prefixed with "lib".
-    set_target_properties(${cython_module} PROPERTIES PREFIX "")
+    # Generate C++ from Cython and create a library for the resulting extension module to compile.
+    add_cython_target(${cython_module_filename} "${cython_filename}" ${language} PY3 OUTPUT_VAR
+                      cythonized_file)
+    add_library(${cython_module} MODULE ${cythonized_file})
+    python_extension_module(${cython_module})
+
+    # The final library name must match the original filename and must ignore the prefix.
+    set_target_properties(${cython_module} PROPERTIES LIBRARY_OUTPUT_NAME ${cython_module_filename})
 
     # Link the module to the requested libraries
     if(DEFINED RAPIDS_CYTHON_LINKED_LIBRARIES)

--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -83,7 +83,7 @@ function(rapids_cython_create_modules)
   set(CREATED_TARGETS "")
 
   if(NOT DEFINED RAPIDS_CYTHON_MODULE_PREFIX)
-      set(RAPIDS_CYTHON_MODULE_PREFIX "")
+    set(RAPIDS_CYTHON_MODULE_PREFIX "")
   endif()
 
   foreach(cython_filename IN LISTS RAPIDS_CYTHON_SOURCE_FILES)

--- a/testing/cython/CMakeLists.txt
+++ b/testing/cython/CMakeLists.txt
@@ -21,3 +21,4 @@ add_cmake_config_test(create_modules_errors.cmake SHOULD_FAIL "You must call rap
 
 add_cmake_config_test(create_modules)
 add_cmake_config_test(create_modules_with_library)
+add_cmake_config_test(create_modules_with_prefix)

--- a/testing/cython/create_modules/CMakeLists.txt
+++ b/testing/cython/create_modules/CMakeLists.txt
@@ -40,5 +40,5 @@ rapids_cython_create_modules(
     )
 
 if(NOT TARGET test)
-  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed target test")
+  message(FATAL_ERROR "rapids_cython_init didn't create the target `test`")
 endif()

--- a/testing/cython/create_modules/CMakeLists.txt
+++ b/testing/cython/create_modules/CMakeLists.txt
@@ -38,3 +38,17 @@ rapids_cython_create_modules()
 rapids_cython_create_modules(
     SOURCE_FILES test.pyx
     )
+
+if(NOT TARGET test)
+  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed target test")
+endif()
+
+# Test that we can use a prefix to generate a different library target.
+rapids_cython_create_modules(
+    SOURCE_FILES test.pyx
+    MODULE_PREFIX "test_"
+    )
+
+if(NOT TARGET test_test)
+  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed library target test::test")
+endif()

--- a/testing/cython/create_modules_with_prefix/CMakeLists.txt
+++ b/testing/cython/create_modules_with_prefix/CMakeLists.txt
@@ -34,11 +34,12 @@ rapids_cython_init()
 # Test that an empty invocation works.
 rapids_cython_create_modules()
 
-# Test that a basic invocation with a single file works.
+# Test that we can use a prefix to generate a different library target.
 rapids_cython_create_modules(
     SOURCE_FILES test.pyx
+    MODULE_PREFIX "test_"
     )
 
-if(NOT TARGET test)
-  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed target test")
+if(NOT TARGET test_test)
+  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed library target test::test")
 endif()

--- a/testing/cython/create_modules_with_prefix/CMakeLists.txt
+++ b/testing/cython/create_modules_with_prefix/CMakeLists.txt
@@ -41,5 +41,5 @@ rapids_cython_create_modules(
     )
 
 if(NOT TARGET test_test)
-  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed library target test::test")
+  message(FATAL_ERROR "rapids_cython_init didn't create the prefixed library target `test_test`")
 endif()


### PR DESCRIPTION
<!--

Thank you for contributing to rapids-cmake :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have followed the following guidelines for the changes made/features
   added.

   - Each function should follow the `rapids_<component>_<file_name>` naming pattern
   - Each function should go into a separate `.cmake` file in the appropriate directory
   - Each user facing `.cmake` file should have include guards (`include_guard(GLOBAL)`)
   - Each user facing `.cmake` file should be documented using the rst structure
   - Each user facing function should be added to the `cmake-format.json` document
    - Run `cmake-genparsers -f json` on the `.cmake` file as a starting point
   - Each function first line should be `list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.<component>.<function>")`

   - A file should not modify any state simply by being included. State modification should
     only occur inside functions unless absolutely necessary due to restrictions of the CMake
     language.
      - Any files that do need to break this rule can't be part of `rapids-<component>.cmake`.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please mark your pull request as Draft.
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove it from "Draft" and make it "Ready for Review".
   https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review

   If assistance is required to complete the functionality, for example when the
   CMake code of a feature is complete but downstream testing is still required,
   then add the label `help wanted` so that others can triage and assist.
   The additional changes then can be implemented on top of the same PR.
   If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on main/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against main they should be resolved by merging main
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
A package composed of subpackages may contain multiple Cython modules with the same filename at different paths i.e. in different parts of the package directory tree. Since we use the filenames to construct the CMake library targets, the resulting library target names will conflict unless there is a way to customize them. This PR adds that functionality. Note that because of the way that scikit-build's Cython is designed, we need to ensure that the generated shared library is named  according to the original filename; the prefix should only be applied to the CMake target to avoid conflicts within CMake.