### PR TITLE
Make docs builds less verbose

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -26,6 +26,7 @@ popd
 
 
 if [[ ${RAPIDS_BUILD_TYPE} == "branch" ]]; then
+  rapids-logger "Upload Docs to S3"
   aws s3 sync --delete docs/_html "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/html"
   aws s3 sync --delete docs/_text "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/txt"
 fi

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -27,6 +27,6 @@ popd
 
 if [[ ${RAPIDS_BUILD_TYPE} == "branch" ]]; then
   rapids-logger "Upload Docs to S3"
-  aws s3 sync --delete docs/_html "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/html"
-  aws s3 sync --delete docs/_text "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/txt"
+  aws s3 sync --no-progress --delete docs/_html "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/html"
+  aws s3 sync --no-progress --delete docs/_text "s3://rapidsai-docs/rapids-cmake/${VERSION_NUMBER}/txt"
 fi


### PR DESCRIPTION
This PR adds the `--no-progress` flag to reduce verbose output from the `s3 sync` commands.