### PR TITLE
Update to thrust 1.17

### DIFF
--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -55,21 +55,38 @@ Result Variables
 function(rapids_cpm_thrust NAMESPACE namespaces_name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.thrust")
 
+  set(options)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(multi_value)
+  cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  set(enable_install OFF)
+  if(_RAPIDS_INSTALL_EXPORT_SET)
+    set(enable_install ON)
+    # Make sure we install thrust into the `include/rapids` subdirectory instead of the default
+    include(GNUInstallDirs)
+    set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/rapids")
+  endif()
+
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(Thrust version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(Thrust ${version} ${ARGN}
+  rapids_cpm_find(Thrust ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS ${namespaces_name}::Thrust
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "THRUST_ENABLE_INSTALL_RULES OFF")
+                  OPTIONS "THRUST_ENABLE_INSTALL_RULES ${enable_install}")
 
   if(NOT TARGET ${namespaces_name}::Thrust)
     thrust_create_target(${namespaces_name}::Thrust FROM_OPTIONS)
+    set_target_properties(${namespaces_name}::Thrust PROPERTIES IMPORTED_NO_SYSTEM ON)
+    if(TARGET _Thrust_Thrust)
+      set_target_properties(_Thrust_Thrust PROPERTIES IMPORTED_NO_SYSTEM ON)
+    endif()
   endif()
 
   # Since `GLOBAL_TARGET ${namespaces_name}::Thrust` will list the target to be promoted to global
@@ -78,11 +95,6 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
   #
   # So determine what `BUILD_EXPORT_SET` and `INSTALL_EXPORT_SET` this was added to and remove
   # ${namespaces_name}::Thrust
-  set(options CPM_ARGS)
-  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
-  set(multi_value)
-  cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
-
   if(_RAPIDS_BUILD_EXPORT_SET)
     set(target_name rapids_export_build_${_RAPIDS_BUILD_EXPORT_SET})
     get_target_property(global_targets ${target_name} GLOBAL_TARGETS)
@@ -95,70 +107,6 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     get_target_property(global_targets ${target_name} GLOBAL_TARGETS)
     list(REMOVE_ITEM global_targets "${namespaces_name}::Thrust")
     set_target_properties(${target_name} PROPERTIES GLOBAL_TARGETS "${global_targets}")
-  endif()
-
-  # only install thrust when we have an in-source version
-  if(Thrust_SOURCE_DIR AND _RAPIDS_INSTALL_EXPORT_SET AND NOT exclude)
-    #[==[
-    Projects such as cudf, and rmm require a newer versions of thrust than can be found in the oldest supported CUDA toolkit.
-    This requires these components to install/packaged so that consumers use the same version. To make sure that the custom
-    version of thrust is used over the CUDA toolkit version we need to ensure we always use an user include and not a system.
-
-    By default if we allow thrust to install into `CMAKE_INSTALL_INCLUDEDIR` alongside rmm (or other pacakges)
-    we will get a install tree that looks like this:
-
-      install/include/rmm
-      install/include/cub
-      install/include/thrust
-
-    This is a problem for CMake+NVCC due to the rules around import targets, and user/system includes. In this case both
-    rmm and thrust will specify an include path of `install/include`, while thrust tries to mark it as an user include,
-    since rmm uses CMake's default of system include. Compilers when provided the same include as both user and system
-    always goes with system.
-
-    Now while rmm could also mark `install/include` as system this just pushes the issue to another dependency which
-    isn't built by RAPIDS and comes by and marks `install/include` as system.
-
-    Instead the more reliable option is to make sure that we get thrust to be placed in an unique include path that
-    to other project will use. In the case of rapids-cmake we install the headers to `include/rapids/thrust`
-    #]==]
-    include(GNUInstallDirs)
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/" FILES_MATCHING
-            REGEX "\\.(h|inl)$")
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies/" FILES_MATCHING
-            PATTERN "*.cuh")
-
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/thrust/")
-    install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake"
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapids/thrust/dependencies/cub/")
-
-    include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
-    rapids_cmake_install_lib_dir(install_location) # Use the correct conda aware path
-
-    # We need to install the forwarders in `lib/cmake/thrust` and `lib/cmake/cub`
-    set(scratch_dir
-        "${CMAKE_BINARY_DIR}/rapids-cmake/${_RAPIDS_INSTALL_EXPORT_SET}/install/scratch/")
-
-    file(WRITE "${scratch_dir}/thrust-config.cmake"
-         [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/thrust/cmake/thrust-config.cmake")]=]
-    )
-    file(WRITE "${scratch_dir}/thrust-config-version.cmake"
-         [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/thrust/cmake/thrust-config-version.cmake")]=]
-    )
-    install(FILES "${scratch_dir}/thrust-config.cmake" "${scratch_dir}/thrust-config-version.cmake"
-            DESTINATION "${install_location}/cmake/thrust")
-
-    file(WRITE "${scratch_dir}/cub-config.cmake"
-         [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/dependencies/cub/cub-config.cmake")]=]
-    )
-    file(WRITE "${scratch_dir}/cub-config-version.cmake"
-         [=[include("${CMAKE_CURRENT_LIST_DIR}/../../../include/rapids/thrust/dependencies/cub/cub-config-version.cmake")]=]
-    )
-    install(FILES "${scratch_dir}/cub-config.cmake" "${scratch_dir}/cub-config-version.cmake"
-            DESTINATION "${install_location}/cmake/cub")
   endif()
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,9 +31,9 @@
       "git_tag" : "v${version}"
     },
     "Thrust" : {
-      "version" : "1.15.0.0",
+      "version" : "1.17.0",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "1.15.0"
+      "git_tag" : "${version}"
     },
     "libcudacxx" : {
       "version" : "1.7.0",


### PR DESCRIPTION
This pulls out the Thrust bump from https://github.com/rapidsai/rapids-cmake/pull/227 so that we can roll out changes slowly and have an easier time to track down issues.

Once this is in and RAPIDS is happy, we can go ahead and merge https://github.com/rapidsai/rapids-cmake/pull/199 which has breaking changes.