### PR TITLE
Add thrust output iterator fix to rapids-cmake thrust patches

### DIFF
--- a/rapids-cmake/cpm/patches/Thrust/transform_iter_with_reduce_by_key.diff
+++ b/rapids-cmake/cpm/patches/Thrust/transform_iter_with_reduce_by_key.diff
@@ -1,0 +1,26 @@
+diff --git a/thrust/iterator/transform_input_output_iterator.h b/thrust/iterator/transform_input_output_iterator.h
+index f512a36..a5f725d 100644
+--- a/thrust/iterator/transform_input_output_iterator.h
++++ b/thrust/iterator/transform_input_output_iterator.h
+@@ -102,6 +102,8 @@ template <typename InputFunction, typename OutputFunction, typename Iterator>
+   /*! \endcond
+    */
+ 
++  transform_input_output_iterator() = default;
++
+   /*! This constructor takes as argument a \c Iterator an \c InputFunction and an
+    * \c OutputFunction and copies them to a new \p transform_input_output_iterator
+    *
+diff --git a/thrust/iterator/transform_output_iterator.h b/thrust/iterator/transform_output_iterator.h
+index 66fb46a..4a68cb5 100644
+--- a/thrust/iterator/transform_output_iterator.h
++++ b/thrust/iterator/transform_output_iterator.h
+@@ -104,6 +104,8 @@ template <typename UnaryFunction, typename OutputIterator>
+   /*! \endcond
+    */
+ 
++  transform_output_iterator() = default;
++
+   /*! This constructor takes as argument an \c OutputIterator and an \c
+    * UnaryFunction and copies them to a new \p transform_output_iterator
+    *

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -37,6 +37,11 @@
       "git_tag" : "${version}",
       "patches" : [
         {
+          "file" : "Thrust/transform_iter_with_reduce_by_key.diff",
+          "issue" : "Support transform iterator with reduce by key [https://github.com/NVIDIA/thrust/pull/1805]",
+          "fixed_in" : "2.1"
+        },
+        {
           "file" : "Thrust/install_rules.diff",
           "issue" : "Thrust 1.X installs incorrect files [https://github.com/NVIDIA/thrust/issues/1790]",
           "fixed_in" : "2.0"


### PR DESCRIPTION
## Description
Backports  https://github.com/NVIDIA/thrust/pull/1805 to thrust 1.17.2 since it looks to be slated for thrust 2.1 . Adding the patch to ensure that all RAPIDS projects won't be hit by this issue 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
