### PR TITLE
Fix docs: default behavior is to use a shallow git clone.

### DIFF
--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -55,7 +55,7 @@ as needed.
     An optional boolean value that represents if we should do a shallow git clone
     or not.
 
-    If no such field exists the default is `false`.
+    If no such field exists the default is `true`.
 
 ``exclude_from_all``
 


### PR DESCRIPTION
Fixes the documentation to indicate that git clones are shallow by default.