### PR TITLE
Correct basics to api cross refs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,7 @@
 API Reference
 #############
 
+.. _`common`:
 
 Common
 ******
@@ -18,6 +19,8 @@ require.
    /command/rapids_cmake_support_conda_env
    /command/rapids_cmake_write_git_revision_file
    /command/rapids_cmake_write_version_file
+
+.. _`cpm`:
 
 CPM
 ***
@@ -56,6 +59,8 @@ package uses :ref:`can be found here. <cpm_versions>`
    /packages/rapids_cpm_thrust
    /command/rapids_cpm_package_override
 
+.. _`cython`:
+
 Cython
 ******
 
@@ -74,6 +79,8 @@ The `rapids_cython` functions allow projects to easily build cython modules usin
    /command/rapids_cython_add_rpath_entries
 
 
+.. _`find`:
+
 Find
 ****
 
@@ -85,6 +92,8 @@ tracking of these dependencies for correct export support.
 
    /command/rapids_find_generate_module
    /command/rapids_find_package
+
+.. _`cuda`:
 
 CUDA
 ****
@@ -100,6 +109,8 @@ require.
     rapids_cuda_patch_toolkit </command/rapids_cuda_patch_toolkit>
     rapids_cuda_set_architectures [Advanced] </command/rapids_cuda_set_architectures>
 
+
+.. _`export`:
 
 Export Set Generation
 *********************
@@ -133,6 +144,8 @@ correct export generation. These should only be used when :cmake:command:`rapids
    rapids_export_find_package_file [Advanced] </command/rapids_export_find_package_file>
    rapids_export_find_package_root [Advanced] </command/rapids_export_find_package_root>
    rapids_export_package [Advanced] </command/rapids_export_package>
+
+.. _`testing`:
 
 Testing
 *******

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -33,9 +33,11 @@ this `rapids-cmake` comprises the following primary components:
 
 - `cmake <api.html#common>`__
 - `cpm <api.html#cpm>`__
+- `cython <api.html#cython>`__
 - `cuda <api.html#cuda>`__
 - `export <api.html#export>`__
 - `find <api.html#find>`__
+- `testing <api.html#testing>`__
 
 There are two ways projects can use ``rapids-cmake`` functions.
 


### PR DESCRIPTION
## Description
Correct some 404 links on the `basics.html` page and also quick links for cython and testing.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.