### PR TITLE
More robust solution of CMake policy 135

### DIFF
--- a/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary.cmake
@@ -70,13 +70,6 @@ function(rapids_cpm_get_proprietary_binary package_name version)
     include(FetchContent)
     set(pkg_name "${package_name}_proprietary_binary")
 
-    # Prefer to use the download time for timestamp, instead of the timestamp in the archive unless
-    # explicitly set by user. This allows for proper rebuilds when a projects url changes
-    if(POLICY CMP0135)
-      cmake_policy(SET CMP0135 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-    endif()
-
     FetchContent_Declare(${pkg_name} URL ${proprietary_binary})
     FetchContent_MakeAvailable(${pkg_name})
 

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -61,6 +61,13 @@ function(rapids_cpm_init)
     rapids_cpm_package_override("${_RAPIDS_OVERRIDE}")
   endif()
 
+  # Prefer to use the download time for timestamp, instead of the timestamp in the archive unless
+  # explicitly set by user. This allows for proper rebuilds when a projects url changes
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW CACHE STRING "")
+  endif()
+
   include("${rapids-cmake-dir}/cpm/detail/download.cmake")
   rapids_cpm_download()
 


### PR DESCRIPTION
By enabling CMake policy 135 we ensure that extracted files timestamp match that of the download time, instead of when the
archive is created. This makes sure that if the URL changes to an older version we still rebuild everything as the timestamp
stays newer.
