### PR TITLE
When nvcomp is found locally print where it is on disk

### DIFF
--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -93,6 +93,10 @@ function(rapids_cpm_nvcomp)
     include("${rapids-cmake-dir}/find/package.cmake")
     rapids_find_package(nvcomp ${version} GLOBAL_TARGETS nvcomp::nvcomp ${_RAPIDS_EXPORT_ARGUMENTS}
                         FIND_ARGS QUIET)
+    if(nvcomp_FOUND)
+      # report where nvcomp was found
+      message(STATUS "Found nvcomp: ${nvcomp_DIR} (found version ${nvcomp_VERSION})")
+    endif()
   endif()
 
   # second see if we have a proprietary pre-built binary listed in versions.json and it if


### PR DESCRIPTION
## Description

This way users always get some console output for where nvcomp is located. We don't remove the `QUIET` request since that would print out the following:

```
  CMake Warning at ..../rapids-cmake/find/package.cmake:125 (find_package):
  By not providing "Findnvcomp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "nvcomp", but
  CMake did not find one.

  Could not find a package configuration file provided by "nvcomp" (requested
  version 2.6.1) with any of the following names:

    nvcompConfig.cmake
    nvcomp-config.cmake

  Add the installation prefix of "nvcomp" to CMAKE_PREFIX_PATH or set
  "nvcomp_DIR" to a directory containing one of the above files.  If "nvcomp"
  provides a separate development package or SDK, be sure it has been
  installed.
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
