### PR TITLE
Enable copy_prs ops-bot config

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,5 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
+copy_prs: true
 external_contributors: false


### PR DESCRIPTION
Required for github actions to work on rapids-cmake

