### PR TITLE
Patch results are only displayed once per invocation of CMake

### DIFF
--- a/rapids-cmake/cpm/detail/display_patch_status.cmake
+++ b/rapids-cmake/cpm/detail/display_patch_status.cmake
@@ -29,12 +29,16 @@ Displays the result of any patches applied to the requested package
 
 #]=======================================================================]
 function(rapids_cpm_display_patch_status package_name)
-  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.display_patch_status")
-  set(log_file "${CMAKE_BINARY_DIR}/rapids-cmake/patches/${package_name}/log")
-  if(EXISTS "${log_file}")
-    file(STRINGS "${log_file}" contents)
-    foreach(line IN LISTS contents)
-      message(STATUS "${line}")
-    endforeach()
+  # Only display the status information on the first execution of
+  # the call
+  if(${package_name}_ADDED)
+    list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.display_patch_status")
+    set(log_file "${CMAKE_BINARY_DIR}/rapids-cmake/patches/${package_name}/log")
+    if(EXISTS "${log_file}")
+      file(STRINGS "${log_file}" contents)
+      foreach(line IN LISTS contents)
+        message(STATUS "${line}")
+      endforeach()
+    endif()
   endif()
 endfunction()

--- a/rapids-cmake/cpm/detail/display_patch_status.cmake
+++ b/rapids-cmake/cpm/detail/display_patch_status.cmake
@@ -29,8 +29,7 @@ Displays the result of any patches applied to the requested package
 
 #]=======================================================================]
 function(rapids_cpm_display_patch_status package_name)
-  # Only display the status information on the first execution of
-  # the call
+  # Only display the status information on the first execution of the call
   if(${package_name}_ADDED)
     list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.display_patch_status")
     set(log_file "${CMAKE_BINARY_DIR}/rapids-cmake/patches/${package_name}/log")


### PR DESCRIPTION
## Description
Instead of showing the patch status for each call to `rapids_cpm_<pkg>` only display it on the first. This makes it clearer that we aren't applying the patches multiple times.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.

