### PR TITLE
Bump spdlog to 1.11, add fmt as dependency for spdlog

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -166,6 +166,7 @@
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
+          "FMT_OPTION": 1,
           "INSTALL_EXPORT_SET": 1
         }
       },

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -35,6 +35,8 @@ across all RAPIDS projects.
                      [<CPM_ARGS> ...])
 
 ``FMT_OPTION``
+.. versionadded:: v23.04.00
+
   Spdlog depends on the fmt library and offers multiple ways of handling this dependency when spdlog is built. This
   option only controls the behavior when spdlog is fetched and built, NOT when an installed spdlog is found on the
   system.
@@ -71,7 +73,8 @@ function(rapids_cpm_spdlog)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  # Fix up _RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS as this is need for rapids_cpm_find
+  # Fix up _RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS as this is need for rapids_cpm_find. Also
+  # propagate the user provided build and install export sets.
   if(_RAPIDS_INSTALL_EXPORT_SET)
     list(APPEND _RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
   endif()
@@ -105,8 +108,8 @@ function(rapids_cpm_spdlog)
     # search beside it before looking globally.
     list(APPEND fmt_ROOT ${spdlog_ROOT})
 
-    rapids_cpm_fmt(BUILD_EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET}
-                   INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
+    rapids_cpm_fmt(${_RAPIDS_UNPARSED_ARGUMENTS})
+
     set(spdlog_fmt_option "SPDLOG_${_RAPIDS_FMT_OPTION} ON")
     if(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT")
       set(spdlog_fmt_target fmt::fmt)

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -29,9 +29,22 @@ across all RAPIDS projects.
 
 .. code-block:: cmake
 
-  rapids_cpm_spdlog( [BUILD_EXPORT_SET <export-name>]
+  rapids_cpm_spdlog( [FMT_OPTION <fmt-option-name>]
+                     [BUILD_EXPORT_SET <export-name>]
                      [INSTALL_EXPORT_SET <export-name>]
                      [<CPM_ARGS> ...])
+
+``FMT_OPTION``
+  Spdlog depends on the fmt library and offers multiple ways of handling this dependency when spdlog is built. This
+  option only controls the behavior when spdlog is fetched and built, NOT when and installed spdlog is found on the
+  system.
+
+  This option can be set to one of three values: `BUNDLED`, `EXTERNAL_FMT`, or `EXTERNAL_FMT_HO`. If set to
+  `BUNDLED`, then spdlog will use its own bundled version of fmt. If set to `EXTERNAL_FMT` then spdlog will use the
+  `fmt::fmt` target and be linked with the fmt library. If set to `EXTERNAL_FMT_HO` then spdlog will use the
+  `fmt::fmt-header-only` target and be linked with a header only fmt library.
+
+  Defaults to `EXTERNAL_FMT_HO`.
 
 .. |PKG_NAME| replace:: spdlog
 .. include:: common_package_args.txt
@@ -46,13 +59,27 @@ Result Variables
   :cmake:variable:`spdlog_BINARY_DIR` is set to the path to the build directory of  spdlog.
   :cmake:variable:`spdlog_ADDED`      is set to a true value if spdlog has not been added before.
   :cmake:variable:`spdlog_VERSION`    is set to the version of spdlog specified by the versions.json.
+  :cmake:variable:`spdlog_fmt_target` is set to the fmt target used, if used
 
 #]=======================================================================]
 function(rapids_cpm_spdlog)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.spdlog")
 
+  set(options)
+  set(one_value FMT_OPTION BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(multi_value)
+  cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  # Fix up _RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS as this is need for rapids_cpm_find
+  if(_RAPIDS_INSTALL_EXPORT_SET)
+    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
+  endif()
+  if(_RAPIDS_BUILD_EXPORT_SET)
+    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS BUILD_EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
+  endif()
+
   set(to_install OFF)
-  if(INSTALL_EXPORT_SET IN_LIST ARGN)
+  if(_RAPIDS_INSTALL_EXPORT_SET)
     set(to_install ON)
   endif()
 
@@ -62,12 +89,35 @@ function(rapids_cpm_spdlog)
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
   rapids_cpm_generate_patch_command(spdlog ${version} patch_command)
 
-  # Add fmt in the case where we need to fetch spdlog from source
-  include("${rapids-cmake-dir}/cpm/fmt.cmake")
-  rapids_cpm_fmt(BUILD_EXPORT_SET spdlog INSTALL_EXPORT_SET spdlog)
+  # If the option wasn't passed to the command, default to header only fmt
+  if(NOT _RAPIDS_FMT_OPTION)
+    set(_RAPIDS_FMT_OPTION "EXTERNAL_FMT_HO")
+  endif()
+
+  if("${_RAPIDS_FMT_OPTION}" STREQUAL "BUNDLED")
+    set(spdlog_fmt_option "")
+  elseif("${_RAPIDS_FMT_OPTION}" STREQUAL "EXTERNAL_FMT" OR "${_RAPIDS_FMT_OPTION}" STREQUAL
+                                                            "EXTERNAL_FMT_HO")
+    include("${rapids-cmake-dir}/cpm/fmt.cmake")
+
+    # Using `spdlog_ROOT` needs to cause any internal find calls in `spdlog-config.cmake` to first
+    # search beside it before looking globally.
+    list(APPEND fmt_ROOT ${spdlog_ROOT})
+
+    rapids_cpm_fmt(BUILD_EXPORT_SET spdlog INSTALL_EXPORT_SET spdlog)
+    set(spdlog_fmt_option "SPDLOG_${fmt_target_name} ON")
+    if("${_RAPIDS_FMT_OPTION}" STREQUAL "EXTERNAL_FMT")
+      set(spdlog_fmt_target fmt::fmt)
+    elseif("${_RAPIDS_FMT_OPTION}" STREQUAL "EXTERNAL_FMT_HO")
+      set(spdlog_fmt_target fmt::fmt-header-only)
+    endif()
+  else()
+    message(FATAL_ERROR "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO'"
+    )
+  endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(spdlog ${version} ${ARGN}
+  rapids_cpm_find(spdlog ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
@@ -75,7 +125,7 @@ function(rapids_cpm_spdlog)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_FMT_EXTERNAL_HO ON")
+                  OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(spdlog)
@@ -85,6 +135,7 @@ function(rapids_cpm_spdlog)
   set(spdlog_BINARY_DIR "${spdlog_BINARY_DIR}" PARENT_SCOPE)
   set(spdlog_ADDED "${spdlog_ADDED}" PARENT_SCOPE)
   set(spdlog_VERSION ${version} PARENT_SCOPE)
+  set(spdlog_fmt_target ${spdlog_fmt_target} PARENT_SCOPE)
 
   # spdlog creates the correct namespace aliases
 endfunction()

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -36,7 +36,7 @@ across all RAPIDS projects.
 
 ``FMT_OPTION``
   Spdlog depends on the fmt library and offers multiple ways of handling this dependency when spdlog is built. This
-  option only controls the behavior when spdlog is fetched and built, NOT when and installed spdlog is found on the
+  option only controls the behavior when spdlog is fetched and built, NOT when an installed spdlog is found on the
   system.
 
   This option can be set to one of three values: `BUNDLED`, `EXTERNAL_FMT`, or `EXTERNAL_FMT_HO`. If set to

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -62,6 +62,10 @@ function(rapids_cpm_spdlog)
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
   rapids_cpm_generate_patch_command(spdlog ${version} patch_command)
 
+  # Add fmt in the case where we need to fetch spdlog from source
+  include("${rapids-cmake-dir}/cpm/fmt.cmake")
+  rapids_cpm_fmt(BUILD_EXPORT_SET spdlog INSTALL_EXPORT_SET spdlog)
+
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(spdlog ${version} ${ARGN}
                   GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
@@ -71,7 +75,7 @@ function(rapids_cpm_spdlog)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "SPDLOG_INSTALL ${to_install}")
+                  OPTIONS "SPDLOG_INSTALL ${to_install}" "SPDLOG_FMT_EXTERNAL_HO ON")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(spdlog)

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -119,7 +119,7 @@ function(rapids_cpm_spdlog)
   elseif(_RAPIDS_FMT_OPTION STREQUAL "STD_FORMAT")
     set(spdlog_fmt_option "SPDLOG_USE_${_RAPIDS_FMT_OPTION} ON")
   else()
-    message(FATAL_ERROR "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO'"
+    message(FATAL_ERROR "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO', 'STD_FORMAT'"
     )
   endif()
 

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -48,7 +48,7 @@
       "git_tag" : "branch-${version}"
     },
     "spdlog" : {
-      "version" : "1.8.5",
+      "version" : "1.11.0",
       "git_url" : "https://github.com/gabime/spdlog.git",
       "git_tag" : "v${version}"
     },


### PR DESCRIPTION
## Description

Bumps spdlog to 1.11.0 and adds `fmt` as a dependency of spdlog and sets the `SPDLOG_FMT_EXTERNAL_HO` cmake option for spdlog. Happy to change that to be controlled by an argument to the `rapids_cpm_spdlog` function if desired. I believe the existing testing should cover the changes made here as the `spdlog` and `rmm` related tests were failing until adding `fmt` to the `spdlog` `BUILD_EXPORT_SET` and `INSTALL_EXPORT_SET`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
