### PR TITLE
Add `ninja` as build dependency

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -15,6 +15,9 @@ set +eu
 conda activate test
 set -u
 
+# Disable `sccache` S3 backend since compile times are negligible
+unset SCCACHE_BUCKET
+
 rapids-print-env
 
 rapids-logger "Check GPU usage"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -15,6 +15,7 @@ set +eu
 conda activate test
 set -u
 
+rapids-print-env
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - cmake>=3.23.1
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
-    - make
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
     - make
+    - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake>=3.23.1
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
+    - make
     - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
     - make
-    - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake>=3.23.1
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
+    - make
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake>=3.23.1
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
+    - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,6 +20,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1
+          - ninja
       - output_types: conda
         packages:
           - c-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,12 +20,12 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1
-          - make
           - ninja
       - output_types: conda
         packages:
           - c-compiler
           - cxx-compiler
+          - make
   cudatoolkit:
     specific:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,6 +20,7 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1
+          - make
           - ninja
       - output_types: conda
         packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,7 +20,6 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1
-          - ninja
       - output_types: conda
         packages:
           - c-compiler

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,7 +24,6 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
-          - make
   cudatoolkit:
     specific:
       - output_types: conda

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -24,6 +24,7 @@ dependencies:
         packages:
           - c-compiler
           - cxx-compiler
+          - make
   cudatoolkit:
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description

This PR adds `ninja` and `make` as build dependencies of `rapids-cmake`. Additionally, it disables the `sccache` S3 backend for the c++ tests since compile times are negligible.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
