### PR TITLE
Remove trailing comma and add pre-commit hook for JSON validation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
           (?x)^(
             ^rapids-cmake/cpm/patches/.*
           )
+      - id: check-json
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.1
     hooks:

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -36,7 +36,7 @@
           "file" : "libcudacxx/reroot_support.diff",
           "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/libcudacxx/pull/490]",
           "fixed_in" : "2.2"
-        },
+        }
       ]
     },
     "nvbench" : {


### PR DESCRIPTION
## Description
This PR fixes a trailing comma (invalid in JSON) that makes `versions.json` have invalid syntax, and adds a lightweight pre-commit hook to prevent this problem from happening again.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
