### PR TITLE
Handle reconfiguring with USE_PROPRIETARY_BINARY value differing

### DIFF
--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -104,12 +104,13 @@ function(rapids_cpm_nvcomp)
       endif()
     endif()
 
-    # Record the nvcomp_DIR so that if USE_PROPRIETARY_BINARY is disabled
-    # we can safely clear the nvcomp_DIR value
+    # Record the nvcomp_DIR so that if USE_PROPRIETARY_BINARY is disabled we can safely clear the
+    # nvcomp_DIR value
     if(nvcomp_proprietary_binary)
       set(nvcomp_proprietary_binary_dir "${nvcomp_ROOT}/lib/cmake/nvcomp")
       cmake_path(NORMAL_PATH nvcomp_proprietary_binary_dir)
-      set(rapids_cpm_nvcomp_proprietary_binary_dir "${nvcomp_proprietary_binary_dir}" CACHE INTERNAL "nvcomp proprietary location")
+      set(rapids_cpm_nvcomp_proprietary_binary_dir "${nvcomp_proprietary_binary_dir}"
+          CACHE INTERNAL "nvcomp proprietary location")
     endif()
   elseif(DEFINED nvcomp_DIR)
     cmake_path(NORMAL_PATH nvcomp_DIR)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -103,6 +103,20 @@ function(rapids_cpm_nvcomp)
         file(WRITE "${target_file}" "${file_contents}")
       endif()
     endif()
+
+    # Record the nvcomp_DIR so that if USE_PROPRIETARY_BINARY is disabled
+    # we can safely clear the nvcomp_DIR value
+    if(nvcomp_proprietary_binary)
+      set(nvcomp_proprietary_binary_dir "${nvcomp_ROOT}/lib/cmake/nvcomp")
+      cmake_path(NORMAL_PATH nvcomp_proprietary_binary_dir)
+      set(rapids_cpm_nvcomp_proprietary_binary_dir "${nvcomp_proprietary_binary_dir}" CACHE INTERNAL "nvcomp proprietary location")
+    endif()
+  elseif(DEFINED nvcomp_DIR)
+    cmake_path(NORMAL_PATH nvcomp_DIR)
+    if(nvcomp_DIR STREQUAL rapids_cpm_nvcomp_proprietary_binary_dir)
+      unset(nvcomp_DIR)
+      unset(nvcomp_DIR CACHE)
+    endif()
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")


### PR DESCRIPTION
Previously once `USE_PROPRIETARY_BINARY` was enabled you would need to fully delete your build directory for a non proprietary version to be used

Fixes #246