### PR TITLE
rapids_cpm_nvbench properly specify usage of external fmt library

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -45,6 +45,7 @@ dependencies:
               cuda: "11.4"
             packages:
               - cudatoolkit=11.4
+              - gcc<11.0.0
           - matrix:
               cuda: "11.5"
             packages:

--- a/rapids-cmake/cpm/patches/nvbench/public_fmt_dep_in_conda.diff
+++ b/rapids-cmake/cpm/patches/nvbench/public_fmt_dep_in_conda.diff
@@ -1,0 +1,31 @@
+diff --git a/nvbench/CMakeLists.txt b/nvbench/CMakeLists.txt
+index f86bd41..ba6418f 100644
+--- a/nvbench/CMakeLists.txt
++++ b/nvbench/CMakeLists.txt
+@@ -76,10 +76,25 @@ target_link_libraries(nvbench
+   PUBLIC
+     ${ctk_libraries}
+   PRIVATE
+-    fmt::fmt
+     nvbench_json
+     nvbench_git_revision
+ )
++
++# ##################################################################################################
++# * conda environment -----------------------------------------------------------------------------
++rapids_cmake_support_conda_env(conda_env MODIFY_PREFIX_PATH)
++if(TARGET conda_env)
++  # When we are inside a conda env the linker will be set to
++  # `ld.bfd` which will try to resolve all undefined symbols at link time.
++  #
++  # Since we could be using a shared library version of fmt we need
++  # it on the final link line of consumers
++  target_link_libraries(nvbench PRIVATE $<BUILD_INTERFACE:conda_env>
++                        PUBLIC fmt::fmt)
++else()
++  target_link_libraries(nvbench PRIVATE fmt::fmt)
++endif()
++
+ target_compile_features(nvbench PUBLIC cuda_std_17 PRIVATE cxx_std_17)
+ add_dependencies(nvbench.all nvbench)
+ 

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -37,6 +37,11 @@
           "file" : "nvbench/use_existing_fmt.diff",
           "issue" : "Fix add support for using an existing fmt [https://github.com/NVIDIA/nvbench/pull/125]",
           "fixed_in" : ""
+        },
+        {
+          "file" : "nvbench/public_fmt_dep_in_conda.diff",
+          "issue" : "Propagate fmt requirement in conda envs [https://github.com/NVIDIA/nvbench/pull/127]",
+          "fixed_in" : ""
         }
       ]
     },

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -63,6 +63,7 @@ add_cmake_config_test( cpm_libcudacxx-simple.cmake )
 add_cmake_config_test( cpm_nvbench-export.cmake )
 add_cmake_config_test( cpm_nvbench-simple.cmake )
 add_cmake_config_test( cpm_nvbench-already-found-fmt.cmake )
+add_cmake_build_test( cpm_nvbench-conda-fmt.cmake )
 
 add_cmake_config_test( cpm_nvcomp-export.cmake )
 add_cmake_config_test( cpm_nvcomp-proprietary-off.cmake )

--- a/testing/cpm/cpm_nvbench-conda-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-conda-fmt.cmake
@@ -1,0 +1,53 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
+include(${rapids-cmake-dir}/cpm/nvbench.cmake)
+
+enable_language(CUDA)
+enable_language(CXX)
+
+include(${rapids-cmake-dir}/cuda/set_architectures.cmake)
+rapids_cuda_set_architectures(RAPIDS)
+
+# Force shared libs so that nvbench doesn't have a chance to use a static fmt
+set(BUILD_SHARED_LIBS ON)
+set(NVBench_ENABLE_CUPTI OFF)
+rapids_cpm_init()
+rapids_cpm_rmm()
+rapids_cpm_nvbench()
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/use_fmt.cpp" [=[
+#include <spdlog/spdlog.h>
+#include <nvbench/nvbench.cuh>
+
+template <typename Type>
+void nvbench_distinct(nvbench::state& state, nvbench::type_list<Type>)
+{
+}
+
+using data_type = nvbench::type_list<bool, int8_t, int32_t, int64_t, float>;
+
+NVBENCH_BENCH_TYPES(nvbench_distinct, NVBENCH_TYPE_AXES(data_type))
+  .set_name("distinct")
+  .set_type_axes_names({"Type"})
+  .add_int64_axis("NumRows", {10'000, 100'000, 1'000'000, 10'000'000});
+]=])
+
+
+add_library(uses_fmt SHARED "${CMAKE_CURRENT_BINARY_DIR}/use_fmt.cpp")
+target_link_libraries(uses_fmt PRIVATE rmm::rmm nvbench::nvbench nvbench::main)
+target_compile_features(uses_fmt PRIVATE cxx_std_17)

--- a/testing/cpm/cpm_nvbench-conda-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-conda-fmt.cmake
@@ -45,7 +45,7 @@ NVBENCH_BENCH_TYPES(nvbench_distinct, NVBENCH_TYPE_AXES(data_type))
   .set_name("distinct")
   .set_type_axes_names({"Type"})
   .add_int64_axis("NumRows", {10'000, 100'000, 1'000'000, 10'000'000});
-  
+
 int main() { return 0; }
 ]=])
 

--- a/testing/cpm/cpm_nvbench-conda-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-conda-fmt.cmake
@@ -45,9 +45,11 @@ NVBENCH_BENCH_TYPES(nvbench_distinct, NVBENCH_TYPE_AXES(data_type))
   .set_name("distinct")
   .set_type_axes_names({"Type"})
   .add_int64_axis("NumRows", {10'000, 100'000, 1'000'000, 10'000'000});
+  
+int main() { return 0; }
 ]=])
 
 
 add_library(uses_fmt SHARED "${CMAKE_CURRENT_BINARY_DIR}/use_fmt.cpp")
-target_link_libraries(uses_fmt PRIVATE rmm::rmm nvbench::nvbench nvbench::main)
+target_link_libraries(uses_fmt PRIVATE rmm::rmm nvbench::nvbench)
 target_compile_features(uses_fmt PRIVATE cxx_std_17)


### PR DESCRIPTION
## Description
When we are inside a conda env the linker will be set to ld.bfd which will try to resolve all undefined symbols at link time.

Since we could be using a shared library version of fmt we need it on the final link line of consumers. So patch nvbench to understand this requirement.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
