### PR TITLE
Timestamps for URL downloads match the download time

### DIFF
--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -70,9 +70,8 @@ function(rapids_cpm_get_proprietary_binary package_name version)
     include(FetchContent)
     set(pkg_name "${package_name}_proprietary_binary")
 
-    # Prefer to use the download time for timestamp, instead of the timestamp in the archive
-    # unless explicitly set by user. This allows for proper rebuilds when a projects
-    # url changes
+    # Prefer to use the download time for timestamp, instead of the timestamp in the archive unless
+    # explicitly set by user. This allows for proper rebuilds when a projects url changes
     if(POLICY CMP0135)
       cmake_policy(SET CMP0135 NEW)
       set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)

--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -69,6 +69,15 @@ function(rapids_cpm_get_proprietary_binary package_name version)
     # download and extract the binaries since they don't exist on the machine
     include(FetchContent)
     set(pkg_name "${package_name}_proprietary_binary")
+
+    # Prefer to use the download time for timestamp, instead of the timestamp in the archive
+    # unless explicitly set by user. This allows for proper rebuilds when a projects
+    # url changes
+    if(POLICY CMP0135)
+      cmake_policy(SET CMP0135 NEW)
+      set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+    endif()
+
     FetchContent_Declare(${pkg_name} URL ${proprietary_binary})
     FetchContent_MakeAvailable(${pkg_name})
 


### PR DESCRIPTION
By enabling CMake policy 135 we ensure that extracted files timestamp match that of the download time, instead of when the
archive is created. This makes sure that if the URL changes to an older version we still rebuild everything as the timestamp
stays newer.


https://cmake.org/cmake/help/latest/policy/CMP0135.html