### PR TITLE
Docs: RAPIDS.cmake should be placed in current bin dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Content](https://cmake.org/cmake/help/latest/module/FetchContent.html) into your
 cmake_minimum_required(...)
 
 file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
-    ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)
@@ -119,8 +119,8 @@ like this:
     GIT_TAG        <my_feature_branch>
   )
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-21.12/RAPIDS.cmake
-      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+      ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 ```
 
 This tells ``FetchContent`` to ignore the explicit url and branch in ``RAPIDS.cmake`` and use the

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Content](https://cmake.org/cmake/help/latest/module/FetchContent.html) into your
 
 cmake_minimum_required(...)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/<PROJECT>_RAPIDS.cmake)
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/<PROJECT>_RAPIDS.cmake)
+endif()
+include(${CMAKE_CURRENT_BINARY_DIR}/<PROJECT>_RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -12,9 +12,11 @@ Content <https://cmake.org/cmake/help/latest/module/FetchContent.html>`_ into yo
 
   cmake_minimum_required(...)
 
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
+  endif()
+  include(${CMAKE_CURRENT_BINARY_DIR}/<PROJ>_RAPIDS.cmake)
   include(rapids-cmake)
   include(rapids-cpm)
   include(rapids-cuda)

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -13,8 +13,8 @@ Content <https://cmake.org/cmake/help/latest/module/FetchContent.html>`_ into yo
   cmake_minimum_required(...)
 
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-    ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
   include(rapids-cmake)
   include(rapids-cpm)
   include(rapids-cuda)
@@ -55,8 +55,8 @@ like this:
     GIT_TAG        <my_feature_branch>
   )
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+      ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 
 
 This tells ``FetchContent`` to ignore the explicit url and branch in ``RAPIDS.cmake`` and use the

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,9 +16,9 @@
 
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.04/RAPIDS.cmake
-    ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,9 +16,11 @@
 
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
-include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+       ${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
+endif()
+include(${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
 
 include(rapids-cmake)
 include(rapids-cpm)

--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -55,9 +55,11 @@ Example on how to properly use :cmake:command:`rapids_cuda_init_architectures`:
 
   cmake_minimum_required(...)
 
-  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
+  endif()
+  include(${CMAKE_CURRENT_BINARY_DIR}/EXAMPLE_RAPIDS.cmake)
   include(rapids-cuda)
 
   rapids_cuda_init_architectures(ExampleProject)

--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -56,8 +56,8 @@ Example on how to properly use :cmake:command:`rapids_cuda_init_architectures`:
   cmake_minimum_required(...)
 
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-<VERSION_MAJOR>.<VERSION_MINOR>/RAPIDS.cmake
-    ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
-  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
   include(rapids-cuda)
 
   rapids_cuda_init_architectures(ExampleProject)


### PR DESCRIPTION
Instead of placing in the root level binary directory place it in the current binary dir to avoid clobbering an existing RAPIDS.cmake

Fixes #240
