### PR TITLE
Update GHAs Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - "branch-*"
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true
@@ -29,16 +29,6 @@ jobs:
   cpp-build:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-build.yaml@branch-23.04
-    with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      repo: rapidsai/rapids-cmake
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-  upload-conda:
-    needs: cpp-build
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-upload-packages.yaml@branch-23.04
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       repo: rapidsai/rapids-cmake

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 name: nightly
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       branch:
         required: true
@@ -17,15 +17,6 @@ jobs:
   cpp-tests:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/conda-cpp-tests.yaml@branch-23.04
-    with:
-      build_type: nightly
-      repo: rapidsai/rapids-cmake
-      branch: ${{ inputs.branch }}
-      date: ${{ inputs.date }}
-      sha: ${{ inputs.sha }}
-  python-tests:
-    secrets: inherit
-    uses: rapidsai/shared-action-workflows/.github/workflows/conda-python-tests.yaml@branch-23.04
     with:
       build_type: nightly
       repo: rapidsai/rapids-cmake


### PR DESCRIPTION
This PR catches up `rapids-cmake` with some workflow changes that have been made to other repositories in the last few weeks.

The `workflow_call` => `workflow_dispatch` change is described in [this cudf PR](https://github.com/rapidsai/cudf/pull/12462).

The `upload-conda` job was removed from `build.yaml` since `rapids-cmake` currently doesn't upload any conda packages.

The `python-tests` job was removed from `test.yaml` since `rapids-cmake` doesn't have any Python tests.
