### PR TITLE
disable cuco install rules when no INSTALL_EXPORT_SET

### DIFF
--- a/rapids-cmake/cpm/cuco.cmake
+++ b/rapids-cmake/cpm/cuco.cmake
@@ -57,15 +57,17 @@ function(rapids_cpm_cuco)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   # Fix up _RAPIDS_UNPARSED_ARGUMENTS to have INSTALL_EXPORT_SET as this is need for rapids_cpm_find
+  set(to_install OFF)
   if(_RAPIDS_INSTALL_EXPORT_SET)
     list(APPEND _RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
+    set(to_install ON)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(cuco version repository tag shallow exclude)
 
   set(to_exclude OFF)
-  if(NOT _RAPIDS_INSTALL_EXPORT_SET OR exclude)
+  if(NOT to_install OR exclude)
     set(to_exclude ON)
   endif()
 
@@ -77,7 +79,8 @@ function(rapids_cpm_cuco)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   EXCLUDE_FROM_ALL ${to_exclude}
-                  OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF")
+                  OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
+                          "INSTALL_CUCO ${to_install}")
 
   # Propagate up variables that CPMFindPackage provide
   set(cuco_SOURCE_DIR "${cuco_SOURCE_DIR}" PARENT_SCOPE)

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -44,7 +44,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "3a49fc7143366e33334ce25846fb9854fbdc99f3"
+      "git_tag" : "3ff2032ef1c9de1d1dfc7ed3779d8cec07346191"
     }
   }
 }

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -62,3 +62,4 @@ add_cmake_config_test( cpm_thrust-simple.cmake )
 
 add_cmake_config_test( cpm_cuco-simple.cmake )
 add_cmake_config_test( cpm_cuco-export.cmake )
+add_cmake_config_test( cpm_cuco-libcudacxx-no-install-export.cmake )

--- a/testing/cpm/cpm_cuco-libcudacxx-no-install-export.cmake
+++ b/testing/cpm/cpm_cuco-libcudacxx-no-install-export.cmake
@@ -1,0 +1,33 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/cuco.cmake)
+include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
+
+rapids_cpm_init()
+
+rapids_cpm_libcudacxx(BUILD_EXPORT_SET test_export_set)
+# Verify that cuco doesn't fail to generate when
+# it encounters a libcudacxx that has has no INSTALL rules
+rapids_cpm_cuco(BUILD_EXPORT_SET test_export_set)
+
+get_target_property(packages rapids_export_build_test_export_set PACKAGE_NAMES)
+if(NOT libcudacxx IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_cuco failed to record cuco needs to be exported")
+endif()
+if(NOT cuco IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_cuco failed to record cuco needs to be exported")
+endif()

--- a/testing/utils/fill_cache/CMakeLists.txt
+++ b/testing/utils/fill_cache/CMakeLists.txt
@@ -19,6 +19,7 @@ project(fill_cache LANGUAGES CXX)
 
 include(${rapids-cmake-dir}/cpm/init.cmake)
 
+include(${rapids-cmake-dir}/cpm/cuco.cmake)
 include(${rapids-cmake-dir}/cpm/gtest.cmake)
 include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
 include(${rapids-cmake-dir}/cpm/nvbench.cmake)
@@ -33,6 +34,7 @@ set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
 
 # Download all source packages
 set(CPM_DOWNLOAD_ALL "ON")
+rapids_cpm_cuco(DOWNLOAD_ONLY ON)
 rapids_cpm_gtest(DOWNLOAD_ONLY ON)
 rapids_cpm_libcudacxx(DOWNLOAD_ONLY ON)
 rapids_cpm_nvbench(DOWNLOAD_ONLY ON)


### PR DESCRIPTION
Fixes issues encountered by projects such as cugraph when they use cuco privately