### PR TITLE
Patch nvbench to allow usage of external fmt

### DIFF
--- a/rapids-cmake/cpm/patches/nvbench/use_existing_fmt.diff
+++ b/rapids-cmake/cpm/patches/nvbench/use_existing_fmt.diff
@@ -1,0 +1,12 @@
+diff --git a/cmake/NVBenchDependencies.cmake b/cmake/NVBenchDependencies.cmake
+index d0daa90..c058cbc 100644
+--- a/cmake/NVBenchDependencies.cmake
++++ b/cmake/NVBenchDependencies.cmake
+@@ -1,6 +1,7 @@
+ ################################################################################
+ # fmtlib/fmt
+ rapids_cpm_find(fmt 9.1.0
++  GLOBAL_TARGETS fmt fmt::fmt
+   CPM_ARGS
+     GITHUB_REPOSITORY fmtlib/fmt
+     GIT_TAG 9.1.0

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,7 +31,14 @@
       "version" : "0.0",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
-      "git_tag" : "e477bb386289a11ad8d7e358cff6527cfc593974"
+      "git_tag" : "e477bb386289a11ad8d7e358cff6527cfc593974",
+      "patches" : [
+        {
+          "file" : "nvbench/use_existing_fmt.diff",
+          "issue" : "Fix add support for using an existing fmt [https://github.com/NVIDIA/nvbench/pull/125]",
+          "fixed_in" : ""
+        }
+      ]
     },
     "nvcomp" : {
       "version" : "2.6.1",

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -62,6 +62,7 @@ add_cmake_config_test( cpm_libcudacxx-simple.cmake )
 
 add_cmake_config_test( cpm_nvbench-export.cmake )
 add_cmake_config_test( cpm_nvbench-simple.cmake )
+add_cmake_config_test( cpm_nvbench-already-found-fmt.cmake )
 
 add_cmake_config_test( cpm_nvcomp-export.cmake )
 add_cmake_config_test( cpm_nvcomp-proprietary-off.cmake )

--- a/testing/cpm/cpm_nvbench-already-found-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-already-found-fmt.cmake
@@ -1,0 +1,26 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/nvbench.cmake)
+
+# Fake bring in fmt via find package
+add_library(fmt::fmt INTERFACE IMPORTED GLOBAL)
+
+rapids_cpm_init()
+rapids_cpm_nvbench()
+if(fmt_ADDED)
+  message(FATAL_ERROR "fmt shouldn't be added if it exists via `find_package`")
+endif()


### PR DESCRIPTION
## Description
Patch nvbench to allow it to use an externally built fmt that was brought in via `find_package` instead of `cpm`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
