### PR TITLE
support_conda_env only add rpath-link flag to linkers that support it.

### DIFF
--- a/rapids-cmake/cmake/support_conda_env.cmake
+++ b/rapids-cmake/cmake/support_conda_env.cmake
@@ -78,10 +78,14 @@ function(rapids_cmake_support_conda_env target)
       target_include_directories(${target} INTERFACE "$ENV{PREFIX}/include"
                                                      "$ENV{BUILD_PREFIX}/include")
       target_link_directories(${target} INTERFACE "$ENV{PREFIX}/lib" "$ENV{BUILD_PREFIX}/lib")
-      target_link_options(${target} INTERFACE
-                          "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{PREFIX}/lib>")
-      target_link_options(${target} INTERFACE
-                          "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{BUILD_PREFIX}/lib>")
+
+      if(DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG
+         OR DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CXX_FLAG)
+        target_link_options(${target} INTERFACE
+                            "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{PREFIX}/lib>")
+        target_link_options(${target} INTERFACE
+                            "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{BUILD_PREFIX}/lib>")
+      endif()
 
       if(modify_prefix_path)
         list(PREPEND CMAKE_PREFIX_PATH "$ENV{PREFIX}" "$ENV{BUILD_PREFIX}")
@@ -92,8 +96,11 @@ function(rapids_cmake_support_conda_env target)
     elseif(in_conda_prefix)
       target_include_directories(${target} INTERFACE "$ENV{CONDA_PREFIX}/include")
       target_link_directories(${target} INTERFACE "$ENV{CONDA_PREFIX}/lib")
-      target_link_options(${target} INTERFACE
-                          "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{CONDA_PREFIX}/lib>")
+      if(DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG
+         OR DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CXX_FLAG)
+        target_link_options(${target} INTERFACE
+                            "$<HOST_LINK:SHELL:LINKER:-rpath-link=$ENV{CONDA_PREFIX}/lib>")
+      endif()
 
       if(modify_prefix_path)
         list(PREPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")


### PR DESCRIPTION
## Description
Fixes #383

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
