### PR TITLE
Introduce rapids_cuda_patch_toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The most commonly used function are:
 
 - `rapids_cuda_init_architectures(<project_name>)` handles initialization of `CMAKE_CUDA_ARCHITECTURE`. MUST BE CALLED BEFORE `PROJECT()`
 - `rapids_cuda_init_runtime(<mode>)` handles initialization of `CMAKE_CUDA_RUNTIME_LIBRARY`.
+- `rapids_cuda_patch_toolkit()` corrects bugs in the CUDAToolkit module that are being upstreamed.
 
 ### cython
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -94,8 +94,8 @@ require.
 
     rapids_cuda_init_architectures </command/rapids_cuda_init_architectures>
     rapids_cuda_init_runtime </command/rapids_cuda_init_runtime>
-    rapids_cuda_set_architectures [Advanced] </command/rapids_cuda_set_architectures>
     rapids_cuda_patch_toolkit </command/rapids_cuda_patch_toolkit>
+    rapids_cuda_set_architectures [Advanced] </command/rapids_cuda_set_architectures>
 
 
 Export Set Generation

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -95,6 +95,7 @@ require.
     rapids_cuda_init_architectures </command/rapids_cuda_init_architectures>
     rapids_cuda_init_runtime </command/rapids_cuda_init_runtime>
     rapids_cuda_set_architectures [Advanced] </command/rapids_cuda_set_architectures>
+    rapids_cuda_patch_toolkit </command/rapids_cuda_patch_toolkit>
 
 
 Export Set Generation

--- a/docs/command/rapids_cuda_patch_toolkit.rst
+++ b/docs/command/rapids_cuda_patch_toolkit.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cuda/patch_toolkit.cmake

--- a/rapids-cmake/cuda/patch_toolkit.cmake
+++ b/rapids-cmake/cuda/patch_toolkit.cmake
@@ -1,0 +1,52 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+
+---------------------------------
+
+.. versionadded:: v22.10.00
+
+Corrects missing dependencies in the CUDA toolkit
+
+  .. code-block:: cmake
+
+    rapids_cuda_patch_toolkit( )
+
+For CMake versions 3.23.1-3, and 3.24.1 the dependencies
+of cublas and cusolver targets are incorrect. This module must be called
+from the same CMakeLists.txt as the first `find_project(CUDAToolkit)` to
+patch the targets.
+
+.. note::
+  :cmake:command:`rapids_cpm_find` will automatically call this module
+  when asked to find the CUDAToolkit.
+
+#]=======================================================================]
+function(rapids_cuda_patch_toolkit)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cuda.patch_toolkit")
+
+  get_directory_property(itargets IMPORTED_TARGETS)
+  if(CUDA::cublas_static IN_LIST itargets)
+    target_link_libraries(CUDA::cublas INTERFACE CUDA::cublasLt)
+    target_link_libraries(CUDA::cusparse INTERFACE CUDA::cublas)
+
+    target_link_libraries(CUDA::cublas_static INTERFACE CUDA::cublasLt_static)
+    target_link_libraries(CUDA::cusolver_static INTERFACE CUDA::cusolver_lapack_static)
+    target_link_libraries(CUDA::cusparse_static INTERFACE CUDA::cublas_static)
+  endif()
+endfunction()

--- a/rapids-cmake/find/package.cmake
+++ b/rapids-cmake/find/package.cmake
@@ -122,6 +122,11 @@ macro(rapids_find_package name)
   # OPTIONAL find packages
   if(${${name}_FOUND})
 
+    if(${name} STREQUAL "CUDAToolkit")
+      include("${rapids-cmake-dir}/cuda/patch_toolkit.cmake")
+      rapids_cuda_patch_toolkit()
+    endif()
+
     set(_rapids_extra_info)
     if(_RAPIDS_GLOBAL_TARGETS)
       list(APPEND _rapids_extra_info "GLOBAL_TARGETS" ${_RAPIDS_GLOBAL_TARGETS})

--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -27,8 +27,10 @@ add_cmake_config_test( init_arch-native.cmake )
 add_cmake_config_test( init_arch-native-via-empty-str )
 add_cmake_config_test( init_arch-user.cmake )
 
+add_cmake_config_test( patch_toolkit.cmake )
+add_cmake_config_test( patch_toolkit-nested )
+
 add_cmake_config_test( set_arch-all.cmake )
 add_cmake_config_test( set_arch-existing.cmake )
 add_cmake_config_test( set_arch-invalid-mode.cmake )
 add_cmake_config_test( set_arch-native.cmake )
-

--- a/testing/cuda/patch_toolkit-nested/CMakeLists.txt
+++ b/testing/cuda/patch_toolkit-nested/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-project LANGUAGES CUDA)
+
+include(${rapids-cmake-dir}/cuda/patch_toolkit.cmake)
+
+function(verify_links_to target library)
+  get_target_property(link_libs ${target} INTERFACE_LINK_LIBRARIES)
+  if(NOT ${library} IN_LIST link_libs)
+    message(FATAL_ERROR "${target} doesn't link to ${library}")
+  endif()
+endfunction()
+
+find_package(CUDAToolkit)
+rapids_cuda_patch_toolkit()
+
+add_subdirectory(subdir)
+
+if(TARGET CUDA::cublas_static)
+  verify_links_to(CUDA::cublas CUDA::cublasLt)
+  verify_links_to(CUDA::cusparse CUDA::cublas)
+  verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
+  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
+  verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
+endif()

--- a/testing/cuda/patch_toolkit-nested/subdir/CMakeLists.txt
+++ b/testing/cuda/patch_toolkit-nested/subdir/CMakeLists.txt
@@ -1,0 +1,28 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/patch_toolkit.cmake)
+
+rapids_cuda_patch_toolkit()
+find_package(CUDAToolkit)
+rapids_cuda_patch_toolkit()
+
+if(TARGET CUDA::cublas_static)
+  verify_links_to(CUDA::cublas CUDA::cublasLt)
+  verify_links_to(CUDA::cusparse CUDA::cublas)
+  verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
+  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
+  verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
+endif()

--- a/testing/cuda/patch_toolkit.cmake
+++ b/testing/cuda/patch_toolkit.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/patch_toolkit.cmake)
+
+function(verify_links_to target library)
+  get_target_property(link_libs ${target} INTERFACE_LINK_LIBRARIES)
+  if(NOT ${library} IN_LIST link_libs)
+    message(FATAL_ERROR "${target} doesn't link to ${library}")
+  endif()
+endfunction()
+
+# Verify we can call before find_package
+rapids_cuda_patch_toolkit()
+
+find_package(CUDAToolkit)
+rapids_cuda_patch_toolkit()
+
+if(TARGET CUDA::cublas_static)
+  verify_links_to(CUDA::cublas CUDA::cublasLt)
+  verify_links_to(CUDA::cusparse CUDA::cublas)
+  verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
+  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
+  verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
+endif()

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -20,6 +20,8 @@ add_cmake_config_test( find_package-no-variable-leak.cmake )
 add_cmake_config_test( find_package-build.cmake )
 add_cmake_config_test( find_package-install.cmake )
 
+add_cmake_config_test( find_package-cudatoolkit-patching.cmake )
+
 # The inverse of `find_package-optional-failed` is the
 # above two tests.
 # The inverse of `find_package-required-found` is always

--- a/testing/find/find_package-cudatoolkit-patching.cmake
+++ b/testing/find/find_package-cudatoolkit-patching.cmake
@@ -1,0 +1,33 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/package.cmake)
+
+function(verify_links_to target library)
+  get_target_property(link_libs ${target} INTERFACE_LINK_LIBRARIES)
+  if(NOT ${library} IN_LIST link_libs)
+    message(FATAL_ERROR "${target} doesn't link to ${library}")
+  endif()
+endfunction()
+
+rapids_find_package(CUDAToolkit)
+
+if(TARGET CUDA::cublas_static)
+  verify_links_to(CUDA::cublas CUDA::cublasLt)
+  verify_links_to(CUDA::cusparse CUDA::cublas)
+  verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
+  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
+  verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
+endif()


### PR DESCRIPTION
Allows rapids-cmake patch CUDAToolkit to fix missing cublas and cusolver dependencies.

https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7633

