### PR TITLE
Revert "Upgrade spdlog to 1.10.0 (#312)"

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -32,7 +32,7 @@
       "git_tag" : "branch-${version}"
     },
     "spdlog" : {
-      "version" : "1.10.0",
+      "version" : "1.8.5",
       "git_url" : "https://github.com/gabime/spdlog.git",
       "git_tag" : "v${version}"
     },


### PR DESCRIPTION
## Description
This reverts commit 4b079dcced873038fd4fa3263a5297a844f2bcb9.

See https://github.com/rapidsai/rmm/pull/1176 for details.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
