### PR TITLE
install_relocatable generate correct installed RESOURCE_SPEC_FILE

### DIFF
--- a/rapids-cmake/test/install_relocatable.cmake
+++ b/rapids-cmake/test/install_relocatable.cmake
@@ -75,7 +75,7 @@ function(rapids_test_install_relocatable)
       "
   set(CTEST_SCRIPT_DIRECTORY \".\")
   set(CTEST_RESOURCE_SPEC_FILE \"./${rapids_test_json_file_name}\")
-  execute_process(COMMAND ./${rapids_test_generate_exe_name} OUTPUT_FILE \"${CTEST_RESOURCE_SPEC_FILE}\")
+  execute_process(COMMAND ./${rapids_test_generate_exe_name} OUTPUT_FILE \"\${CTEST_RESOURCE_SPEC_FILE}\")
   ")
 
   foreach(test IN LISTS tests_to_run)

--- a/testing/test/install_relocatable-simple.cmake
+++ b/testing/test/install_relocatable-simple.cmake
@@ -29,6 +29,11 @@ rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing
 set(generated_testfile "${CMAKE_CURRENT_BINARY_DIR}/rapids-cmake/testing/CTestTestfile.cmake.to_install")
 file(READ "${generated_testfile}" contents)
 
+set(execute_process_match_string [===[execute_process(COMMAND ./generate_ctest_json OUTPUT_FILE "${CTEST_RESOURCE_SPEC_FILE}")]===])
+string(FIND "${contents}" ${execute_process_match_string} is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "Failed to generate a `execute_process` with escaped CTEST_RESOURCE_SPEC_FILE")
+endif()
 
 set(add_test_match_strings [===[add_test([=[verify_]=] cmake;-Dcommand_to_run=ls;-Dcommand_args=;-P;./run_gpu_test.cmake)]===])
 foreach(item IN LISTS add_test_match_strings)


### PR DESCRIPTION
## Description
Correct an error where we evaluated the build directory version of `CTEST_RESOURCE_SPEC_FILE` instead of using the installed version value.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
