### PR TITLE
Switch thrust over to use rapids-cmake patches

### DIFF
--- a/rapids-cmake/cpm/patches/Thrust/install_rules.diff
+++ b/rapids-cmake/cpm/patches/Thrust/install_rules.diff
@@ -1,0 +1,22 @@
+diff --git a/cmake/ThrustInstallRules.cmake b/cmake/ThrustInstallRules.cmake
+index 93084c1..bf6c195 100644
+--- a/cmake/ThrustInstallRules.cmake
++++ b/cmake/ThrustInstallRules.cmake
+@@ -13,7 +13,7 @@ install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust"
+ 
+ install(DIRECTORY "${Thrust_SOURCE_DIR}/thrust/cmake/"
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/thrust"
+-  PATTERN thrust-header-search EXCLUDE
++  REGEX thrust-header-search.* EXCLUDE
+ )
+ # Need to configure a file to store the infix specified in
+ # CMAKE_INSTALL_INCLUDEDIR since it can be defined by the user
+@@ -39,7 +39,7 @@ if (THRUST_INSTALL_CUB_HEADERS)
+   # Need to configure a file to store THRUST_INSTALL_HEADER_INFIX
+   install(DIRECTORY "${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake/"
+     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cub"
+-    PATTERN cub-header-search EXCLUDE
++    REGEX cub-header-search.* EXCLUDE
+   )
+   set(install_location "${CMAKE_INSTALL_LIBDIR}/cmake/cub")
+   configure_file("${Thrust_SOURCE_DIR}/dependencies/cub/cub/cmake/cub-header-search.cmake.in"

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -33,7 +33,14 @@
     "Thrust" : {
       "version" : "1.17.2",
       "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "${version}"
+      "git_tag" : "${version}",
+      "patches" : [
+        {
+          "file" : "Thrust/install_rules.diff",
+          "issue" : "Thrust 1.X installs incorrect files [https://github.com/NVIDIA/thrust/issues/1790]",
+          "fixed_in" : "2.0"
+        }
+      ]
     },
     "libcudacxx" : {
       "version" : "1.8.0",


### PR DESCRIPTION
Leverages the infrastructure of https://github.com/rapidsai/rapids-cmake/pull/264 to switch rapids_cpm_thrust over to using the built-in patch support.