### PR TITLE
Update to CPM 0.35.6 as it has needed changes for cpm patching support.

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,7 +42,7 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.35.5)
+  set(CPM_DOWNLOAD_VERSION 0.35.6)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)


### PR DESCRIPTION
The relevant changes in CPM for rapids-cmake are:
* cpm_find_package Use found package version when possible
* Don't warn about dirty source trees when a PATCH_COMMAND is provided

