### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -103,7 +103,7 @@ dependencies:
             packages:
               - cuda-version=11.5
               - cudatoolkit
-              - gcc<12.0.0
+              - gcc<11.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "11.6"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.