### PR TITLE
Correct install_relocatable issues found by libcudf

### DIFF
--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -157,7 +157,7 @@ function(set_tests_properties name)
       set(prop_value "${_RAPIDS_TEST_${prop}}")
       find_and_convert_paths_from_var_list(prop_value)
       string(APPEND test_prop_content
-             "set_tests_properties([=[${name}]=] PROPERTIES ${prop} ${prop_value})\n")
+             "set_tests_properties([=[${name}]=] PROPERTIES ${prop} \"${prop_value}\")\n")
     endif()
   endforeach()
 
@@ -210,7 +210,7 @@ endfunction()
 #
 # Find all the cmake_install.cmake files in the install directory and parse them for install rules
 function(determine_install_location_of_all_targets)
-  file(GLOB_RECURSE install_rule_files "${_RAPIDS_BUILD_DIR}/cmake_install.cmake")
+  file(GLOB_RECURSE install_rule_files "${_RAPIDS_PROJECT_DIR}/cmake_install.cmake")
   foreach(file IN LISTS install_rule_files)
     file(STRINGS "${file}" contents REGEX "INSTALL DESTINATION")
     foreach(line IN LISTS contents)

--- a/rapids-cmake/test/install_relocatable.cmake
+++ b/rapids-cmake/test/install_relocatable.cmake
@@ -48,6 +48,10 @@ the install directory.
   State that these install rules should be part of the default install set.
   By default tests are not part of the default install set.
 
+.. note::
+  rapids_test_install_relocatable behavior is undefined when used with
+  multi-config generators such as "Visual Studio" and "Ninja Multi-Config"
+
 #]=======================================================================]
 function(rapids_test_install_relocatable)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.test.install_relocatable")
@@ -80,7 +84,7 @@ function(rapids_test_install_relocatable)
     set(_RAPIDS_TEST_DESTINATION \"${_RAPIDS_TEST_DESTINATION}\")
     set(_RAPIDS_INSTALL_PREFIX \"${from_install_prefix}\")
     set(_RAPIDS_BUILD_DIR \"${CMAKE_CURRENT_BINARY_DIR}\")
-    set(_RAPIDS_PROJECT_DIR \"${PROJECT_BINARY_DIR}\")
+    set(_RAPIDS_PROJECT_DIR \"${CMAKE_BINARY_DIR}\")
     set(_RAPIDS_INSTALL_COMPONENT_SET \"${_RAPIDS_TEST_INSTALL_COMPONENT_SET}\")
     set(_RAPIDS_TARGETS_INSTALLED \"${targets_to_install}\")
     set(_RAPIDS_TESTS_TO_RUN \"${tests_to_run}\")

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -43,6 +43,7 @@ add_cmake_build_test(install_relocatable-include-in-all.cmake)
 add_cmake_build_test(install_relocatable-labels.cmake)
 add_cmake_build_test(install_relocatable-no-tests.cmake)
 add_cmake_build_test(install_relocatable-simple.cmake)
+add_cmake_build_test(install_relocatable-complex)
 add_cmake_config_test(install_relocatable-wrong-component.cmake SHOULD_FAIL "${wrong_component_message}")
 
 add_cmake_ctest_test(add-impossible-allocation SHOULD_FAIL "Insufficient resources for test")

--- a/testing/test/install_relocatable-complex/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/CMakeLists.txt
@@ -1,0 +1,25 @@
+#=============================================================================
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+set(CMAKE_CONFIGURATION_TYPES Debug)
+project(rapids-test-project LANGUAGES CUDA)
+
+include(${rapids-cmake-dir}/rapids-test.cmake)
+
+add_library(preload SHARED usage.cu)
+add_subdirectory(tests)
+
+install(TARGETS preload DESTINATION lib)

--- a/testing/test/install_relocatable-complex/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/test/install_relocatable-complex/tests/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/tests/CMakeLists.txt
@@ -1,0 +1,61 @@
+#=============================================================================
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+include(${rapids-cmake-dir}/rapids-test.cmake)
+
+enable_testing()
+rapids_test_init()
+
+rapids_test_add(NAME verify_ COMMAND ls GPUS 1 INSTALL_COMPONENT_SET testing)
+set_tests_properties(
+    verify_
+    PROPERTIES
+      ENVIRONMENT
+      "STREAM_MODE=new_mode;LD_PRELOAD=$<TARGET_FILE:preload>"
+  )
+
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing
+                                DESTINATION bin/testing
+                                INCLUDE_IN_ALL)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/verify_installed_CTestTestfile.cmake"
+  "set(installed_test_file \"${CMAKE_CURRENT_BINARY_DIR}/install/bin/testing/CTestTestfile.cmake\")")
+file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/verify_installed_CTestTestfile.cmake"
+[==[
+
+file(READ "${installed_test_file}" contents)
+set(execute_process_match_string [===[execute_process(COMMAND ./generate_ctest_json OUTPUT_FILE "${CTEST_RESOURCE_SPEC_FILE}")]===])
+string(FIND "${contents}" ${execute_process_match_string} is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "Failed to generate a `execute_process` with escaped CTEST_RESOURCE_SPEC_FILE")
+endif()
+
+set(properties_match_strings [===[PROPERTIES ENVIRONMENT "STREAM_MODE]===]
+                             [===[LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libpreload]===])
+foreach(to_match IN LISTS properties_match_strings)
+  string(FIND "${contents}" ${to_match} is_found)
+  if(is_found EQUAL -1)
+    message(FATAL_ERROR "${contents}\nFailed to generate a proper set of test properties")
+  endif()
+endforeach()
+]==])
+
+add_custom_target(install_testing_component ALL
+  COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix install/ --config Debug
+  COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/verify_installed_CTestTestfile.cmake"
+  )
+
+add_dependencies(install_testing_component preload)

--- a/testing/test/install_relocatable-complex/tests/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
https://github.com/rapidsai/cudf/pull/13513 found 2 issues in the `install_relocatable` logic that caused LD_PRELOAD setup to fail. This PR corrects those two issues:

1. The `ENVIRONMENT` value always needs to be quoted to properly support multiple variables to be set
2. We need to scan for all `cmake_install.cmake` starting from the root build directory

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
