### PR TITLE
rapids_cuda_init_architectures now supports CUDAARCHS env variable

### DIFF
--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -89,7 +89,7 @@ function(rapids_cuda_init_architectures project_name)
     set(cuda_arch_mode "ALL")
   elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
     set(cuda_arch_mode "NATIVE")
-  elseif(NOT (DEFINED ENV{CUDAARCHS} OR DEFINED CMAKE_CUDA_ARCHITECTURES) )
+  elseif(NOT (DEFINED ENV{CUDAARCHS} OR DEFINED CMAKE_CUDA_ARCHITECTURES))
     set(cuda_arch_mode "ALL")
   endif()
 

--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -79,8 +79,6 @@ function(rapids_cuda_init_architectures project_name)
   # If `CMAKE_CUDA_ARCHITECTURES` is not defined, build for all supported architectures. If
   # `CMAKE_CUDA_ARCHITECTURES` is set to an empty string (""), build for only the current
   # architecture. If `CMAKE_CUDA_ARCHITECTURES` is specified by the user, use user setting.
-
-
   if(DEFINED ENV{CUDAARCHS} AND "$ENV{CUDAARCHS}" STREQUAL "ALL")
     set(cuda_arch_mode "ALL")
   elseif(DEFINED ENV{CUDAARCHS} AND "$ENV{CUDAARCHS}" STREQUAL "NATIVE")

--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -28,10 +28,10 @@ to include support for `ALL` and `NATIVE` to make CUDA architecture compilation 
 
     rapids_cuda_init_architectures(<project_name>)
 
-Used before enabling the CUDA language either via :cmake:command:`project() <cmake:command:project>` or
-:cmake:command:`enable_language() <cmake:command:enable_language>` to establish the CUDA architectures to be compiled for.
-Parses the :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>` for special
-values `ALL`, `NATIVE` and `""`.
+Used before enabling the CUDA language either via :cmake:command:`project() <cmake:command:project>` to establish the
+CUDA architectures to be compiled for. Parses the :cmake:envvar:`CUDAARCHS <cmake:envvar:CUDAARCHS>`, and
+:cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>` for special values
+`ALL`, `NATIVE` and `""`.
 
 .. note::
   Required to be called before the first :cmake:command:`project() <cmake:command:project>` call.
@@ -41,7 +41,7 @@ values `ALL`, `NATIVE` and `""`.
   the correct values for :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`.
 
 ``project_name``
-  Name of the project
+  Name of the project in the subsequent :cmake:command:`project() <cmake:command:project>` call.
 
 ``NATIVE`` or ``""``:
   When passed as the value for :cmake:variable:`CMAKE_CUDA_ARCHITECTURES <cmake:variable:CMAKE_CUDA_ARCHITECTURES>`
@@ -80,17 +80,25 @@ function(rapids_cuda_init_architectures project_name)
   # `CMAKE_CUDA_ARCHITECTURES` is set to an empty string (""), build for only the current
   # architecture. If `CMAKE_CUDA_ARCHITECTURES` is specified by the user, use user setting.
 
-  # This needs to be run before enabling the CUDA language since RAPIDS supports the magic string of
-  # "ALL"
-  set(no_user_cuda_archs TRUE)
-  if(DEFINED ENV{CUDAARCHS} OR DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(no_user_cuda_archs FALSE)
+
+  if(DEFINED ENV{CUDAARCHS} AND "$ENV{CUDAARCHS}" STREQUAL "ALL")
+    set(cuda_arch_mode "ALL")
+  elseif(DEFINED ENV{CUDAARCHS} AND "$ENV{CUDAARCHS}" STREQUAL "NATIVE")
+    set(cuda_arch_mode "NATIVE")
+  elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
+    set(cuda_arch_mode "ALL")
+  elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
+    set(cuda_arch_mode "NATIVE")
+  elseif(NOT (DEFINED ENV{CUDAARCHS} OR DEFINED CMAKE_CUDA_ARCHITECTURES) )
+    set(cuda_arch_mode "ALL")
   endif()
 
-  if(no_user_cuda_archs OR CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
+  # This needs to be run before enabling the CUDA language since RAPIDS supports the magic string of
+  # "ALL"
+  if(cuda_arch_mode STREQUAL "ALL")
     set(CMAKE_CUDA_ARCHITECTURES OFF PARENT_SCOPE)
     set(load_file "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/detail/invoke_set_all_architectures.cmake")
-  elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
+  elseif(cuda_arch_mode STREQUAL "NATIVE")
     set(CMAKE_CUDA_ARCHITECTURES OFF PARENT_SCOPE)
     set(load_file "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/detail/invoke_set_native_architectures.cmake")
   endif()

--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -21,10 +21,12 @@ add_cmake_config_test( init_runtime-shared.cmake )
 add_cmake_config_test( init_runtime-static.cmake )
 
 add_cmake_config_test( init_arch-all-via-undef )
+add_cmake_config_test( init_arch-all-via-env.cmake )
 add_cmake_config_test( init_arch-all.cmake )
 add_cmake_config_test( init_arch-existing-project-flags.cmake )
 add_cmake_config_test( init_arch-native.cmake )
 add_cmake_config_test( init_arch-native-via-empty-str )
+add_cmake_config_test( init_arch-native-via-env.cmake )
 add_cmake_config_test( init_arch-user.cmake )
 add_cmake_config_test( init_arch-user-via-env.cmake )
 

--- a/testing/cuda/init_arch-all-via-env.cmake
+++ b/testing/cuda/init_arch-all-via-env.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cuda/init_arch-all-via-env.cmake
+++ b/testing/cuda/init_arch-all-via-env.cmake
@@ -1,0 +1,32 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/init_architectures.cmake)
+
+
+set(ENV{CUDAARCHS} "ALL")
+rapids_cuda_init_architectures(rapids-project)
+project(rapids-project LANGUAGES CUDA)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  message(FATAL_ERROR "CMAKE_CUDA_ARCHITECTURES should exist after calling rapids_cuda_init_architectures()")
+endif()
+
+if(CMAKE_CUDA_ARCHITECTURES STREQUAL "ALL")
+  message(FATAL_ERROR "rapids_cuda_init_architectures didn't init CUDA_ARCHITECTURES")
+endif()
+
+
+include("${rapids-cmake-testing-dir}/cuda/validate-cuda-all.cmake")

--- a/testing/cuda/init_arch-native-via-env.cmake
+++ b/testing/cuda/init_arch-native-via-env.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cuda/init_arch-native-via-env.cmake
+++ b/testing/cuda/init_arch-native-via-env.cmake
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/init_architectures.cmake)
+
+
+set(ENV{CUDAARCHS} "NATIVE")
+rapids_cuda_init_architectures(rapids-project)
+project(rapids-project LANGUAGES CUDA)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  message(FATAL_ERROR "CMAKE_CUDA_ARCHITECTURES should exist after calling rapids_cuda_init_architectures()")
+endif()
+
+if(CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
+  message(FATAL_ERROR "rapids_cuda_init_architectures didn't init CUDA_ARCHITECTURES")
+endif()
+
+include("${rapids-cmake-testing-dir}/cuda/validate-cuda-native.cmake")


### PR DESCRIPTION
## Description
`rapids_cuda_init_architectures` now will handle magic values in `ENV{CUDAARCHS}` allowing users to specify values like `NATIVE` or `ALL` via that method.

Fixes #313

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
