### PR TITLE
Add `COMPONENT` arguments for rapids_export to formatting file.

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -218,6 +218,8 @@
           "FINAL_CODE_BLOCK": 1,
           "VERSION": 1,
           "GLOBAL_TARGETS": "+",
+          "COMPONENTS": "+",
+          "COMPONENTS_EXPORT_SET": "+",
           "LANGUAGES": "+"
         }
       },


### PR DESCRIPTION
## Description
Update the cmake-format-rapids-cmake.json with the new `COMPONENTS` and `COMPONENTS_EXPORT_SET` arguments.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The `cmake-format.json` is up to date with these changes.
