### PR TITLE
Update nvCOMP version to 2.6.1

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -18,7 +18,7 @@
       "git_tag" : "12d13bdc5e74801645eba3e46a64081b9b020dca"
     },
     "nvcomp" : {
-      "version" : "2.6.0",
+      "version" : "2.6.1",
       "git_url" : "https://github.com/NVIDIA/nvcomp.git",
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {


### PR DESCRIPTION
## Description
Update nvCOMP version to include a critical bug fix in the 2.6.1 version.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
