### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -15,6 +15,10 @@ set +eu
 conda activate test
 set -u
 
+# Disable `sccache` S3 backend since compile times are negligible
+unset SCCACHE_BUCKET
+
+rapids-print-env
 
 rapids-logger "Check GPU usage"
 nvidia-smi

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - cmake>=3.23.1
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
+    - make
+    - ninja
     - sysroot_{{ target_platform }} {{ sysroot_version }}
   host:
     - cudatoolkit {{ cuda_version }}.*

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -20,10 +20,12 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cmake>=3.23.1
+          - ninja
       - output_types: conda
         packages:
           - c-compiler
           - cxx-compiler
+          - make
   cudatoolkit:
     specific:
       - output_types: conda


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.