### PR TITLE
Use trap to handle errors in test scripts

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -31,6 +31,7 @@ cd build
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
+
 ctest --schedule-random --output-on-failure
 
 rapids-logger "Test script exiting with value: $EXITCODE"

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -23,11 +23,15 @@ rapids-print-env
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+EXITCODE=0
+trap "EXITCODE=1" ERR
+set +e
+
 rapids-logger "Begin cpp tests"
 cmake -S testing -B build
 
 cd build
 ctest --schedule-random --output-on-failure
-exitcode=$?
 
-exit ${exitcode}
+rapids-logger "Test script exiting with value: $EXITCODE"
+exit ${EXITCODE}

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -23,14 +23,14 @@ rapids-print-env
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 rapids-logger "Begin cpp tests"
 cmake -S testing -B build
 
 cd build
+
+EXITCODE=0
+trap "EXITCODE=1" ERR
+set +e
 ctest --schedule-random --output-on-failure
 
 rapids-logger "Test script exiting with value: $EXITCODE"


### PR DESCRIPTION
This PR adds a less verbose [trap method](https://github.com/rapidsai/cugraph/blob/f2b081075704aabc789603e14ce552eac3fbe692/ci/test.sh#L19), for error handling to help ensure that we capture all potential error codes in our test scripts, and works as follows:

- setting an environment variable, EXITCODE, with a default value of 0
- setting a trap statement triggered by ERR signals which will set EXITCODE=1 when any commands return a non-zero exit code

cc @ajschmidt8