### PR TITLE
[FIX] `rapids_find_package()` called with explicit version and REQUIRED should fail

### DIFF
--- a/rapids-cmake/find/package.cmake
+++ b/rapids-cmake/find/package.cmake
@@ -27,7 +27,7 @@ tracking of these dependencies for correct export support.
 .. code-block:: cmake
 
   rapids_find_package(<PackageName>
-                      [REQUIRED]
+                      [ all normal find_package options ]
                       [GLOBAL_TARGETS <targets...>]
                       [BUILD_EXPORT_SET <name>]
                       [INSTALL_EXPORT_SET <name>]
@@ -46,6 +46,17 @@ so users have consistency. List all targets used by your project in `GLOBAL_TARG
 .. note::
   If the project/package you are looking for doesn't have an existing
   CMake Find module, please look at using :cmake:command:`rapids_find_generate_module`.
+
+.. note::
+  This function supports two call modes:
+  1. The same initial signature as :cmake:command:`find_package`, followed by
+     `BUILD_EXPORT_SET` and/or `INSTALL_EXPORT_SET` as the last two arguments.
+  2. `BUILD_EXPORT_SET` and/or `INSTALL_EXPORT_SET` defined after the package
+     name, followed by `FIND_ARGS` and the rest of the :cmake:command:`find_package`
+     arguments you'd like to pass. The `FIND_ARGS` delimiter is necessary because
+     :cmake:command:`cmake_parse_arguments` is a greedy parser and will consume
+     the :cmake:command:`find_package` arguments unless they're part of a separate
+     argument option.
 
 ``PackageName``
   Name of the package to find.

--- a/rapids-cmake/find/package.cmake
+++ b/rapids-cmake/find/package.cmake
@@ -75,19 +75,13 @@ macro(rapids_find_package name)
   # same. If it doesn't it would make drop in replacements impossible
   #
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.find.package")
-  set(_rapids_options FIND_ARGS REQUIRED)
+  set(_rapids_options FIND_ARGS)
   set(_rapids_one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(_rapids_multi_value GLOBAL_TARGETS)
   cmake_parse_arguments(_RAPIDS "${_rapids_options}" "${_rapids_one_value}"
                         "${_rapids_multi_value}" ${ARGN})
 
-  set(_rapids_required_flag)
-  if(_RAPIDS_REQUIRED)
-    set(_rapids_required_flag REQUIRED)
-  endif()
-
-  find_package(${name} ${_rapids_required_flag} ${_RAPIDS_UNPARSED_ARGUMENTS})
-  unset(_rapids_required_flag)
+  find_package(${name} ${_RAPIDS_UNPARSED_ARGUMENTS})
 
   if(_RAPIDS_GLOBAL_TARGETS)
     include("${rapids-cmake-dir}/cmake/make_global.cmake")

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -26,11 +26,12 @@ add_cmake_config_test( find_package-install.cmake )
 # a hard error and therefore has no test
 add_cmake_config_test( find_package-optional-failed.cmake )
 add_cmake_config_test( find_package-required-found.cmake )
+add_cmake_config_test( find_package-version-explicit-failed.cmake )
 
 add_cmake_config_test( find_package-version-explicit.cmake )
 add_cmake_config_test( find_package-version-none.cmake )
+add_cmake_config_test( find_package-version-required-explicit-failed.cmake SHOULD_FAIL "but required is exact version \"99999999999\"")
 
 add_cmake_config_test( find_generate_module-build )
 add_cmake_config_test( find_generate_module-install )
 add_cmake_config_test( find_generate_module-header-only )
-

--- a/testing/find/find_package-optional-failed.cmake
+++ b/testing/find/find_package-optional-failed.cmake
@@ -47,8 +47,8 @@ endif()
 
 # Check the export information was invoked
 if(TARGET rapids_export_build_test_export_set)
-  message(FATAL_ERROR "rapids_find_package shoulnd't have constructed a export set")
+  message(FATAL_ERROR "rapids_find_package shouldn't have constructed a export set")
 endif()
 if(TARGET rapids_export_install_test_export_set)
-  message(FATAL_ERROR "rapids_find_package shoulnd't have constructed a export set")
+  message(FATAL_ERROR "rapids_find_package shouldn't have constructed a export set")
 endif()

--- a/testing/find/find_package-version-explicit-failed.cmake
+++ b/testing/find/find_package-version-explicit-failed.cmake
@@ -1,0 +1,23 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/package.cmake)
+
+rapids_find_package(ZLIB 99999999999 EXACT CONFIG
+  INSTALL_EXPORT_SET test_export_set GLOBAL_TARGETS ZLIB::ZLIB)
+
+if(ZLIB_FOUND)
+  message(FATAL_ERROR "rapids_find_package should have reported a failed find")
+endif()

--- a/testing/find/find_package-version-required-explicit-failed.cmake
+++ b/testing/find/find_package-version-required-explicit-failed.cmake
@@ -1,0 +1,19 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/package.cmake)
+
+rapids_find_package(ZLIB 99999999999 EXACT REQUIRED
+  INSTALL_EXPORT_SET test_export_set GLOBAL_TARGETS ZLIB::ZLIB)


### PR DESCRIPTION
Calling `rapids_find_package(<pkg> <version> EXACT REQUIRED)` should cause find_package to fail due to not finding the specified version, but it doesn't because the `REQUIRED` flag [is placed in front](https://github.com/rapidsai/rapids-cmake/blob/branch-22.08/rapids-cmake/find/package.cmake#L89) of the version in the `find_package()` call.