### PR TITLE
Remove usage of FetchContent from tests to improve perf

### DIFF
--- a/testing/utils/project_template.cmake.in
+++ b/testing/utils/project_template.cmake.in
@@ -18,18 +18,21 @@ cmake_minimum_required(VERSION 3.23.1)
 include(FetchContent)
 
 set(local-rapids-cmake-root "${rapids-cmake-dir}/..")
-set(rapids-cmake_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/rapids-cmake-src")
-set(rapids-cmake_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/rapids-cmake-build")
+cmake_path(NORMAL_PATH local-rapids-cmake-root)
 
-# Copy any local uncommited changes over
-file(COPY ${local-rapids-cmake-root}/rapids-cmake/
-     DESTINATION ${rapids-cmake_SOURCE_DIR}/rapids-cmake/)
-file(COPY ${local-rapids-cmake-root}/CMakeLists.txt
-     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
-file(COPY ${local-rapids-cmake-root}/init.cmake
-     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
-file(COPY ${local-rapids-cmake-root}/RAPIDS.cmake
-     DESTINATION ${rapids-cmake_SOURCE_DIR}/)
+set(scratch_dir "${CMAKE_CURRENT_BINARY_DIR}/_deps")
+set(rapids-cmake_SOURCE_DIR "${scratch_dir}/rapids-cmake-src")
+set(rapids-cmake_BINARY_DIR "${scratch_dir}/rapids-cmake-build")
+
+# construct a symlink from the source to the build dir
+# so we get the latest local changes without issue
+execute_process(
+     COMMAND ${CMAKE_COMMAND} -E make_directory "${scratch_dir}"
+     COMMAND ${CMAKE_COMMAND} -E create_symlink "${local-rapids-cmake-root}" "${rapids-cmake_SOURCE_DIR}"
+     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+     ECHO_OUTPUT_VARIABLE
+     ECHO_ERROR_VARIABLE)
+unset(scratch_dir)
 
 add_subdirectory(${rapids-cmake_SOURCE_DIR} ${rapids-cmake_BINARY_DIR})
 

--- a/testing/utils/project_template.cmake.in
+++ b/testing/utils/project_template.cmake.in
@@ -21,8 +21,18 @@ set(local-rapids-cmake-root "${rapids-cmake-dir}/..")
 cmake_path(NORMAL_PATH local-rapids-cmake-root)
 
 set(scratch_dir "${CMAKE_CURRENT_BINARY_DIR}/_deps")
+
+# emulate the variables and properties that FetchContent would set so
+# tests that themselves download rapids-cmake will use the version we have
+# symlinked.
 set(rapids-cmake_SOURCE_DIR "${scratch_dir}/rapids-cmake-src")
 set(rapids-cmake_BINARY_DIR "${scratch_dir}/rapids-cmake-build")
+set(rapids-cmake_POPULATED TRUE)
+set(prefix "_FetchContent_rapids-cmake")
+set_property(GLOBAL PROPERTY ${prefix}_sourceDir "${rapids-cmake_SOURCE_DIR}")
+set_property(GLOBAL PROPERTY ${prefix}_binaryDir "${rapids-cmake_BINARY_DIR}")
+define_property(GLOBAL PROPERTY ${prefix}_populated)
+
 
 # construct a symlink from the source to the build dir
 # so we get the latest local changes without issue

--- a/testing/utils/project_template.cmake.in
+++ b/testing/utils/project_template.cmake.in
@@ -27,7 +27,8 @@ set(rapids-cmake_BINARY_DIR "${scratch_dir}/rapids-cmake-build")
 # construct a symlink from the source to the build dir
 # so we get the latest local changes without issue
 execute_process(
-     COMMAND ${CMAKE_COMMAND} -E make_directory "${scratch_dir}"
+     COMMAND ${CMAKE_COMMAND} -E make_directory "${scratch_dir}")
+execute_process(
      COMMAND ${CMAKE_COMMAND} -E create_symlink "${local-rapids-cmake-root}" "${rapids-cmake_SOURCE_DIR}"
      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
      ECHO_OUTPUT_VARIABLE

--- a/testing/utils/project_template.cmake.in
+++ b/testing/utils/project_template.cmake.in
@@ -18,14 +18,8 @@ cmake_minimum_required(VERSION 3.23.1)
 include(FetchContent)
 
 set(local-rapids-cmake-root "${rapids-cmake-dir}/..")
-FetchContent_Declare(
-  rapids-cmake
-  GIT_REPOSITORY "${local-rapids-cmake-root}/.git"
-  GIT_TAG HEAD
-  )
-
-FetchContent_GetProperties(rapids-cmake)
-FetchContent_Populate(rapids-cmake)
+set(rapids-cmake_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/rapids-cmake-src")
+set(rapids-cmake_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/_deps/rapids-cmake-build")
 
 # Copy any local uncommited changes over
 file(COPY ${local-rapids-cmake-root}/rapids-cmake/


### PR DESCRIPTION
## Description
Improve performance of rapids-cmake tests in CI by removing the usage of fetch content, and instead
using symlinks and tricking fetch content that it was used to get rapids-cmake.

This reduces the size of each test in the binary directory as they no longer have a copy of rapids-cmake. Plus still works
for tests that fetch rapids-cmake indirectly ( via cpm due to testing projects like rmm ). 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.

