### PR TITLE
Remove `rapids-dependency-file-generator` `FIXME`

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -6,13 +6,10 @@ set -euo pipefail
 rapids-logger "Create checks conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-# FIXME: "checks" environment doesn't depend on a CUDA version.
-# "cuda=*" can be removed after https://github.com/rapidsai/dependency-file-generator/issues/17
-# is addressed. Right now "cuda=*" is a no-op to prevent an error from being thrown
 rapids-dependency-file-generator \
   --output conda \
   --file_key checks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*}" | tee env.yaml
+  --matrix "" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks
 


### PR DESCRIPTION
## Description

Now that https://github.com/rapidsai/dependency-file-generator/issues/17 has been closed, this `FIXME` can be removed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
