### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -6,13 +6,10 @@ set -euo pipefail
 rapids-logger "Create checks conda environment"
 . /opt/conda/etc/profile.d/conda.sh
 
-# FIXME: "checks" environment doesn't depend on a CUDA version.
-# "cuda=*" can be removed after https://github.com/rapidsai/dependency-file-generator/issues/17
-# is addressed. Right now "cuda=*" is a no-op to prevent an error from being thrown
 rapids-dependency-file-generator \
   --output conda \
   --file_key checks \
-  --matrix "cuda=${RAPIDS_CUDA_VERSION%.*}" | tee env.yaml
+  --matrix "" | tee env.yaml
 
 rapids-mamba-retry env create --force -f env.yaml -n checks
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.