### PR TITLE
Correct two issues found when testing CMake 3.27 rc2

### DIFF
--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ function(rapids_cpm_rmm)
   rapids_cpm_generate_patch_command(rmm ${version} patch_command)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(rmm ${version} ${ARGN} {_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(rmm ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS rmm::rmm
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -104,7 +104,8 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
                                     ${_RAPIDS_INSTALL_EXPORT_SET})
   endif()
 
-  if(NOT TARGET ${namespaces_name}::Thrust)
+  # Check for the existence of thrust_create_target so we support fetching Thrust with DOWNLOAD_ONLY
+  if(NOT TARGET ${namespaces_name}::Thrust AND COMMAND thrust_create_target)
     thrust_create_target(${namespaces_name}::Thrust FROM_OPTIONS)
     set_target_properties(${namespaces_name}::Thrust PROPERTIES IMPORTED_NO_SYSTEM ON)
     if(TARGET _Thrust_Thrust)

--- a/testing/utils/fill_cache/CMakeLists.txt
+++ b/testing/utils/fill_cache/CMakeLists.txt
@@ -44,7 +44,7 @@ rapids_cpm_nvbench(DOWNLOAD_ONLY ON)
 rapids_cpm_rmm(DOWNLOAD_ONLY ON)
 rapids_cpm_spdlog(DOWNLOAD_ONLY ON)
 rapids_cpm_fmt(DOWNLOAD_ONLY ON)
-rapids_cpm_thrust(temp DOWNLOAD_ONLY ON)
+rapids_cpm_thrust(NAMESPACE temp DOWNLOAD_ONLY ON)
 rapids_cpm_find(skbuild 0.14.1
                 GIT_REPOSITORY https://github.com/scikit-build/scikit-build.git
                 GIT_TAG 0.14.1


### PR DESCRIPTION
## Description
Corrects two small logic errors that became exposed due to changes in `ExternalProject` in CMake 3.27 which made it less robust to invalid inputs.

The `rapids_cpm_thrust` function now properly supports the `DOWNLOAD_ONLY` parameter, and `rapids_cpm_rmm` now propagates arguments correctly to the underlying CPMFindPackage. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
