### PR TITLE
Set `CUDA_USE_STATIC_CUDA_RUNTIME` to control legacy `FindCUDA.cmake`behavior

### DIFF
--- a/rapids-cmake/cuda/init_runtime.cmake
+++ b/rapids-cmake/cuda/init_runtime.cmake
@@ -45,11 +45,11 @@ function(rapids_cuda_init_runtime use_static value)
     if(${value})
       # Control legacy FindCUDA.cmake behavior too
       set(CUDA_USE_STATIC_CUDA_RUNTIME ON PARENT_SCOPE)
-      set(CMAKE_CUDA_RUNTIME_LIBRARY "Static" PARENT_SCOPE)
+      set(CMAKE_CUDA_RUNTIME_LIBRARY STATIC PARENT_SCOPE)
     else()
       # Control legacy FindCUDA.cmake behavior too
       set(CUDA_USE_STATIC_CUDA_RUNTIME OFF PARENT_SCOPE)
-      set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared" PARENT_SCOPE)
+      set(CMAKE_CUDA_RUNTIME_LIBRARY STATIC PARENT_SCOPE)
     endif()
   endif()
 endfunction()

--- a/rapids-cmake/cuda/init_runtime.cmake
+++ b/rapids-cmake/cuda/init_runtime.cmake
@@ -43,8 +43,12 @@ function(rapids_cuda_init_runtime use_static value)
 
   if(NOT DEFINED CMAKE_CUDA_RUNTIME_LIBRARY)
     if(${value})
+      # Control legacy FindCUDA.cmake behavior too
+      set(CUDA_USE_STATIC_CUDA_RUNTIME ON PARENT_SCOPE)
       set(CMAKE_CUDA_RUNTIME_LIBRARY "Static" PARENT_SCOPE)
     else()
+      # Control legacy FindCUDA.cmake behavior too
+      set(CUDA_USE_STATIC_CUDA_RUNTIME OFF PARENT_SCOPE)
       set(CMAKE_CUDA_RUNTIME_LIBRARY "Shared" PARENT_SCOPE)
     endif()
   endif()

--- a/rapids-cmake/cuda/init_runtime.cmake
+++ b/rapids-cmake/cuda/init_runtime.cmake
@@ -28,12 +28,14 @@ Establish what CUDA runtime library should be propagated
     rapids_cuda_init_runtime( USE_STATIC (TRUE|FALSE) )
 
   Establishes what CUDA runtime will be used, if not already explicitly
-  specified via :cmake:variable:`CMAKE_CUDA_RUNTIME_LIBRARY` variable.
+  specified, via the :cmake:variable:`CMAKE_CUDA_RUNTIME_LIBRARY` variable.
+  We also set :cmake:variable:`CUDA_USE_STATIC_CUDA_RUNTIME` to control
+  targets using the legacy `FindCUDA.cmake`
 
-  When `USE_STATIC TRUE` is provided all target will link to a
+  When `USE_STATIC TRUE` is provided all targets will link to a
     statically-linked CUDA runtime library.
 
-  When `USE_STATIC FALSE` is provided all target will link to a
+  When `USE_STATIC FALSE` is provided all targets will link to a
     shared-linked CUDA runtime library.
 
 
@@ -43,13 +45,19 @@ function(rapids_cuda_init_runtime use_static value)
 
   if(NOT DEFINED CMAKE_CUDA_RUNTIME_LIBRARY)
     if(${value})
-      # Control legacy FindCUDA.cmake behavior too
-      set(CUDA_USE_STATIC_CUDA_RUNTIME ON PARENT_SCOPE)
       set(CMAKE_CUDA_RUNTIME_LIBRARY STATIC PARENT_SCOPE)
     else()
-      # Control legacy FindCUDA.cmake behavior too
-      set(CUDA_USE_STATIC_CUDA_RUNTIME OFF PARENT_SCOPE)
-      set(CMAKE_CUDA_RUNTIME_LIBRARY STATIC PARENT_SCOPE)
+      set(CMAKE_CUDA_RUNTIME_LIBRARY SHARED PARENT_SCOPE)
     endif()
   endif()
+
+  # Control legacy FindCUDA.cmake behavior too
+  if(NOT DEFINED CUDA_USE_STATIC_CUDA_RUNTIME)
+    if(${value})
+      set(CUDA_USE_STATIC_CUDA_RUNTIME ON PARENT_SCOPE)
+    else()
+      set(CUDA_USE_STATIC_CUDA_RUNTIME OFF PARENT_SCOPE)
+    endif()
+  endif()
+
 endfunction()

--- a/testing/cuda/init_runtime-multiple.cmake
+++ b/testing/cuda/init_runtime-multiple.cmake
@@ -16,13 +16,11 @@
 include(${rapids-cmake-dir}/cuda/init_runtime.cmake)
 
 rapids_cuda_init_runtime(USE_STATIC FALSE)
-if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "SHARED")
   message(FATAL_ERROR "rapids_cuda_init_runtime didn't correctly set CMAKE_CUDA_RUNTIME_LIBRARY")
 endif()
 
 rapids_cuda_init_runtime(USE_STATIC TRUE)
-if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "SHARED")
   message(FATAL_ERROR "apids_cuda_init_runtime shouldn't override an existing value")
 endif()
-
-

--- a/testing/cuda/init_runtime-shared.cmake
+++ b/testing/cuda/init_runtime-shared.cmake
@@ -16,6 +16,6 @@
 include(${rapids-cmake-dir}/cuda/init_runtime.cmake)
 
 rapids_cuda_init_runtime(USE_STATIC FALSE)
-if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "SHARED")
   message(FATAL_ERROR "rapids_cuda_init_runtime didn't correctly set CMAKE_CUDA_RUNTIME_LIBRARY")
 endif()

--- a/testing/cuda/init_runtime-static.cmake
+++ b/testing/cuda/init_runtime-static.cmake
@@ -16,6 +16,6 @@
 include(${rapids-cmake-dir}/cuda/init_runtime.cmake)
 
 rapids_cuda_init_runtime(USE_STATIC TRUE)
-if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
+if( NOT CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "STATIC")
   message(FATAL_ERROR "rapids_cuda_init_runtime didn't correctly set CMAKE_CUDA_RUNTIME_LIBRARY")
 endif()


### PR DESCRIPTION
Set `CUDA_USE_STATIC_CUDA_RUNTIME` in `rapids_cuda_init_runtime` to control legacy [`FindCUDA.cmake`](https://cmake.org/cmake/help/latest/module/FindCUDA.html) behavior too.
