### PR TITLE
rapids_cuda_init_architectures now obeys CUDAARCHS env variable

### DIFF
--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -21,15 +21,15 @@ rapids_cuda_init_architectures
 
 .. versionadded:: v21.06.00
 
-Extends :cmake:variable:`CMAKE_CUDA_ARCHITECTURES` to include support
-for `ALL` and `NATIVE` to make CUDA architecture compilation easier.
+Extends :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`
+to include support for `ALL` and `NATIVE` to make CUDA architecture compilation easier.
 
   .. code-block:: cmake
 
     rapids_cuda_init_architectures(<project_name>)
 
 Establishes what CUDA architectures that will be compiled for.
-Parses the :cmake:variable:`CMAKE_CUDA_ARCHITECTURES` for special
+Parses the :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>` for special
 values `ALL`, `NATIVE` and `""`.
 
 .. note::
@@ -37,16 +37,19 @@ values `ALL`, `NATIVE` and `""`.
 
   Will automatically call :cmake:command:`rapids_cuda_set_architectures` immediately
   after :cmake:command:`project() <cmake:command:project>` establishing the correct values for
-  :cmake:variable:`CMAKE_CUDA_ARCHITECTURES`.
+  :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`.
 
 ``project_name``
   Name of the project
 
 ``NATIVE`` or ``""``:
-  When passed will compile for all GPU architectures present on the current machine
+  When passed as the value for :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`
+  will compile for all GPU architectures present on the current machine.
 
-``ALL``:
-  When passed will compile for all supported RAPIDS GPU architectures
+``ALL`` or no :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>` and
+  :cmake:envvar:`ENV{CUDAARCHS} <cmake:envvar:CUDAARCHS>`:
+  When passed as the value for :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`
+  will compile for all supported RAPIDS GPU architectures.
 
 
 Example on how to properly use :cmake:command:`rapids_cuda_init_architectures`:
@@ -78,7 +81,12 @@ function(rapids_cuda_init_architectures project_name)
 
   # This needs to be run before enabling the CUDA language since RAPIDS supports the magic string of
   # "ALL"
-  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES OR CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
+  set(no_user_cuda_archs TRUE)
+  if(DEFINED ENV{CUDAARCHS} OR DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(no_user_cuda_archs FALSE)
+  endif()
+
+  if(no_user_cuda_archs OR CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
     set(CMAKE_CUDA_ARCHITECTURES OFF PARENT_SCOPE)
     set(load_file "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/detail/invoke_set_all_architectures.cmake")
   elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")

--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -26,6 +26,7 @@ add_cmake_config_test( init_arch-existing-project-flags.cmake )
 add_cmake_config_test( init_arch-native.cmake )
 add_cmake_config_test( init_arch-native-via-empty-str )
 add_cmake_config_test( init_arch-user.cmake )
+add_cmake_config_test( init_arch-user-via-env.cmake )
 
 add_cmake_config_test( patch_toolkit.cmake )
 add_cmake_config_test( patch_toolkit-nested )

--- a/testing/cuda/init_arch-user-via-env.cmake
+++ b/testing/cuda/init_arch-user-via-env.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cuda/init_arch-user-via-env.cmake
+++ b/testing/cuda/init_arch-user-via-env.cmake
@@ -1,0 +1,29 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/init_architectures.cmake)
+
+set(ENV{CUDAARCHS} "80")
+rapids_cuda_init_architectures(rapids-project)
+project(rapids-project LANGUAGES CUDA)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  message(FATAL_ERROR "CMAKE_CUDA_ARCHITECTURES should exist after calling rapids_cuda_init_architectures()")
+endif()
+
+if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "80")
+  message(FATAL_ERROR "rapids_cuda_init_architectures didn't ignore users CUDA_ARCHITECTURES value")
+endif()
+


### PR DESCRIPTION
If the CUDAARCHS env variable is set use those values instead of treating it as a request to compile for all RAPIDS cuda archs.

Fixes #268
