### PR TITLE
Update rapids_find_generate_module to cmake 3.23

### DIFF
--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -16,7 +16,7 @@
 include_guard(GLOBAL)
 
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.20)
+cmake_policy(VERSION 3.23)
 
 #[=======================================================================[.rst:
 rapids_find_generate_module


### PR DESCRIPTION
Missed as part of https://github.com/rapidsai/rapids-cmake/pull/227 was an update to the policy version set in `rapids_find_generate_module`