### PR TITLE
Revert "Update spdlog to 1.11 ( latest version ) (#342)"

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -32,7 +32,7 @@
       "git_tag" : "branch-${version}"
     },
     "spdlog" : {
-      "version" : "1.11.0",
+      "version" : "1.8.5",
       "git_url" : "https://github.com/gabime/spdlog.git",
       "git_tag" : "v${version}"
     },


### PR DESCRIPTION
## Description
This reverts commit 3d5c0a1e0d94b0882f714cce05cb9a3bd1b0e3c7 / PR #342.

The update to `spdlog 1.11.0` was tested for `cuml` (and seemed fine) but broke builds for `cugraph` both locally and in CI:
- https://github.com/rapidsai/cugraph/actions/runs/3980866464/jobs/6824225844
- https://github.com/rapidsai/rapids-cmake/pull/342#issuecomment-1399183315

I am reverting that change until a diagnosis can be performed and solution can be found.

See also this packaging change for rmm (not yet merged): https://github.com/rapidsai/rmm/pull/1177

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
