### PR TITLE
Fix google benchmark name and update version

### DIFF
--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -33,7 +33,7 @@ across all RAPIDS projects.
                      [INSTALL_EXPORT_SET <export-name>]
                      [<CPM_ARGS> ...])
 
-.. |PKG_NAME| replace:: Google benchmark
+.. |PKG_NAME| replace:: benchmark
 .. include:: common_package_args.txt
 
 Result Targets

--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ rapids_cpm_gbench
 
 .. versionadded:: v22.12.00
 
-Allow projects to find or build `Google Benchmark` via `CPM` with built-in
+Allow projects to find or build Google Benchmark via `CPM` with built-in
 tracking of these dependencies for correct export support.
 
-Uses the version of GBench :ref:`specified in the version file <cpm_versions>` for consistency
+Uses the version of Google benchmark :ref:`specified in the version file <cpm_versions>` for consistency
 across all RAPIDS projects.
 
 .. code-block:: cmake
@@ -33,7 +33,7 @@ across all RAPIDS projects.
                      [INSTALL_EXPORT_SET <export-name>]
                      [<CPM_ARGS> ...])
 
-.. |PKG_NAME| replace:: GBench
+.. |PKG_NAME| replace:: Google benchmark
 .. include:: common_package_args.txt
 
 Result Targets
@@ -50,16 +50,16 @@ function(rapids_cpm_gbench)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(GBench version repository tag shallow exclude)
+  rapids_cpm_package_details(benchmark version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(GBench ${version} patch_command)
+  rapids_cpm_generate_patch_command(benchmark ${version} patch_command)
 
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(GBench ${version} ${ARGN}
+  rapids_cpm_find(benchmark ${version} ${ARGN}
                   GLOBAL_TARGETS benchmark::benchmark benchmark::benchmark_main
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
@@ -72,7 +72,7 @@ function(rapids_cpm_gbench)
                           "CMAKE_INSTALL_LIBDIR ${lib_dir}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
-  rapids_cpm_display_patch_status(GBench)
+  rapids_cpm_display_patch_status(benchmark)
 
   if(NOT TARGET benchmark::benchmark AND TARGET benchmark)
     add_library(benchmark::benchmark ALIAS benchmark)

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,9 +13,9 @@
       "git_tag" : "${version}"
     },
     "benchmark" : {
-      "version" : "1.5.3",
+      "version" : "1.8.0",
       "git_url" : "https://github.com/google/benchmark.git",
-      "git_tag" : "v1.5.3"
+      "git_tag" : "v1.8.0"
     },
     "GTest" : {
       "version" : "1.13.0",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -1,6 +1,11 @@
 
 {
   "packages" : {
+    "benchmark" : {
+      "version" : "1.8.0",
+      "git_url" : "https://github.com/google/benchmark.git",
+      "git_tag" : "v${1.8.0}"
+    },
     "cuco" : {
       "version" : "0.0.1",
       "git_shallow" : false,
@@ -11,11 +16,6 @@
       "version" : "9.1.0",
       "git_url" : "https://github.com/fmtlib/fmt.git",
       "git_tag" : "${version}"
-    },
-    "benchmark" : {
-      "version" : "1.8.0",
-      "git_url" : "https://github.com/google/benchmark.git",
-      "git_tag" : "v1.8.0"
     },
     "GTest" : {
       "version" : "1.13.0",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -12,7 +12,7 @@
       "git_url" : "https://github.com/fmtlib/fmt.git",
       "git_tag" : "${version}"
     },
-    "GBench" : {
+    "benchmark" : {
       "version" : "1.5.3",
       "git_url" : "https://github.com/google/benchmark.git",
       "git_tag" : "v1.5.3"

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -4,7 +4,7 @@
     "benchmark" : {
       "version" : "1.8.0",
       "git_url" : "https://github.com/google/benchmark.git",
-      "git_tag" : "v${1.8.0}"
+      "git_tag" : "v${version}"
     },
     "cuco" : {
       "version" : "0.0.1",

--- a/testing/cpm/cpm_gbench-export.cmake
+++ b/testing/cpm/cpm_gbench-export.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ rapids_cpm_gbench(BUILD_EXPORT_SET bench)
 rapids_cpm_gbench(BUILD_EXPORT_SET bench2)
 
 get_target_property(packages rapids_export_build_bench PACKAGE_NAMES)
-if(NOT GBench IN_LIST packages)
-  message(FATAL_ERROR "rapids_cpm_gbench failed to record gbench needs to be exported")
+if(NOT benchmark IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_gbench failed to record benchmark needs to be exported")
 endif()
 
 get_target_property(packages rapids_export_build_bench2 PACKAGE_NAMES)
-if(NOT GBench IN_LIST packages)
-  message(FATAL_ERROR "rapids_cpm_gbench failed to record gbench needs to be exported")
+if(NOT benchmark IN_LIST packages)
+  message(FATAL_ERROR "rapids_cpm_gbench failed to record benchmark needs to be exported")
 endif()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The google benchmark package name was incorrect, making it impossible to find benchmark if it was previously installed. However, the currently pinned version of benchmark has a broken CMake config on conda-forge (it claims it is version 0.0.0) so it cannot be found even with the name fix. This is as good a time as any to go ahead and update to the latest version.

Resolves #424 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
