### PR TITLE
rapids_test_install_relocatable tracks tests environment properties

### DIFF
--- a/rapids-cmake/test/install_relocatable.cmake
+++ b/rapids-cmake/test/install_relocatable.cmake
@@ -79,16 +79,16 @@ function(rapids_test_install_relocatable)
 
   foreach(test IN LISTS tests_to_run)
     get_test_property(${test} INSTALL_COMMAND command)
-    get_test_property(${test} RESOURCE_GROUPS resources)
-    get_test_property(${test} LABELS labels)
     string(APPEND content "add_test([=[${test}]=] ${command})\n")
-    if(resources)
-      string(APPEND content
-             "set_tests_properties([=[${test}]=] PROPERTIES RESOURCE_GROUPS ${resources})\n")
-    endif()
-    if(labels)
-      string(APPEND content "set_tests_properties([=[${test}]=] PROPERTIES LABELS ${labels})\n")
-    endif()
+
+    set(properties_to_record ENVIRONMENT ENVIRONMENT_MODIFICATION RESOURCE_GROUPS LABELS)
+    foreach(prop_name IN LISTS properties_to_record)
+      get_test_property(${test} ${prop_name} prop_value)
+      if(prop_value)
+        string(APPEND content
+               "set_tests_properties([=[${test}]=] PROPERTIES ${prop_name} ${prop_value})\n")
+      endif()
+    endforeach()
   endforeach()
 
   set(test_launcher_file

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_cmake_config_test(init-simple.cmake)
 
 set(wrong_component_message "No install component set [wrong_component] can be found")
 add_cmake_build_test(install_relocatable-include-in-all.cmake)
+add_cmake_build_test(install_relocatable-env-vars.cmake)
 add_cmake_build_test(install_relocatable-labels.cmake)
 add_cmake_config_test(install_relocatable-simple.cmake)
 add_cmake_config_test(install_relocatable-wrong-component.cmake SHOULD_FAIL "${wrong_component_message}")

--- a/testing/test/install_relocatable-env-vars.cmake
+++ b/testing/test/install_relocatable-env-vars.cmake
@@ -1,0 +1,43 @@
+#=============================================================================
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/test/init.cmake)
+include(${rapids-cmake-dir}/test/add.cmake)
+include(${rapids-cmake-dir}/test/install_relocatable.cmake)
+
+enable_language(CUDA)
+rapids_test_init()
+
+rapids_test_add(NAME verify_env COMMAND env GPUS 1 INSTALL_COMPONENT_SET testing)
+set_tests_properties(verify_env PROPERTIES ENVIRONMENT "MYVAR=my_value")
+set_tests_properties(verify_env PROPERTIES ENVIRONMENT_MODIFICATION "PATH=path_list_append:/fake/path")
+
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing
+                                DESTINATION bin/testing)
+
+set(generated_testfile "${CMAKE_CURRENT_BINARY_DIR}/rapids-cmake/testing/CTestTestfile.cmake.to_install")
+file(READ "${generated_testfile}" contents)
+
+set(env_match_string [===[PROPERTIES ENVIRONMENT MYVAR=my_value]===])
+string(FIND "${contents}" "${env_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "Failed to record the ENVIRONMENT property")
+endif()
+
+set(env_mod_match_string [===[PROPERTIES ENVIRONMENT_MODIFICATION PATH=path_list_append:/fake/path]===])
+string(FIND "${contents}" "${env_mod_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "Failed to record the ENVIRONMENT_MODIFICATION property")
+endif()


### PR DESCRIPTION
## Description
Will allow projects to specify env variables on tests and have those recorded on the installed tests

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
