### PR TITLE
Restore rapids_cython_create_modules output variable name

### DIFF
--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -59,7 +59,7 @@ $ORIGIN.
 
 Result Variables
 ^^^^^^^^^^^^^^^^
-  :cmake:variable:`_RAPIDS_CYTHON_CREATED_TARGETS` will be set to a list of
+  :cmake:variable:`RAPIDS_CYTHON_CREATED_TARGETS` will be set to a list of
   targets created by this function.
 
 #]=======================================================================]
@@ -123,5 +123,5 @@ function(rapids_cython_create_modules)
     list(APPEND CREATED_TARGETS "${cython_module}")
   endforeach()
 
-  set(_RAPIDS_CYTHON_CREATED_TARGETS ${CREATED_TARGETS} PARENT_SCOPE)
+  set(RAPIDS_CYTHON_CREATED_TARGETS ${CREATED_TARGETS} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
The changes in #203 are meant to guard rapids-cmake from acting or behaving differently due to an existing variable prefixed with RAPIDS which causes un-intended code paths to be executed.

In the case of `rapids_cython_create_modules` it is perfectly reasonable to have an output variable with the `RAPIDS` prefix. rapids-cmake won't execute differently due this variable being set before function execution.