### PR TITLE
Don't use CMake 3.25.0 as it has a show stopping FindCUDAToolkit bug

### DIFF
--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.23.1
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
     - make

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,7 +19,7 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - cmake>=3.23.1
+          - cmake>=3.23.1,!=3.25.0
           - ninja
       - output_types: conda
         packages:


### PR DESCRIPTION
## Description
Don't use CMake 3.25.0 as it has a show stopping FindCUDAToolkit bug

