### PR TITLE
Support fmt use in debug builds

### DIFF
--- a/rapids-cmake/cpm/patches/fmt/no_debug_warnings.diff
+++ b/rapids-cmake/cpm/patches/fmt/no_debug_warnings.diff
@@ -1,0 +1,13 @@
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index f6a37af..ffabe63 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -286,7 +286,7 @@
+ 
+ // Enable minimal optimizations for more compact code in debug mode.
+ FMT_GCC_PRAGMA("GCC push_options")
+-#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER)
++#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER) && !defined(__LCC__) && !defined(__CUDACC__)
+ FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
+ #endif
+ 

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -15,7 +15,14 @@
     "fmt" : {
       "version" : "9.1.0",
       "git_url" : "https://github.com/fmtlib/fmt.git",
-      "git_tag" : "${version}"
+      "git_tag" : "${version}",
+      "patches" : [
+        {
+          "file" : "fmt/no_debug_warnings.diff",
+          "issue" : "No warnings during debug builds [https://github.com/fmtlib/fmt/issues/3351]",
+          "fixed_in" : "10.0"
+        }
+      ]
     },
     "GTest" : {
       "version" : "1.13.0",


### PR DESCRIPTION
## Description
Fixes #454

Backport of an upstream patch (https://github.com/fmtlib/fmt/pull/3352) to our version of fmt 9.1

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
