### PR TITLE
Update cuco git tag to fetch bug fixes and cleanups

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -62,7 +62,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "2a194c9831324904120113bc18135e7933369ee8"
+      "git_tag" : "31e1d5df6869ef6cb60f36a614b30a244cf3bd78"
     }
   }
 }


### PR DESCRIPTION
This PR fetches the latest changes in cuco to:

- Inline `cuco::sentinel` namespace (https://github.com/NVIDIA/cuCollections/pull/247)
- Fix memory leak in `static_map::retrieve_all` (https://github.com/NVIDIA/cuCollections/pull/257)
- Use public `cuco::murmurhash3_32` (https://github.com/NVIDIA/cuCollections/pull/253)

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
