### PR TITLE
Update to CPM v0.35.4 for URL downloads match the download time

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,7 +42,7 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.35.3)
+  set(CPM_DOWNLOAD_VERSION 0.35.4)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)


### PR DESCRIPTION
With https://github.com/cpm-cmake/CPM.cmake/pull/372 merged into CPM we should update our CPM version so that RAPIDS developers don't see CMake policy warnings with CMake 3.24+