### PR TITLE
Update cuco git tag to fetch several bug fixes

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -5,7 +5,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "d1ae9094b7e25afa20520301b494ef41f3afd62f"
+      "git_tag" : "a371904f50a0553346407f163a9ad14275d2aee9"
     },
     "fmt" : {
       "version" : "9.1.0",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -5,7 +5,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "a371904f50a0553346407f163a9ad14275d2aee9"
+      "git_tag" : "546ca606a17f480fa9d58d1752cce2aad6575bc4"
     },
     "fmt" : {
       "version" : "9.1.0",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -5,7 +5,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "31e1d5df6869ef6cb60f36a614b30a244cf3bd78"
+      "git_tag" : "d1ae9094b7e25afa20520301b494ef41f3afd62f"
     },
     "fmt" : {
       "version" : "9.1.0",


### PR DESCRIPTION
## Description
This is a follow-up PR of #407. It fetches the latest cuco that fixes several bugs uncovered during libcudf integration.

https://github.com/rapidsai/cudf/pull/13343 verified this won't break cudf.
 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
