### PR TITLE
Bump cuco version

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -10,7 +10,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "303f134573afa315cf14fca3f7a0b730438497c3"
+      "git_tag" : "5186b39522e13a3681c0eb591db4eaacbf969485"
     },
     "fmt" : {
       "version" : "9.1.0",


### PR DESCRIPTION
## Description
This PR fetches the latest cuco to unblock https://github.com/rapidsai/cudf/pull/13807.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
