### PR TITLE
Introduce clang-format to rapids-cmake to format C++ code examples

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,155 @@
+---
+# Refer to the following link for the explanation of each params:
+#   http://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language: Cpp
+# BasedOnStyle: Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLambdasOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+# This is deprecated
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments:  false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:            false
+  AfterControlStatement: false
+  AfterEnum:             false
+  AfterFunction:         false
+  AfterNamespace:        false
+  AfterObjCDeclaration:  false
+  AfterStruct:           false
+  AfterUnion:            false
+  AfterExternBlock:      false
+  BeforeCatch:           false
+  BeforeElse:            false
+  IndentBraces:          false
+  # disabling the below splits, else, they'll just add to the vertical length of source files!
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# Kept the below 2 to be the same as `IndentWidth` to keep everything uniform
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+# Enabling comment reflow causes doxygen comments to be messed up in their formats!
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+# Be consistent with indent-width, even for people who use tab for indentation!
+TabWidth: 2
+UseTab: Never

--- a/testing/cmake/write_git_revision-custom-prefix/main.cpp
+++ b/testing/cmake/write_git_revision-custom-prefix/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-#include <type_traits>
 #include <demo_git_version.hpp>
 #include <nested_git_version.h>
+#include <type_traits>
 
 constexpr const char* dbranch = DEMO_GIT_BRANCH;
-constexpr const char* dsha1 = DEMO_GIT_SHA1;
-constexpr const char* dvers = DEMO_GIT_VERSION;
+constexpr const char* dsha1   = DEMO_GIT_SHA1;
+constexpr const char* dvers   = DEMO_GIT_VERSION;
 #if defined(DEMO_GIT_IS_DIRTY)
-  constexpr const bool disdirty = true;
+constexpr const bool disdirty = true;
 #else
-  constexpr const bool disdirty = false;
+constexpr const bool disdirty = false;
 #endif
 
 constexpr const char* nbranch = NESTED_GIT_BRANCH;
-constexpr const char* nsha1 = NESTED_GIT_SHA1;
-constexpr const char* nvers = DEMO_GIT_VERSION;
+constexpr const char* nsha1   = NESTED_GIT_SHA1;
+constexpr const char* nvers   = DEMO_GIT_VERSION;
 #if defined(NESTED_GIT_IS_DIRTY)
-  constexpr const bool nisdirty = true;
+constexpr const bool nisdirty = true;
 #else
-  constexpr const bool nisdirty = false;
+constexpr const bool nisdirty = false;
 #endif
 
 int main()

--- a/testing/cmake/write_git_revision-dirty/main.cpp
+++ b/testing/cmake/write_git_revision-dirty/main.cpp
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#include <type_traits>
-#include <iostream>
 #include <git_version.hpp>
+#include <iostream>
+#include <type_traits>
 
 int main()
 {
 #if defined(IS_DIRTY) && !defined(DEMO_GIT_IS_DIRTY)
-  # error "failed to encode dirty state correctly"
+#error "failed to encode dirty state correctly"
 #endif
 
 #if defined(DEMO_GIT_IS_DIRTY) && !defined(IS_DIRTY)
-  # error "failed to encode dirty state correctly"
+#error "failed to encode dirty state correctly"
 #endif
 
   return 0;

--- a/testing/cmake/write_git_revision-embed/main.cpp
+++ b/testing/cmake/write_git_revision-embed/main.cpp
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#include <type_traits>
-#include <iostream>
 #include <git_version.hpp>
+#include <iostream>
+#include <type_traits>
 
 constexpr const char* dbranch = "branch=" DEMO_GIT_BRANCH;
-constexpr const char* dsha1 = "sha1=" DEMO_GIT_SHA1;
-constexpr const char* dvers = "version=" DEMO_GIT_VERSION;
+constexpr const char* dsha1   = "sha1=" DEMO_GIT_SHA1;
+constexpr const char* dvers   = "version=" DEMO_GIT_VERSION;
 
 int main()
 {
-  std::cout <<  dbranch << std::endl;
-  std::cout <<  dsha1 << std::endl;
-  std::cout <<  dvers << std::endl;
+  std::cout << dbranch << std::endl;
+  std::cout << dsha1 << std::endl;
+  std::cout << dvers << std::endl;
   return 0;
 }

--- a/testing/cmake/write_git_revision-no-git/main.cpp
+++ b/testing/cmake/write_git_revision-no-git/main.cpp
@@ -1,5 +1,5 @@
- /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-#include <type_traits>
-#include <iostream>
 #include <git_version.hpp>
+#include <iostream>
+#include <type_traits>
 
 constexpr const char* dbranch = DEMO_GIT_BRANCH;
-constexpr const char* dsha1 = DEMO_GIT_SHA1;
-constexpr const char* dvers = DEMO_GIT_VERSION;
-
+constexpr const char* dsha1   = DEMO_GIT_SHA1;
+constexpr const char* dvers   = DEMO_GIT_VERSION;
 
 int main()
 {
@@ -29,9 +28,9 @@ int main()
   static_assert(dsha1 == "unknown");
   static_assert(dvers == "unknown");
 
-# ifdef DEMO_GIT_IS_DIRTY
-#   error "DEMO_GIT_IS_DIRTY define shouldn't exist as git shouldn't have been found"
-# endif
+#ifdef DEMO_GIT_IS_DIRTY
+#error "DEMO_GIT_IS_DIRTY define shouldn't exist as git shouldn't have been found"
+#endif
 
   return 0;
 }

--- a/testing/cmake/write_git_revision-simple/main.cpp
+++ b/testing/cmake/write_git_revision-simple/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-#include <type_traits>
 #include <demo_git_version.hpp>
 #include <nested_git_version.h>
+#include <type_traits>
 
 constexpr const char* dbranch = DEMO_GIT_BRANCH;
-constexpr const char* dsha1 = DEMO_GIT_SHA1;
-constexpr const char* dvers = DEMO_GIT_VERSION;
+constexpr const char* dsha1   = DEMO_GIT_SHA1;
+constexpr const char* dvers   = DEMO_GIT_VERSION;
 #if defined(DEMO_GIT_IS_DIRTY)
-  constexpr const bool disdirty = true;
+constexpr const bool disdirty = true;
 #else
-  constexpr const bool disdirty = false;
+constexpr const bool disdirty = false;
 #endif
 
 constexpr const char* nbranch = NESTED_GIT_BRANCH;
-constexpr const char* nsha1 = NESTED_GIT_SHA1;
-constexpr const char* nvers = DEMO_GIT_VERSION;
+constexpr const char* nsha1   = NESTED_GIT_SHA1;
+constexpr const char* nvers   = DEMO_GIT_VERSION;
 #if defined(NESTED_GIT_IS_DIRTY)
-  constexpr const bool nisdirty = true;
+constexpr const bool nisdirty = true;
 #else
-  constexpr const bool nisdirty = false;
+constexpr const bool nisdirty = false;
 #endif
 
 int main()

--- a/testing/cmake/write_version-absolute/main.cpp
+++ b/testing/cmake/write_version-absolute/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <type_traits>
 #include <demo/version.h>
 #include <nested/version.h>
+#include <type_traits>
 
 constexpr int dmajor = DEMO_VERSION_MAJOR;
 constexpr int dminor = DEMO_VERSION_MINOR;

--- a/testing/cmake/write_version-custom-prefix/main.cpp
+++ b/testing/cmake/write_version-custom-prefix/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <type_traits>
 #include <demo_version.hpp>
 #include <nested_version.hpp>
+#include <type_traits>
 
 constexpr int dmajor = DEMO_VERSION_MAJOR;
 constexpr int dminor = DEMO_VERSION_MINOR;

--- a/testing/cmake/write_version-relative/main.cpp
+++ b/testing/cmake/write_version-relative/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <type_traits>
 #include <demo_version.hpp>
 #include <nested_version.hpp>
+#include <type_traits>
 
 constexpr int dmajor = DEMO_VERSION_MAJOR;
 constexpr int dminor = DEMO_VERSION_MINOR;

--- a/testing/export/write_language-multiple-nested-enables/A/B/D/static.cu
+++ b/testing/export/write_language-multiple-nested-enables/A/B/D/static.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-
-static __global__ void example_cuda_kernel(int& r, int x, int y)
-{
-
-  r =  x * y + ( x * 4 - (y/2) );
-}
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
 
 int static_launch_kernelD(int x, int y)
 {

--- a/testing/export/write_language-multiple-nested-enables/A/C/static.cpp
+++ b/testing/export/write_language-multiple-nested-enables/A/C/static.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-int cpu_function(int x, int y)
-{
-  return x * y + ( x * 4 - (y/2) );
-}
+int cpu_function(int x, int y) { return x * y + (x * 4 - (y / 2)); }

--- a/testing/export/write_language-multiple-nested-enables/A/static.cu
+++ b/testing/export/write_language-multiple-nested-enables/A/static.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-
-static __global__ void example_cuda_kernel(int& r, int x, int y)
-{
-
-  r =  x * y + ( x * 4 - (y/2) );
-}
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
 
 int static_launch_kernelA(int x, int y)
 {

--- a/testing/export/write_language-multiple-nested-enables/main.cpp
+++ b/testing/export/write_language-multiple-nested-enables/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,16 @@ int static_launch_kernelB(int x, int y);
 int static_launch_kernelD(int x, int y);
 int cpu_function(int x, int y);
 
-int main(int argc, char **) {
-
+int main(int argc, char**)
+{
   auto resultA = static_launch_kernelA(3, argc);
   auto resultB = static_launch_kernelB(3, argc);
   auto resultC = cpu_function(3, argc);
   auto resultD = static_launch_kernelD(3, argc);
 
-  if (resultA != 6) {
-    return 1;
-  }
+  if (resultA != 6) { return 1; }
 
-  if ((resultA != resultB) || (resultA != resultC) || (resultA != resultD)) {
-    return 1;
-  }
+  if ((resultA != resultB) || (resultA != resultC) || (resultA != resultD)) { return 1; }
 
   return 0;
 }

--- a/testing/export/write_language-nested-dirs/A/B/static.cu
+++ b/testing/export/write_language-nested-dirs/A/B/static.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-
-static __global__ void example_cuda_kernel(int& r, int x, int y)
-{
-
-  r =  x * y + ( x * 4 - (y/2) );
-}
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
 
 int static_launch_kernelB(int x, int y)
 {

--- a/testing/export/write_language-nested-dirs/A/static.cu
+++ b/testing/export/write_language-nested-dirs/A/static.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-
-static __global__ void example_cuda_kernel(int& r, int x, int y)
-{
-
-  r =  x * y + ( x * 4 - (y/2) );
-}
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
 
 int static_launch_kernelA(int x, int y)
 {

--- a/testing/export/write_language-nested-dirs/main.cu
+++ b/testing/export/write_language-nested-dirs/main.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,10 @@
 int static_launch_kernelA(int x, int y);
 int static_launch_kernelB(int x, int y);
 
-int main(int argc, char **) {
-
+int main(int argc, char**)
+{
   auto resultA = static_launch_kernelA(3, argc);
   auto resultB = static_launch_kernelB(3, argc);
-  if (resultA != 6 && resultB != 6) {
-    return 1;
-  }
+  if (resultA != 6 && resultB != 6) { return 1; }
   return 0;
 }


### PR DESCRIPTION
## Description
In preparation of more C++ code being added to rapids-cmake introduce a .clang-format file to the project to keep everything with a consistent style and formatting.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
