### PR TITLE
Update to latest nvbench

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,7 +31,7 @@
       "version" : "0.0",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
-      "git_tag" : "12d13bdc5e74801645eba3e46a64081b9b020dca"
+      "git_tag" : "e477bb386289a11ad8d7e358cff6527cfc593974"
     },
     "nvcomp" : {
       "version" : "2.6.1",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The changes involving spdlog and fmt have led to RAPIDS using a newer version of fmt while also avoiding using CPM when a conda package is preinstalled. Previously we were force downloading fmt for nvbench compatibility in cudf while using a separate version in spdlog via rmm. Now that we need to make these consistent, we need a version of nvbench that is compatible with the latest fmt. This PR bumps the nvbench hash past [my nvbench PR](https://github.com/NVIDIA/nvbench/pull/102) that includes the necessary compatibility changes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
