### PR TITLE
Ensure that we install Thrust and Cub correctly.

### DIFF
--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -77,8 +77,8 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     include(GNUInstallDirs)
     set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/rapids")
 
-    # Thrust 1.17 has a bug where it doesn't properly install CUB,
-    # so we need to manually invoke cub's install rules
+    # Thrust 1.17 has a bug where it doesn't properly install CUB, so we need to manually invoke
+    # cub's install rules
     set(THRUST_INSTALL_CUB_HEADERS OFF)
     set(CUB_SOURCE_DIR "${Thrust_SOURCE_DIR}/dependencies/cub")
     set(CUB_BINARY_DIR "${Thrust_BINARY_DIR}")


### PR DESCRIPTION
Since thrust ships a `thrust-config.cmake` in the source tree, a re-configure of cmake can disable the built-in thrust install
rules.

In addition thrust 1.17 has a bug in how it install cub so instead rapids-cmake needs to manage installing but packages.
