### PR TITLE
Use string literals for policy test messages so no escaping needed

### DIFF
--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -41,10 +41,10 @@ add_cmake_config_test( set_arch-invalid-mode.cmake )
 add_cmake_config_test( set_arch-native.cmake )
 add_cmake_config_test( set_arch-rapids.cmake )
 
-set(deprecated_message "rapids-cmake policy [deprecated=23.02 removed=23.06]: Usage of `ALL`")
+set(deprecated_message [=[rapids-cmake policy [deprecated=23.02 removed=23.06]: Usage of `ALL`]=])
 add_cmake_config_test( init_arch-all-via-env-deprecated.cmake SHOULD_FAIL "${deprecated_message}")
 add_cmake_config_test( init_arch-all-deprecated.cmake SHOULD_FAIL "${deprecated_message}")
 add_cmake_config_test( set_arch-all-deprecated.cmake SHOULD_FAIL "${deprecated_message}")
 
-set(deprecated_message "rapids-cmake policy [deprecated=23.02 removed=23.06]: Usage of `""`")
+set(deprecated_message [=[rapids-cmake policy [deprecated=23.02 removed=23.06]: Usage of `""`]=])
 add_cmake_config_test( init_arch-native-via-empty-str-deprecated SHOULD_FAIL "${deprecated_message}")


### PR DESCRIPTION
## Description
Corrects the following warning occuring when running the test infrastructure:
```cmake
CMake Warning (dev) at cuda/CMakeLists.txt:49:
  Syntax Warning in cmake code at column 90

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.
````

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
