### PR TITLE
Patch thrust and cub install rules to have proper header searches

### DIFF
--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -77,12 +77,15 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
     include(GNUInstallDirs)
     set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/rapids")
 
-    # Thrust 1.17 has a bug where it doesn't generate proper exclude rules for the `[cub|thrust]-header-search`
-    # files, which causes the build tree version to be installed instead of the install version
+    # Thrust 1.17 has a bug where it doesn't generate proper exclude rules for the
+    # `[cub|thrust]-header-search` files, which causes the build tree version to be installed
+    # instead of the install version
     if(NOT EXISTS "${Thrust_BINARY_DIR}/cmake/ThrustInstallRulesForRapids.cmake")
       file(READ "${Thrust_SOURCE_DIR}/cmake/ThrustInstallRules.cmake" contents)
-      string(REPLACE "PATTERN cub-header-search EXCLUDE" "REGEX cub-header-search.* EXCLUDE" contents "${contents}")
-      string(REPLACE "PATTERN thrust-header-search EXCLUDE" "REGEX thrust-header-search.* EXCLUDE" contents "${contents}")
+      string(REPLACE "PATTERN cub-header-search EXCLUDE" "REGEX cub-header-search.* EXCLUDE"
+                     contents "${contents}")
+      string(REPLACE "PATTERN thrust-header-search EXCLUDE" "REGEX thrust-header-search.* EXCLUDE"
+                     contents "${contents}")
       file(WRITE "${Thrust_BINARY_DIR}/cmake/ThrustInstallRulesForRapids.cmake" ${contents})
     endif()
     include("${Thrust_BINARY_DIR}/cmake/ThrustInstallRulesForRapids.cmake")


### PR DESCRIPTION
Thrust 1.17 has a bug where it doesn't generate proper exclude rules for the `[cub|thrust]-header-search` files, which causes the build tree version to be installed instead of the install version
