### PR TITLE
Update to nvcomp 2.5

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -18,12 +18,12 @@
       "git_tag" : "12d13bdc5e74801645eba3e46a64081b9b020dca"
     },
     "nvcomp" : {
-      "version" : "2.4.1",
+      "version" : "2.5.0",
       "git_url" : "https://github.com/NVIDIA/nvcomp.git",
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {
-        "x86_64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_11.x.tgz",
-        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_sbsa_11.x.tgz"
+        "x86_64-linux" :  "https://developer.download.nvidia.com/compute/nvcomp/2.5/local_installers/nvcomp_${version}_x86_64_11.x.tgz",
+        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/2.5/local_installers/nvcomp_${version}_sbsa_11.x.tgz"
       }
     },
     "rmm" : {

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -23,7 +23,7 @@
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {
         "x86_64-linux" :  "https://developer.download.nvidia.com/compute/nvcomp/2.5/local_installers/nvcomp_${version}_x86_64_11.x.tgz",
-        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/2.5/local_installers/nvcomp_${version}_sbsa_11.x.tgz"
+        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/2.5/local_installers/nvcomp_${version}_SBSA_11.x.tgz"
       }
     },
     "rmm" : {


### PR DESCRIPTION
## Description
Update to the latest version of nvcomp ( 2.5 ).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
