### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.23.1
+    - cmake>=3.23.1,!=3.25.0
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }} {{ cuda_version }}
     - make

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,7 +19,7 @@ dependencies:
     common:
       - output_types: [conda, requirements]
         packages:
-          - cmake>=3.23.1
+          - cmake>=3.23.1,!=3.25.0
           - ninja
       - output_types: conda
         packages:


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.