### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
           (?x)^(
             ^rapids-cmake/cpm/patches/.*
           )
+      - id: check-json
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.1
     hooks:

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -36,7 +36,7 @@
           "file" : "libcudacxx/reroot_support.diff",
           "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/libcudacxx/pull/490]",
           "fixed_in" : "2.2"
-        },
+        }
       ]
     },
     "nvbench" : {


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.