### PR TITLE
rapids_test_install_relocatable EXCLUDE_FROM_ALL is now the default

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -346,7 +346,7 @@
       "rapids_test_install_relocatable": {
         "pargs": {
           "nargs": "0",
-          "flags": ["EXCLUDE_FROM_ALL"]
+          "flags": ["INCLUDE_IN_ALL"]
         },
         "kwargs": {
           "INSTALL_COMPONENT_SET": "1",

--- a/rapids-cmake/test/install_relocatable.cmake
+++ b/rapids-cmake/test/install_relocatable.cmake
@@ -28,7 +28,7 @@ by `ctest` in parallel with GPU awareness.
 
     rapids_test_install_relocatable(INSTALL_COMPONENT_SET <component>
                                     DESTINATION <relative_path>
-                                    [EXCLUDE_FROM_ALL])
+                                    [INCLUDE_IN_ALL])
 
 Will install all tests created by :cmake:command:`rapids_test_add` that are
 part of the provided ``INSTALL_COMPONENT_SET``.
@@ -43,23 +43,22 @@ arguments provided to the tests are machine independent (no absolute paths).
   Relative path from the `CMAKE_INSTALL_PREFIX` to install the infrastructure.
   This needs to be the same directory as the test executables
 
-``EXCLUDE_FROM_ALL``
-  State that these install rules shouldn't be part of the default install set, and
-  instead must be explicitly installed.
-
+``INCLUDE_IN_ALL``
+  State that these install rules should be part of the default install set.
+  By default tests are not part of the default install set.
 
 #]=======================================================================]
 function(rapids_test_install_relocatable)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.test.install_relocatable")
 
-  set(options EXCLUDE_FROM_ALL)
+  set(options INCLUDE_IN_ALL)
   set(one_value INSTALL_COMPONENT_SET DESTINATION)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
-  set(to_exclude)
-  if(_RAPIDS_TEST_EXCLUDE_FROM_ALL)
-    set(to_exclude EXCLUDE_FROM_ALL)
+  set(to_exclude EXCLUDE_FROM_ALL)
+  if(_RAPIDS_TEST_INCLUDE_IN_ALL)
+    set(to_exclude)
   endif()
 
   set(component ${_RAPIDS_TEST_INSTALL_COMPONENT_SET})

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -39,7 +39,8 @@ add_cmake_config_test(init-existing-specfile.cmake)
 add_cmake_config_test(init-simple.cmake)
 
 set(wrong_component_message "No install component set [wrong_component] can be found")
-add_cmake_config_test(install_relocatable-labels.cmake)
+add_cmake_build_test(install_relocatable-include-in-all.cmake)
+add_cmake_build_test(install_relocatable-labels.cmake)
 add_cmake_config_test(install_relocatable-simple.cmake)
 add_cmake_config_test(install_relocatable-wrong-component.cmake SHOULD_FAIL "${wrong_component_message}")
 

--- a/testing/test/install_relocatable-include-in-all.cmake
+++ b/testing/test/install_relocatable-include-in-all.cmake
@@ -23,7 +23,8 @@ rapids_test_init()
 rapids_test_add(NAME verify_ COMMAND ls GPUS 1 INSTALL_COMPONENT_SET testing)
 
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing
-                                DESTINATION bin/testing)
+                                DESTINATION bin/testing
+                                INCLUDE_IN_ALL)
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/verify_cmake_install.cmake"
 "set(install_rules_file \"${CMAKE_CURRENT_BINARY_DIR}/cmake_install.cmake\")")
@@ -32,7 +33,7 @@ file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/verify_cmake_install.cmake"
 [=[
 
 file(READ "${install_rules_file}" contents)
-set(exclude_from_all_string [===[if(CMAKE_INSTALL_COMPONENT STREQUAL "testing")]===])
+set(exclude_from_all_string [===[if(CMAKE_INSTALL_COMPONENT STREQUAL "testing" OR NOT CMAKE_INSTALL_COMPONENT)]===])
 string(FIND "${contents}" ${exclude_from_all_string} is_found)
 if(is_found EQUAL -1)
   message(FATAL_ERROR "`rapids_test_install_relocatable` failed to mark items as EXCLUDE_FROM_ALL")
@@ -48,18 +49,4 @@ set(execute_process_match_string [===[execute_process(COMMAND ./generate_ctest_j
 string(FIND "${contents}" ${execute_process_match_string} is_found)
 if(is_found EQUAL -1)
   message(FATAL_ERROR "Failed to generate a `execute_process` with escaped CTEST_RESOURCE_SPEC_FILE")
-endif()
-
-set(add_test_match_strings [===[add_test([=[verify_]=] cmake;-Dcommand_to_run=ls;-Dcommand_args=;-P;./run_gpu_test.cmake)]===])
-foreach(item IN LISTS add_test_match_strings)
-  string(FIND "${contents}" ${item} is_found)
-  if(is_found EQUAL -1)
-    message(FATAL_ERROR "Failed to generate an installed `add_test` for verify_")
-  endif()
-endforeach()
-
-set(properties_match_string [===[PROPERTIES RESOURCE_GROUPS 1,gpus:100]===])
-string(FIND "${contents}" ${properties_match_string} is_found)
-if(is_found EQUAL -1)
-  message(FATAL_ERROR "Failed to generate an installed `GPU` requirements for verify_")
 endif()

--- a/testing/test/install_relocatable-wrong-component.cmake
+++ b/testing/test/install_relocatable-wrong-component.cmake
@@ -22,5 +22,4 @@ rapids_test_init()
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET wrong_component
                                 DESTINATION bin/testing)
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET another_wrong_component
-                                DESTINATION bin/testing
-                                EXCLUDE_FROM_ALL)
+                                DESTINATION bin/testing)


### PR DESCRIPTION
## Description
Provides better default behavior to `rapids_test_install_relocatable` so that projects don't install test files all the time.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
