### PR TITLE
Use `conda mambabuild` not `mamba mambabuild`

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -11,6 +11,6 @@ rapids-print-env
 
 rapids-logger "Begin cpp build"
 
-rapids-mamba-retry mambabuild conda/recipes/rapids_core_dependencies
+rapids-conda-retry mambabuild conda/recipes/rapids_core_dependencies
 
 rapids-upload-conda-to-s3 cpp

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -132,7 +132,7 @@ dependencies:
         packages:
           - pip
           - pip:
-            - sphinxcontrib-moderncmakedomain
+              - sphinxcontrib-moderncmakedomain
           - sphinx
           - sphinx-copybutton
           - sphinx_rtd_theme
@@ -146,6 +146,7 @@ dependencies:
           - libpng
           - zlib
       - output_types: [conda]
+        packages:
           - fmt==9.1.0
   style_checks:
     common:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -145,6 +145,8 @@ dependencies:
           - scikit-build>=0.13.1
           - libpng
           - zlib
+      - output_types: [conda]
+          - fmt==9.1.0
   style_checks:
     common:
       - output_types: [conda, requirements]


### PR DESCRIPTION
With the release of conda 23.7.3, `mamba mambabuild` stopped working. With boa installed, `conda mambabuild` uses the mamba solver, so just use that instead.

See also https://github.com/rapidsai/cudf/issues/14068.
