### PR TITLE
Improve GPU detection by doing less subsequent executions

### DIFF
--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -29,7 +29,7 @@ function(rapids_cuda_detect_architectures possible_archs_var gpu_archs)
   set(error_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.stderr.log)
 
   if(NOT DEFINED CMAKE_CUDA_COMPILER)
-    message(FATAL_ERROR "No CUDA compiler specified, unable to determine machines GPUs.")
+    message(FATAL_ERROR "No CUDA compiler specified, unable to determine machine's GPUs.")
   endif()
 
   if(NOT EXISTS "${eval_exe}")

--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -68,10 +68,9 @@ int main(int argc, char** argv) {
                     ERROR_FILE "${error_file}")
   endif()
 
-  if (EXISTS "${eval_exe}")
-    execute_process(COMMAND "${eval_exe}"
-                    OUTPUT_VARIABLE __gpu_archs OUTPUT_STRIP_TRAILING_WHITESPACE
-                    ERROR_FILE "${error_file}")
+  if(EXISTS "${eval_exe}")
+    execute_process(COMMAND "${eval_exe}" OUTPUT_VARIABLE __gpu_archs
+                    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_FILE "${error_file}")
     message(STATUS "Auto detection of gpu-archs: ${__gpu_archs}")
   else()
     message(STATUS "Failed auto detection of gpu-archs. Falling back to using ${__gpu_archs}.")

--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -22,13 +22,19 @@ function(rapids_cuda_detect_architectures possible_archs_var gpu_archs)
 
   # Unset this first in case it's set to <empty_string> Which can happen inside rapids
   set(CMAKE_CUDA_ARCHITECTURES OFF)
-  set(possible_archs ${${possible_archs_var}})
+  set(__gpu_archs ${${possible_archs_var}})
 
   set(eval_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.cu)
   set(eval_exe ${PROJECT_BINARY_DIR}/eval_gpu_archs)
   set(error_file ${PROJECT_BINARY_DIR}/eval_gpu_archs.stderr.log)
-  file(WRITE ${eval_file}
-       "
+
+  if(NOT DEFINED CMAKE_CUDA_COMPILER)
+    message(FATAL_ERROR "No CUDA compiler specified, unable to determine machines GPUs.")
+  endif()
+
+  if(NOT EXISTS "${eval_exe}")
+    file(WRITE ${eval_file}
+         "
 #include <cstdio>
 #include <set>
 #include <string>
@@ -46,7 +52,7 @@ int main(int argc, char** argv) {
     }
   }
   if(archs.empty()) {
-    printf(\"${possible_archs}\");
+    printf(\"${__gpu_archs}\");
   } else {
     bool first = true;
     for(const auto& arch : archs) {
@@ -56,15 +62,19 @@ int main(int argc, char** argv) {
   }
   printf(\"\\n\");
   return 0;
-}
-")
+  }
+  ")
+    execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -std=c++11 -o "${eval_exe}" "${eval_file}"
+                    ERROR_FILE "${error_file}")
+  endif()
 
-  set(__gpu_archs "${possible_archs}")
-  if(DEFINED CMAKE_CUDA_COMPILER)
-    execute_process(COMMAND ${CMAKE_CUDA_COMPILER} -std=c++11 -o ${eval_exe} --run ${eval_file}
+  if (EXISTS "${eval_exe}")
+    execute_process(COMMAND "${eval_exe}"
                     OUTPUT_VARIABLE __gpu_archs OUTPUT_STRIP_TRAILING_WHITESPACE
-                    ERROR_FILE ${error_file})
+                    ERROR_FILE "${error_file}")
     message(STATUS "Auto detection of gpu-archs: ${__gpu_archs}")
+  else()
+    message(STATUS "Failed auto detection of gpu-archs. Falling back to using ${__gpu_archs}.")
   endif()
 
   set(${gpu_archs} ${__gpu_archs} PARENT_SCOPE)


### PR DESCRIPTION
We now only write out the source file, and compile the executable when the executable doesn't already exist.
