### PR TITLE
Correct re-root controls from conda-forge with thrust/cub/etc

### DIFF
--- a/rapids-cmake/cpm/patches/Thrust/reroot_support.diff
+++ b/rapids-cmake/cpm/patches/Thrust/reroot_support.diff
@@ -1,0 +1,47 @@
+diff --git a/dependencies/cub/cub/cmake/cub-header-search.cmake b/dependencies/cub/cub/cmake/cub-header-search.cmake
+index 2ff1a8acd8..5e731f2be8 100644
+--- a/dependencies/cub/cub/cmake/cub-header-search.cmake
++++ b/dependencies/cub/cub/cmake/cub-header-search.cmake
+@@ -1,5 +1,6 @@
+ unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
+ find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
++  NO_CMAKE_FIND_ROOT_PATH
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../.."            # Source tree
+diff --git a/dependencies/cub/cub/cmake/cub-header-search.cmake.in b/dependencies/cub/cub/cmake/cub-header-search.cmake.in
+index 271b1b27bd..3bd10e4b70 100644
+--- a/dependencies/cub/cub/cmake/cub-header-search.cmake.in
++++ b/dependencies/cub/cub/cmake/cub-header-search.cmake.in
+@@ -11,6 +11,7 @@ list(TRANSFORM from_install_prefix REPLACE ".+" "../")
+ list(JOIN from_install_prefix "" from_install_prefix)
+ 
+ find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
++  NO_CMAKE_FIND_ROOT_PATH
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
+diff --git a/thrust/cmake/thrust-header-search.cmake b/thrust/cmake/thrust-header-search.cmake
+index 643ec90b7..7d27c68f4 100644
+--- a/thrust/cmake/thrust-header-search.cmake
++++ b/thrust/cmake/thrust-header-search.cmake
+@@ -1,6 +1,7 @@
+ # Parse version information from version.h:
+ unset(_THRUST_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
+ find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
++  NO_CMAKE_FIND_ROOT_PATH
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../.."            # Source tree
+diff --git a/thrust/cmake/thrust-header-search.cmake.in b/thrust/cmake/thrust-header-search.cmake.in
+index c014c469b..adea07e2d 100644
+--- a/thrust/cmake/thrust-header-search.cmake.in
++++ b/thrust/cmake/thrust-header-search.cmake.in
+@@ -11,6 +11,7 @@ list(TRANSFORM from_install_prefix REPLACE ".+" "../")
+ list(JOIN from_install_prefix "" from_install_prefix)
+ 
+ find_path(_THRUST_VERSION_INCLUDE_DIR thrust/version.h
++  NO_CMAKE_FIND_ROOT_PATH
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@"

--- a/rapids-cmake/cpm/patches/libcudacxx/reroot_support.diff
+++ b/rapids-cmake/cpm/patches/libcudacxx/reroot_support.diff
@@ -1,0 +1,12 @@
+diff --git a/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in b/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in
+index 8c44d990..365b9de0 100644
+--- a/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in
++++ b/lib/cmake/libcudacxx/libcudacxx-header-search.cmake.in
+@@ -11,6 +11,7 @@ list(TRANSFORM from_install_prefix REPLACE ".+" "../")
+ list(JOIN from_install_prefix "" from_install_prefix)
+
+ find_path(_libcudacxx_VERSION_INCLUDE_DIR cuda/std/detail/__config
++  NO_CMAKE_FIND_ROOT_PATH # Don't allow CMake to re-root the search
+   NO_DEFAULT_PATH # Only search explicit paths below:
+   PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/${from_install_prefix}/@CMAKE_INSTALL_INCLUDEDIR@" # Install tree

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,7 +31,12 @@
           "file" : "libcudacxx/install_rules.diff",
           "issue" : "libcudacxx 1.X installs incorrect files [https://github.com/NVIDIA/libcudacxx/pull/428]",
           "fixed_in" : "2.2"
-        }
+        },
+        {
+          "file" : "libcudacxx/reroot_support.diff",
+          "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/libcudacxx/pull/490]",
+          "fixed_in" : "2.2"
+        },
       ]
     },
     "nvbench" : {
@@ -71,6 +76,11 @@
       "git_url" : "https://github.com/NVIDIA/thrust.git",
       "git_tag" : "${version}",
       "patches" : [
+        {
+          "file" : "Thrust/reroot_support.diff",
+          "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/thrust/pull/1969]",
+          "fixed_in" : "2.2"
+        },
         {
           "file" : "Thrust/transform_iter_with_reduce_by_key.diff",
           "issue" : "Support transform iterator with reduce by key [https://github.com/NVIDIA/thrust/pull/1805]",


### PR DESCRIPTION
## Description
Upstream fix: https://github.com/NVIDIA/thrust/issues/1966

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
