### PR TITLE
Support static builds of fmt

### DIFF
--- a/rapids-cmake/cpm/fmt.cmake
+++ b/rapids-cmake/cpm/fmt.cmake
@@ -71,7 +71,7 @@ function(rapids_cpm_fmt)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "FMT_INSTALL ${to_install}")
+                  OPTIONS "FMT_INSTALL ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(fmt)


### PR DESCRIPTION
## Description
By default `fmt` doesn't set the `POSITION_INDEPENDENT_CODE` value on targets when built statically. This causes link errors when the static library is consumed by a shared library.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
