### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/rapids-cmake/cython/create_modules.cmake
+++ b/rapids-cmake/cython/create_modules.cmake
@@ -59,7 +59,7 @@ $ORIGIN.
 
 Result Variables
 ^^^^^^^^^^^^^^^^
-  :cmake:variable:`_RAPIDS_CYTHON_CREATED_TARGETS` will be set to a list of
+  :cmake:variable:`RAPIDS_CYTHON_CREATED_TARGETS` will be set to a list of
   targets created by this function.
 
 #]=======================================================================]
@@ -123,5 +123,5 @@ function(rapids_cython_create_modules)
     list(APPEND CREATED_TARGETS "${cython_module}")
   endforeach()
 
-  set(_RAPIDS_CYTHON_CREATED_TARGETS ${CREATED_TARGETS} PARENT_SCOPE)
+  set(RAPIDS_CYTHON_CREATED_TARGETS ${CREATED_TARGETS} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.