### PR TITLE
Add missing CPM_ARGS to gbench

### DIFF
--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -61,6 +61,7 @@ function(rapids_cpm_gbench)
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(GBench ${version} ${ARGN}
                   GLOBAL_TARGETS benchmark::benchmark benchmark::benchmark_main
+                  CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The `rapids_cpm_find` command for Google benchmark is missing a `CPM_ARGS` argument, which is preventing the subsequent arguments from being parsed correctly.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
