### PR TITLE
Fix CUDA 11.5 tests by adding dependencies entries.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -57,6 +57,16 @@ dependencies:
               - nvcc_linux-aarch64=11.4
           - matrix:
               arch: x86_64
+              cuda: "11.5"
+            packages:
+              - nvcc_linux-64=11.5
+          - matrix:
+              arch: aarch64
+              cuda: "11.5"
+            packages:
+              - nvcc_linux-aarch64=11.5
+          - matrix:
+              arch: x86_64
               cuda: "11.8"
             packages:
               - nvcc_linux-64=11.8


### PR DESCRIPTION
## Description
Nightly CI runs are failing for CUDA 11.5 because the `build` package list does not specify a matrix entry for CUDA 11.5. This adds the missing matrix entry.

See failure below:
```
ValueError: No matching matrix found in 'build' for: {'cuda': '11.5', 'arch': 'x86_64'}
```

https://github.com/rapidsai/rapids-cmake/actions/runs/5652925311/job/15313316122

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
