### PR TITLE
Bug/proprietary binary obeys `always_download`

### DIFF
--- a/docs/packages/rapids_cpm_versions.rst
+++ b/docs/packages/rapids_cpm_versions.rst
@@ -106,8 +106,15 @@ as needed.
 
 ``proprietary_binary``
 
-    An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library.
-    If a matching key exists the binary will be used instead of the specified git url and tag.
+    An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library. This creates a new entry in the search
+    logic for a project:
+
+        - Search for a local version matching the `version` key
+            - disabled by `always_download`
+        - Download proprietary version if a valid OS + CPU Arch exists
+            - disabled by `USE_PROPRIETARY_BLOB` being off
+        - Fallback to using git url and tag
+
     To determine the correct key, CMake will query for a key that matches the lower case value of `<arch>-<os>` where `arch` maps to
     :cmake:variable:`CMAKE_SYSTEM_PROCESSOR <cmake:variable:CMAKE_SYSTEM_PROCESSOR>` and `os` maps to :cmake:variable:`CMAKE_SYSTEM_NAME <cmake:variable:CMAKE_SYSTEM_NAME>`.
 

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -29,6 +29,11 @@ rapids_cpm_package_details
                              <exclude_from_all_variable>
                              )
 
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`rapids_cmake_always_download` will contain the value of the `always_download` entry if it exists.
+  :cmake:variable:`CPM_DOWNLOAD_ALL` will contain the value of the `always_download` entry if it exists.
+
 #]=======================================================================]
 # cmake-lint: disable=R0913,R0915
 function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -30,7 +30,7 @@ rapids_cpm_package_details
                              )
 
 #]=======================================================================]
-# cmake-lint: disable=R0913
+# cmake-lint: disable=R0913,R0915
 function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var
          exclude_from_all_var)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_details")
@@ -99,6 +99,7 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   set(${shallow_var} ${git_shallow} PARENT_SCOPE)
   set(${exclude_from_all_var} ${exclude_from_all} PARENT_SCOPE)
   if(DEFINED always_download)
+    set(rapids_cmake_always_download ${always_download} PARENT_SCOPE)
     set(CPM_DOWNLOAD_ALL ${always_download} PARENT_SCOPE)
   endif()
 

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -63,7 +63,7 @@ Result Variables
   :cmake:variable:`nvcomp_proprietary_binary` is set to ON if the proprietary binary is being used
 
 #]=======================================================================]
-# cmake-lint: disable=R0915
+# cmake-lint: disable=R0915,R0912
 function(rapids_cpm_nvcomp)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.nvcomp")
 
@@ -74,11 +74,12 @@ function(rapids_cpm_nvcomp)
 
   # Fix up _RAPIDS_UNPARSED_ARGUMENTS to have EXPORT_SETS as this is need for rapids_cpm_find
   if(_RAPIDS_INSTALL_EXPORT_SET)
-    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
+    list(APPEND _RAPIDS_EXPORT_ARGUMENTS INSTALL_EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
   endif()
   if(_RAPIDS_BUILD_EXPORT_SET)
-    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS BUILD_EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
+    list(APPEND _RAPIDS_EXPORT_ARGUMENTS BUILD_EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
   endif()
+  set(_RAPIDS_UNPARSED_ARGUMENTS ${_RAPIDS_EXPORT_ARGUMENTS})
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
@@ -87,9 +88,17 @@ function(rapids_cpm_nvcomp)
     set(to_exclude ON)
   endif()
 
-  # first see if we have a proprietary pre-built binary listed in versions.json and it if requested.
+  # first search locally if `rapids_cmake_always_download` is false
+  if(NOT rapids_cmake_always_download)
+    include("${rapids-cmake-dir}/find/package.cmake")
+    rapids_find_package(nvcomp ${version} GLOBAL_TARGETS nvcomp::nvcomp ${_RAPIDS_EXPORT_ARGUMENTS}
+                        FIND_ARGS QUIET)
+  endif()
+
+  # second see if we have a proprietary pre-built binary listed in versions.json and it if
+  # requested.
   set(nvcomp_proprietary_binary OFF) # will be set to true by rapids_cpm_get_proprietary_binary
-  if(_RAPIDS_USE_PROPRIETARY_BINARY)
+  if(_RAPIDS_USE_PROPRIETARY_BINARY AND NOT nvcomp_FOUND)
     include("${rapids-cmake-dir}/cpm/detail/get_proprietary_binary_url.cmake")
     include("${rapids-cmake-dir}/cpm/detail/download_proprietary_binary.cmake")
     rapids_cpm_get_proprietary_binary_url(nvcomp ${version} nvcomp_url)

--- a/rapids-cmake/find/package.cmake
+++ b/rapids-cmake/find/package.cmake
@@ -115,18 +115,18 @@ macro(rapids_find_package name)
   set(_rapids_options FIND_ARGS)
   set(_rapids_one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(_rapids_multi_value COMPONENTS GLOBAL_TARGETS)
-  cmake_parse_arguments(_RAPIDS "${_rapids_options}" "${_rapids_one_value}"
+  cmake_parse_arguments(_RAPIDS_FIND "${_rapids_options}" "${_rapids_one_value}"
                         "${_rapids_multi_value}" ${ARGN})
 
-  if(_RAPIDS_COMPONENTS)
-    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS COMPONENTS ${_RAPIDS_COMPONENTS})
+  if(_RAPIDS_FIND_COMPONENTS)
+    list(APPEND _RAPIDS_FIND_UNPARSED_ARGUMENTS COMPONENTS ${_RAPIDS_FIND_COMPONENTS})
   endif()
 
-  find_package(${name} ${_RAPIDS_UNPARSED_ARGUMENTS})
+  find_package(${name} ${_RAPIDS_FIND_UNPARSED_ARGUMENTS})
 
-  if(_RAPIDS_GLOBAL_TARGETS)
+  if(_RAPIDS_FIND_GLOBAL_TARGETS)
     include("${rapids-cmake-dir}/cmake/make_global.cmake")
-    rapids_cmake_make_global(_RAPIDS_GLOBAL_TARGETS)
+    rapids_cmake_make_global(_RAPIDS_FIND_GLOBAL_TARGETS)
   endif()
 
   # Only record the export requirements if the package was found This allows us to handle implicit
@@ -139,11 +139,11 @@ macro(rapids_find_package name)
     endif()
 
     set(_rapids_extra_info)
-    if(_RAPIDS_GLOBAL_TARGETS)
-      list(APPEND _rapids_extra_info "GLOBAL_TARGETS" ${_RAPIDS_GLOBAL_TARGETS})
+    if(_RAPIDS_FIND_GLOBAL_TARGETS)
+      list(APPEND _rapids_extra_info "GLOBAL_TARGETS" ${_RAPIDS_FIND_GLOBAL_TARGETS})
     endif()
-    if(_RAPIDS_COMPONENTS)
-      list(APPEND _rapids_extra_info "COMPONENTS" ${_RAPIDS_COMPONENTS})
+    if(_RAPIDS_FIND_COMPONENTS)
+      list(APPEND _rapids_extra_info "COMPONENTS" ${_RAPIDS_FIND_COMPONENTS})
     endif()
 
     # Record the version we found to be what consumers need to find as well
@@ -152,14 +152,15 @@ macro(rapids_find_package name)
       list(APPEND _rapids_extra_info "VERSION" ${possible_version})
     endif()
 
-    if(_RAPIDS_BUILD_EXPORT_SET)
+    if(_RAPIDS_FIND_BUILD_EXPORT_SET)
       include("${rapids-cmake-dir}/export/package.cmake")
-      rapids_export_package(BUILD ${name} ${_RAPIDS_BUILD_EXPORT_SET} ${_rapids_extra_info})
+      rapids_export_package(BUILD ${name} ${_RAPIDS_FIND_BUILD_EXPORT_SET} ${_rapids_extra_info})
     endif()
 
-    if(_RAPIDS_INSTALL_EXPORT_SET)
+    if(_RAPIDS_FIND_INSTALL_EXPORT_SET)
       include("${rapids-cmake-dir}/export/package.cmake")
-      rapids_export_package(INSTALL ${name} ${_RAPIDS_INSTALL_EXPORT_SET} ${_rapids_extra_info})
+      rapids_export_package(INSTALL ${name} ${_RAPIDS_FIND_INSTALL_EXPORT_SET}
+                                    ${_rapids_extra_info})
     endif()
 
     unset(_rapids_extra_info)
@@ -167,8 +168,8 @@ macro(rapids_find_package name)
 
   # Cleanup all our local variables
   foreach(_rapids_local_var IN LISTS _rapids_options _rapids_one_value _rapids_multi_value)
-    if(DEFINED _RAPIDS_${_rapids_local_var})
-      unset(_RAPIDS_${_rapids_local_var})
+    if(DEFINED _RAPIDS_FIND_${_rapids_local_var})
+      unset(_RAPIDS_FIND_${_rapids_local_var})
     endif()
   endforeach()
   unset(_rapids_local_var)


### PR DESCRIPTION
## Description
Update rapids_cpm_nvcomp to check for a local version before downloading the properitary version

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
