### PR TITLE
Update clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
             ^rapids-cmake/cpm/patches/.*
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v11.1.0
+    rev: v16.0.1
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]


### PR DESCRIPTION
This PR updates the clang-format version used by pre-commit.
