### PR TITLE
rapids_cuda_patch_toolkit: Better handle non-standard toolkits

### DIFF
--- a/rapids-cmake/cuda/patch_toolkit.cmake
+++ b/rapids-cmake/cuda/patch_toolkit.cmake
@@ -32,6 +32,7 @@ of cublas and cusolver targets are incorrect. This module must be called
 from the same CMakeLists.txt as the first `find_project(CUDAToolkit)` to
 patch the targets.
 
+For all version of Cmake the dependencies of cusparse are incorrect.
 .. note::
   :cmake:command:`rapids_cpm_find` will automatically call this module
   when asked to find the CUDAToolkit.
@@ -41,12 +42,24 @@ function(rapids_cuda_patch_toolkit)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cuda.patch_toolkit")
 
   get_directory_property(itargets IMPORTED_TARGETS)
-  if(CUDA::cublas_static IN_LIST itargets)
-    target_link_libraries(CUDA::cublas INTERFACE CUDA::cublasLt)
-    target_link_libraries(CUDA::cusparse INTERFACE CUDA::cublas)
+  if(CMAKE_VERSION VERSION_LESS 3.24.2)
+    if(CUDA::cublas IN_LIST itargets)
+      target_link_libraries(CUDA::cublas INTERFACE CUDA::cublasLt)
+    endif()
 
-    target_link_libraries(CUDA::cublas_static INTERFACE CUDA::cublasLt_static)
-    target_link_libraries(CUDA::cusolver_static INTERFACE CUDA::cusolver_lapack_static)
+    if(CUDA::cublas_static IN_LIST itargets)
+      target_link_libraries(CUDA::cublas_static INTERFACE CUDA::cublasLt_static)
+    endif()
+
+    if(CUDA::cusolver_static IN_LIST itargets)
+      target_link_libraries(CUDA::cusolver_static INTERFACE CUDA::cusolver_lapack_static)
+    endif()
+  endif()
+
+  if(CUDA::cusparse IN_LIST itargets)
+    target_link_libraries(CUDA::cusparse INTERFACE CUDA::cublas)
+  endif()
+  if(CUDA::cusparse_static IN_LIST itargets)
     target_link_libraries(CUDA::cusparse_static INTERFACE CUDA::cublas_static)
   endif()
 endfunction()

--- a/rapids-cmake/cuda/patch_toolkit.cmake
+++ b/rapids-cmake/cuda/patch_toolkit.cmake
@@ -32,7 +32,6 @@ of cublas and cusolver targets are incorrect. This module must be called
 from the same CMakeLists.txt as the first `find_project(CUDAToolkit)` to
 patch the targets.
 
-For all versions of CMake, the dependencies of cusparse are incorrect.
 .. note::
   :cmake:command:`rapids_cpm_find` will automatically call this module
   when asked to find the CUDAToolkit.
@@ -54,12 +53,5 @@ function(rapids_cuda_patch_toolkit)
     if(CUDA::cusolver_static IN_LIST itargets)
       target_link_libraries(CUDA::cusolver_static INTERFACE CUDA::cusolver_lapack_static)
     endif()
-  endif()
-
-  if(CUDA::cusparse IN_LIST itargets)
-    target_link_libraries(CUDA::cusparse INTERFACE CUDA::cublas)
-  endif()
-  if(CUDA::cusparse_static IN_LIST itargets)
-    target_link_libraries(CUDA::cusparse_static INTERFACE CUDA::cublas_static)
   endif()
 endfunction()

--- a/rapids-cmake/cuda/patch_toolkit.cmake
+++ b/rapids-cmake/cuda/patch_toolkit.cmake
@@ -32,7 +32,7 @@ of cublas and cusolver targets are incorrect. This module must be called
 from the same CMakeLists.txt as the first `find_project(CUDAToolkit)` to
 patch the targets.
 
-For all version of Cmake the dependencies of cusparse are incorrect.
+For all versions of CMake, the dependencies of cusparse are incorrect.
 .. note::
   :cmake:command:`rapids_cpm_find` will automatically call this module
   when asked to find the CUDAToolkit.

--- a/testing/cuda/patch_toolkit-nested/CMakeLists.txt
+++ b/testing/cuda/patch_toolkit-nested/CMakeLists.txt
@@ -33,8 +33,6 @@ add_subdirectory(subdir)
 
 if(TARGET CUDA::cublas_static)
   verify_links_to(CUDA::cublas CUDA::cublasLt)
-  verify_links_to(CUDA::cusparse CUDA::cublas)
   verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
-  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
   verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
 endif()

--- a/testing/cuda/patch_toolkit-nested/subdir/CMakeLists.txt
+++ b/testing/cuda/patch_toolkit-nested/subdir/CMakeLists.txt
@@ -21,8 +21,6 @@ rapids_cuda_patch_toolkit()
 
 if(TARGET CUDA::cublas_static)
   verify_links_to(CUDA::cublas CUDA::cublasLt)
-  verify_links_to(CUDA::cusparse CUDA::cublas)
   verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
-  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
   verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
 endif()

--- a/testing/cuda/patch_toolkit.cmake
+++ b/testing/cuda/patch_toolkit.cmake
@@ -30,8 +30,6 @@ rapids_cuda_patch_toolkit()
 
 if(TARGET CUDA::cublas_static)
   verify_links_to(CUDA::cublas CUDA::cublasLt)
-  verify_links_to(CUDA::cusparse CUDA::cublas)
   verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
-  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
   verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
 endif()

--- a/testing/find/find_package-cudatoolkit-patching.cmake
+++ b/testing/find/find_package-cudatoolkit-patching.cmake
@@ -26,8 +26,6 @@ rapids_find_package(CUDAToolkit)
 
 if(TARGET CUDA::cublas_static)
   verify_links_to(CUDA::cublas CUDA::cublasLt)
-  verify_links_to(CUDA::cusparse CUDA::cublas)
   verify_links_to(CUDA::cublas_static CUDA::cublasLt_static)
-  verify_links_to(CUDA::cusparse_static CUDA::cublas_static)
   verify_links_to(CUDA::cusolver_static CUDA::cusolver_lapack_static)
 endif()


### PR DESCRIPTION
## Description
Previously we presumed that `cublas`, `cusparse`, and `cusolver` would always be found and offer both static and shared versions. Now we only setup these rules if the correct targets exist.

Fixes #321 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
