### PR TITLE
rapids_cpm_spdlog properly specify usage of external fmt library

### DIFF
--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -132,7 +132,7 @@ function(rapids_cpm_spdlog)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "SPDLOG_INSTALL ${to_install}" ${spdlog_fmt_option})
+                  OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(spdlog)

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -100,8 +100,20 @@ function(rapids_cpm_spdlog)
 
   if(_RAPIDS_FMT_OPTION STREQUAL "BUNDLED")
     set(spdlog_fmt_option "")
-  elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT" OR _RAPIDS_FMT_OPTION STREQUAL
-                                                       "EXTERNAL_FMT_HO")
+  elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT")
+    set(spdlog_fmt_option "SPDLOG_FMT_EXTERNAL ON")
+    set(spdlog_fmt_target fmt::fmt)
+  elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
+    set(spdlog_fmt_option "SPDLOG_FMT_EXTERNAL_HO ON")
+    set(spdlog_fmt_target fmt::fmt-header-only)
+  elseif(_RAPIDS_FMT_OPTION STREQUAL "STD_FORMAT")
+    set(spdlog_fmt_option "SPDLOG_USE_STD_FORMAT ON")
+  else()
+    message(FATAL_ERROR "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO', 'STD_FORMAT'"
+    )
+  endif()
+
+  if(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT" OR _RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
     include("${rapids-cmake-dir}/cpm/fmt.cmake")
 
     # Using `spdlog_ROOT` needs to cause any internal find calls in `spdlog-config.cmake` to first
@@ -109,18 +121,6 @@ function(rapids_cpm_spdlog)
     list(APPEND fmt_ROOT ${spdlog_ROOT})
 
     rapids_cpm_fmt(${_RAPIDS_UNPARSED_ARGUMENTS})
-
-    set(spdlog_fmt_option "SPDLOG_${_RAPIDS_FMT_OPTION} ON")
-    if(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT")
-      set(spdlog_fmt_target fmt::fmt)
-    elseif(_RAPIDS_FMT_OPTION STREQUAL "EXTERNAL_FMT_HO")
-      set(spdlog_fmt_target fmt::fmt-header-only)
-    endif()
-  elseif(_RAPIDS_FMT_OPTION STREQUAL "STD_FORMAT")
-    set(spdlog_fmt_option "SPDLOG_USE_${_RAPIDS_FMT_OPTION} ON")
-  else()
-    message(FATAL_ERROR "Invalid option used for FMT_OPTION, got: ${_RAPIDS_FMT_OPTION}, expected one of: 'BUNDLED', 'EXTERNAL_FMT', 'EXTERNAL_FMT_HO', 'STD_FORMAT'"
-    )
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
@@ -132,7 +132,7 @@ function(rapids_cpm_spdlog)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}")
+                  OPTIONS "SPDLOG_INSTALL ${to_install}" ${spdlog_fmt_option})
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(spdlog)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -74,6 +74,7 @@ add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake )
 add_cmake_config_test( cpm_rmm-export.cmake )
 add_cmake_config_test( cpm_rmm-simple.cmake )
 
+add_cmake_build_test( cpm_spdlog-external-fmt.cmake )
 add_cmake_config_test( cpm_spdlog-export.cmake )
 add_cmake_config_test( cpm_spdlog-simple.cmake )
 

--- a/testing/cpm/cpm_spdlog-external-fmt.cmake
+++ b/testing/cpm/cpm_spdlog-external-fmt.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/spdlog.cmake)
+
+enable_language(CXX)
+
+rapids_cpm_init()
+rapids_cpm_spdlog(FMT_OPTION "EXTERNAL_FMT_HO")
+
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/use_external_fmt.cpp" [=[
+
+#ifndef SPDLOG_FMT_EXTERNAL
+#error "SPDLOG_FMT_EXTERNAL not defined"
+#endif
+
+]=])
+
+add_library(spdlog_extern_fmt SHARED "${CMAKE_CURRENT_BINARY_DIR}/use_external_fmt.cpp")
+target_link_libraries(spdlog_extern_fmt PRIVATE spdlog::spdlog)
+
+add_library(spdlog-header-only_extern_fmt SHARED "${CMAKE_CURRENT_BINARY_DIR}/use_external_fmt.cpp")
+target_link_libraries(spdlog-header-only_extern_fmt PRIVATE spdlog::spdlog_header_only)


### PR DESCRIPTION
## Description
Previously we specified the wrong options for spdlog to use an the external fmt library. This caused spdlog to use the internal version while we had other non-spdlog components uses the upstream fmt.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
