### PR TITLE
[FIX] call `rapids_find_package(libcudacxx)` before `rapids_cpm_find(libcudacxx)`

### DIFF
--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -58,8 +58,7 @@ function(rapids_cpm_libcudacxx)
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(libcudacxx version repository tag shallow exclude)
-  rapids_find_package(libcudacxx ${version}
-                      GLOBAL_TARGETS libcudacxx::libcudacxx
+  rapids_find_package(libcudacxx ${version} GLOBAL_TARGETS libcudacxx::libcudacxx
                       BUILD_EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET}
                       INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
 

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -124,16 +124,16 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     #]==]
     include(GNUInstallDirs)
     install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/" FILES_MATCHING
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust" FILES_MATCHING
             REGEX "\\.(h|inl)$")
     install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies/" FILES_MATCHING
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies" FILES_MATCHING
             PATTERN "*.cuh")
 
     install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/thrust/")
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/thrust")
     install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies/cub/")
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies/cub")
 
     include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
     rapids_cmake_install_lib_dir(install_location) # Use the correct conda aware path


### PR DESCRIPTION
Attempt to find an existing `libcudacxx` package before falling back to downloading it. calling `CPMFindPackage` with `DOWNLOAD_ONLY TRUE` causes it to skip the `find_package` part, so libcudacxx is never found even if the correct version is installed and could be found.