### PR TITLE
cpm: Rework `always_download` rules to be smarter

### DIFF
--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -73,7 +73,9 @@ as needed.
     An optional boolean value that represents if CPM should just download the
     package ( `CPM_DOWNLOAD_ALL` ) instead of first searching for it on the machine.
 
-    If no such field exists the default is `false` for default packages, and `true` for any package that has an override.
+    The default value for this field is `false` unless all of the following criteria is met.
+        - The projects exists in both the default and override files
+        - The `git_url` or `git_tag` have been overridden
 
 ``patches``
     An optional list of dictionary sets of git patches to apply to the project

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,6 +59,15 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   rapids_cpm_json_get_value(git_url)
   rapids_cpm_json_get_value(git_tag)
 
+  if(override_json_data)
+    string(JSON value ERROR_VARIABLE no_url_override GET "${override_json_data}" git_url)
+    string(JSON value ERROR_VARIABLE no_tag_override GET "${override_json_data}" git_tag)
+    set(git_details_overridden TRUE)
+    if(no_url_override AND no_tag_override)
+      set(git_details_overridden FALSE)
+    endif()
+  endif()
+
   # Parse optional fields, set the variable to the 'default' value first
   set(git_shallow ON)
   rapids_cpm_json_get_value(git_shallow)
@@ -66,10 +75,10 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   set(exclude_from_all OFF)
   rapids_cpm_json_get_value(exclude_from_all)
 
-  if(override_json_data)
-    # The default value for always download is defined by having an override for this package. When
-    # we have an override we presume the user doesn't want to use an existing local installed
-    # version
+  set(always_download OFF)
+  if(override_json_data AND json_data AND git_details_overridden)
+    # `always_download` default value requires the package to exist in both the default and override
+    # and that the git url / git tag have been modified.
     set(always_download ON)
   endif()
   rapids_cpm_json_get_value(always_download)

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "git_tag" : "my_tag",
       "always_download" : false
     },
+    "rmm" : {
+      "git_tag" : "my_tag"
+    },
     "GTest" : {
       "version" : "2.99"
     }
@@ -50,11 +53,22 @@ if(NOT repository STREQUAL nvbench_repository)
   message(FATAL_ERROR "default repository field was removed.")
 endif()
 if(NOT tag STREQUAL "my_tag")
-  message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_url")
+  message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_tag")
 endif()
 if(CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false since the nvbench override explicitly sets it to 'false'")
 endif()
+unset(CPM_DOWNLOAD_ALL)
+
+# Verify that the override works
+rapids_cpm_package_details(rmm version repository tag shallow exclude)
+if(NOT tag STREQUAL "my_tag")
+  message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_tag")
+endif()
+if(NOT CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be true since a custom git tag was used for rmm")
+endif()
+unset(CPM_DOWNLOAD_ALL)
 
 rapids_cpm_package_details(GTest version repository tag shallow exclude)
 if(NOT version STREQUAL "2.99")
@@ -63,6 +77,6 @@ endif()
 if(NOT tag MATCHES "2.99")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
 endif()
-if(NOT CPM_DOWNLOAD_ALL)
-  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be enabled by default when an override exists")
+if(CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false by default when an override exists that doesn't modify url or tag")
 endif()

--- a/testing/cpm/cpm_package_override-simple.cmake
+++ b/testing/cpm/cpm_package_override-simple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
 {
   "packages" : {
     "rmm" : {
-      "git_tag" : "new_rmm_tag",
+      "git_url" : "new_rmm_url",
       "git_shallow" : "OFF",
       "exclude_from_all" : "ON"
     },
@@ -50,13 +50,13 @@ endif()
 if(NOT exclude MATCHES "OFF")
   message(FATAL_ERROR "default value of exclude not found. ${exclude} was found instead")
 endif()
-if(NOT CPM_DOWNLOAD_ALL)
-  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")
+if(CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false by default when an override exists that doesn't modify url or tag")
 endif()
 
 rapids_cpm_package_details(rmm version repository tag shallow exclude)
-if(NOT tag MATCHES "new_rmm_tag")
-  message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead")
+if(NOT repository MATCHES "new_rmm_url")
+  message(FATAL_ERROR "custom url field was not used. ${repository} was found instead")
 endif()
 if(NOT shallow MATCHES "OFF")
   message(FATAL_ERROR "override should not change git_shallow value. ${shallow} was found instead")
@@ -65,5 +65,5 @@ if(NOT exclude MATCHES "ON")
   message(FATAL_ERROR "override should have changed exclude value. ${exclude} was found instead")
 endif()
 if(NOT CPM_DOWNLOAD_ALL)
-  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists with a custom repository")
 endif()


### PR DESCRIPTION
## Description
Now we only mark always_download as true when the override is changing the git_tag or git_url.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
