### PR TITLE
Update thrust tag to 1.17.0.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,9 +31,9 @@
       "git_tag" : "v${version}"
     },
     "Thrust" : {
-      "version" : "1.15.0.0",
+      "version" : "1.17.0",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "1.15.0"
+      "git_tag" : "${version}"
     },
     "libcudacxx" : {
       "version" : "1.7.0",


### PR DESCRIPTION
This PR updates Thrust to version 1.17.0 (to be released soon) for RAPIDS 22.08. The tag format has been updated as noted in #181.

See also: https://github.com/rapidsai/cudf/issues/10841

Checklist:
- [x] Wait for Thrust 1.17.0 final release
- [ ] Test packages with updates for header includes:
  - [x] https://github.com/rapidsai/cuml/pull/4675
  - [x] https://github.com/rapidsai/cuspatial/pull/539
  - [x] https://github.com/NVIDIA/cuCollections/pull/161
  - [x] https://github.com/rapidsai/raft/pull/678
  - [x] https://github.com/rapidsai/cugraph/pull/2310
  - [ ] Make updated PR to cuDF with an updated patch for the sort algorithm, benchmark cudf