### PR TITLE
Define Cython language_level explicitly.

### DIFF
--- a/rapids-cmake/cython/init.cmake
+++ b/rapids-cmake/cython/init.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -57,7 +57,9 @@ macro(rapids_cython_init)
     include("${rapids-cmake-dir}/cython/detail/skbuild_patches.cmake")
 
     if(NOT CYTHON_FLAGS)
-      set(CYTHON_FLAGS "--directive binding=True,embedsignature=True,always_allow_keywords=True")
+      set(CYTHON_FLAGS
+          "--directive always_allow_keywords=True,binding=True,embedsignature=True,language_level=3str"
+      )
     endif()
 
     # Flag


### PR DESCRIPTION
## Description
I saw some warnings while building cudf with Cython 3.0b1 that could be fixed by specifying the language level as the default value (`3str`). Since we only care about one language level (`3str`) in RAPIDS projects, we can specify that directive.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
