### PR TITLE
rapids_find_generate_module Support user code blocks

### DIFF
--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -120,7 +120,7 @@ Result Variables
   folder where `Find<PackageName>.cmake` is located.
 
 
-Example on how to properly use :cmake:command:`rapids_generate_module`:
+Example on how to properly use :cmake:command:`rapids_find_generate_module`:
 
 .. code-block:: cmake
 

--- a/rapids-cmake/find/template/find_module.cmake.in
+++ b/rapids-cmake/find/template/find_module.cmake.in
@@ -45,6 +45,9 @@ This module will set the following variables in your project:
 #]=======================================================================]
 
 # Prefer using a Config module if it exists for this project
+
+@_RAPIDS_FIND_INITIAL_CODE_BLOCK@
+
 set(@_RAPIDS_PKG_NAME@_NO_CONFIG @_RAPIDS_NO_CONFIG@)
 if(NOT @_RAPIDS_PKG_NAME@_NO_CONFIG)
   find_package(@_RAPIDS_PKG_NAME@ CONFIG QUIET)
@@ -112,6 +115,8 @@ if(@_RAPIDS_PKG_NAME@_FOUND)
     endif()
   endif()
 endif()
+
+@_RAPIDS_FIND_FINAL_CODE_BLOCK@
 
 unset(@_RAPIDS_PKG_NAME@_NO_CONFIG)
 unset(@_RAPIDS_PKG_NAME@_IS_HEADER_ONLY)

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,3 +40,7 @@ add_cmake_config_test( find_package-version-required-explicit-failed.cmake SHOUL
 add_cmake_config_test( find_generate_module-build )
 add_cmake_config_test( find_generate_module-install )
 add_cmake_config_test( find_generate_module-header-only )
+
+add_cmake_config_test( find_generate_module-code-blocks )
+add_cmake_config_test( find_generate_module-back-initial-code-block-var.cmake SHOULD_FAIL "INITIAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
+add_cmake_config_test( find_generate_module-back-final-code-block-var.cmake SHOULD_FAIL "FINAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")

--- a/testing/find/find_generate_module-back-final-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-final-code-block-var.cmake
@@ -1,0 +1,22 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/generate_module.cmake)
+
+rapids_find_generate_module( RapidsTest
+    HEADER_NAMES rapids-cmake-test-header_only.hpp
+    FINAL_CODE_BLOCK   var_doesn't_exist
+    INSTALL_EXPORT_SET test_set
+    )

--- a/testing/find/find_generate_module-back-initial-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-initial-code-block-var.cmake
@@ -1,0 +1,22 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/generate_module.cmake)
+
+rapids_find_generate_module( RapidsTest
+    HEADER_NAMES rapids-cmake-test-header_only.hpp
+    INITIAL_CODE_BLOCK   var_doesn't_exist
+    INSTALL_EXPORT_SET test_set
+    )

--- a/testing/find/find_generate_module-code-blocks/CMakeLists.txt
+++ b/testing/find/find_generate_module-code-blocks/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/find/generate_module.cmake)
+
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-test-project LANGUAGES CXX)
+
+set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# Generate the find module
+set(initial_code_block [[set(RapidsTest_INITIAL_CODE_BLOCK TRUE)]])
+set(final_code_block [[set(RapidsTest_FINAL_CODE_BLOCK TRUE)]])
+rapids_find_generate_module( RapidsTest
+    HEADER_NAMES rapids-cmake-test-header_only.hpp
+    INITIAL_CODE_BLOCK initial_code_block
+    FINAL_CODE_BLOCK   final_code_block
+    INSTALL_EXPORT_SET test_set
+    )
+
+find_package(RapidsTest REQUIRED)
+
+if(NOT RapidsTest_INITIAL_CODE_BLOCK)
+  message(FATAL_ERROR "RapidsTest_FOUND should be set to TRUE")
+endif()
+if(NOT RapidsTest_FINAL_CODE_BLOCK)
+  message(FATAL_ERROR "RAPIDSTEST_FOUND should be set to TRUE")
+endif()


### PR DESCRIPTION
## Description
At times people need to have custom code blocks in a find module. This offers the ability to have a pre-amble or post-able to handle all use cases.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [x] I have added new files under rapids-cmake/
   - [x] I have added include guards (`include_guard(GLOBAL)`)
   - [x] I have added the associated docs/ rst file and update the api.rst
