### PR TITLE
Add `current_json_dir` placeholder in json patch file values

### DIFF
--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -48,7 +48,7 @@ as needed.
 
     Supports the following placeholders:
         - ``${rapids-cmake-version}`` will be evulated to 'major.minor' of the current rapids-cmake cal-ver value.
-        - ``${version}`` will be evaulated to the contents of the ``version`` field.
+        - ``${version}`` will be evaluated to the contents of the ``version`` field.
 
 ``git_shallow``
 

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -48,7 +48,7 @@ as needed.
 
     Supports the following placeholders:
         - ``${rapids-cmake-version}`` will be evulated to 'major.minor' of the current rapids-cmake cal-ver value.
-        - ``${version}`` will be evulated to the contents of the ``version`` field.
+        - ``${version}`` will be evaulated to the contents of the ``version`` field.
 
 ``git_shallow``
 
@@ -88,6 +88,9 @@ as needed.
             A required string representing the git diff ( .diff ) or patch ( .patch ) to apply.
             Absolute and relative paths are supported. Relative paths are
             evaluated in relation to the `rapids-cmake/cpm/patches` directory.
+
+            Supports the following placeholders:
+                - ``${current_json_dir}`` will be evaulated to the absolute path to the directory holding the current json file
 
         ``issue``
             A required string that explains the need for the patch. Preference is for the

--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -90,7 +90,7 @@ as needed.
             evaluated in relation to the `rapids-cmake/cpm/patches` directory.
 
             Supports the following placeholders:
-                - ``${current_json_dir}`` will be evaulated to the absolute path to the directory holding the current json file
+                - ``${current_json_dir}`` will be evaluated to the absolute path to the directory holding the current json file
 
         ``issue``
             A required string that explains the need for the patch. Preference is for the

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -55,7 +55,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   endif()
 
   # Need the current_json_dir variable populated before we parse any json entries so that we
-  # properly evalute this placeholder
+  # properly evaluate this placeholder
   cmake_path(GET json_path PARENT_PATH current_json_dir)
 
   # Parse required fields

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -40,6 +40,9 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   get_default_json(${package_name} json_data)
   get_override_json(${package_name} override_json_data)
 
+  get_property(json_path GLOBAL PROPERTY rapids_cpm_${package_name}_json_file)
+  get_property(override_json_path GLOBAL PROPERTY rapids_cpm_${package_name}_override_json_file)
+
   string(JSON json_data ERROR_VARIABLE no_default_patch GET "${json_data}" patches)
   string(JSON override_json_data ERROR_VARIABLE no_override_patch GET "${override_json_data}"
          patches)
@@ -48,7 +51,12 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   endif()
   if(NOT no_override_patch)
     set(json_data "${override_json_data}")
+    set(json_path "${override_json_path}" )
   endif()
+
+  # Need the current_json_dir variable populated before we parse
+  # any json entries so that we properly evalute this placeholder
+  cmake_path(GET json_path PARENT_PATH current_json_dir)
 
   # Parse required fields
   function(rapids_cpm_json_get_value json_data_ name)
@@ -79,6 +87,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
       rapids_cpm_json_get_value(${patch_data} file)
       rapids_cpm_json_get_value(${patch_data} issue)
 
+      cmake_language(EVAL CODE "set(file ${file})")
       cmake_path(IS_RELATIVE file is_relative)
       if(is_relative)
         set(file "${rapids-cmake-dir}/cpm/patches/${file}")

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -51,11 +51,11 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   endif()
   if(NOT no_override_patch)
     set(json_data "${override_json_data}")
-    set(json_path "${override_json_path}" )
+    set(json_path "${override_json_path}")
   endif()
 
-  # Need the current_json_dir variable populated before we parse
-  # any json entries so that we properly evalute this placeholder
+  # Need the current_json_dir variable populated before we parse any json entries so that we
+  # properly evalute this placeholder
   cmake_path(GET json_path PARENT_PATH current_json_dir)
 
   # Parse required fields

--- a/rapids-cmake/cpm/detail/load_preset_versions.cmake
+++ b/rapids-cmake/cpm/detail/load_preset_versions.cmake
@@ -55,6 +55,7 @@ function(rapids_cpm_load_preset_versions)
     string(JSON package_name MEMBER "${json_data}" packages ${index})
     string(JSON data GET "${json_data}" packages "${package_name}")
     set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json "${data}")
+    set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json_file "${filepath}")
   endforeach()
 
 endfunction()

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -78,6 +78,7 @@ function(rapids_cpm_package_override filepath)
       if(NOT override_exists)
         # only add the first override for a project we encounter
         set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_override_json "${data}")
+        set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_override_json_file "${filepath}")
       endif()
     endforeach()
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -36,8 +36,11 @@ add_cmake_config_test( cpm_package_override-empty.cmake )
 add_cmake_config_test( cpm_package_override-multiple.cmake )
 add_cmake_config_test( cpm_package_override-simple.cmake )
 
+
 add_cmake_config_test( cpm_generate_patch_command-invalid.cmake )
 add_cmake_config_test( cpm_generate_patch_command-override.cmake )
+add_cmake_config_test( cpm_generate_patch_command-current_json_dir.cmake )
+
 
 add_cmake_config_test( cpm_gtest-export.cmake )
 add_cmake_config_test( cpm_gtest-simple.cmake )

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,0 +1,61 @@
+#=============================================================================
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
+
+rapids_cpm_init()
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+if(patch_command)
+  message(FATAL_ERROR "pkg_with_patch doesn't have override yet, patch_command should be empty")
+endif()
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages" : {
+    "pkg_with_patch" : {
+      "version" : "10.2",
+      "git_tag" : "a_tag",
+      "git_shallow" : "OFF",
+      "exclude_from_all" : "ON",
+      "patches" : [
+        {
+          "file" : "${current_json_dir}/example.diff",
+          "issue" : "explain",
+          "fixed_in" : ""
+        }
+      ]
+    }
+  }
+}
+  ]=])
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+if(NOT patch_command)
+  message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
+endif()
+
+set(to_match_string "set(files ${CMAKE_CURRENT_BINARY_DIR}/example.diff)")
+
+list(POP_BACK patch_command script_to_run)
+file(READ "${script_to_run}" contents)
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_cpm_generate_patch_command failed to handle the `current_json_dir` placeholder")
+endif()


### PR DESCRIPTION
## Description
This allows cpm overrides to have local patch files, otherwise they always evaluate into the rapids-cmake source

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
