### PR TITLE
Revert "Update to CPM v0.35.4 for URL downloads... (#236)"

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,7 +42,7 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.35.4)
+  set(CPM_DOWNLOAD_VERSION 0.35.3)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)


### PR DESCRIPTION
We are seeing CI failures with dependencies of dependencies and I believe that this is causing the issue.

This reverts commit e72fd084e5db9437df3450bdfcdbb4e83597fa4e.
