### PR TITLE
Revert update of libcudacxx 1.9 

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -54,7 +54,7 @@
       ]
     },
     "libcudacxx" : {
-      "version" : "1.9.0",
+      "version" : "1.8.1",
       "git_url" : "https://github.com/NVIDIA/libcudacxx.git",
       "git_tag" : "${version}"
     },


### PR DESCRIPTION
## Description
This reverts commit 0246df965c6bb7d864451fda9fd60b0a36b4843e.

Needed as downstream projects like libcudf are running into compile issues with `cuda/atomic` and work needs to be done to handle changes in 1.9.
