### PR TITLE
cpm overrides don't occur when `CPM_<pkg>_SOURCE` exists

### DIFF
--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -49,11 +49,14 @@ projects.
 
 .. note::
 
+  .. versionadded:: v23.10.00
+    When the variable `CPM_<package_name>_SOURCE` exists, any override entries
+    for `package_name` will be ignored.
+
   If the override file doesn't specify a value or package entry the default
   version will be used.
 
   Must be called before any invocation of :cmake:command:`rapids_cpm_find`.
-
 
 #]=======================================================================]
 function(rapids_cpm_package_override filepath)
@@ -74,10 +77,10 @@ function(rapids_cpm_package_override filepath)
     # cmake-lint: disable=E1120
     foreach(index RANGE ${package_count})
       string(JSON package_name MEMBER "${json_data}" packages ${index})
-      string(JSON data GET "${json_data}" packages "${package_name}")
       get_property(override_exists GLOBAL PROPERTY rapids_cpm_${package_name}_override_json DEFINED)
-      if(NOT override_exists)
+      if(NOT (override_exists OR DEFINED CPM_${package_name}_SOURCE))
         # only add the first override for a project we encounter
+        string(JSON data GET "${json_data}" packages "${package_name}")
         set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_override_json "${data}")
         set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_override_json_file "${filepath}")
       endif()

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -50,9 +50,12 @@ projects.
 .. note::
 
   .. versionadded:: v23.10.00
+
     When the variable `CPM_<package_name>_SOURCE` exists, any override entries
     for `package_name` will be ignored.
 
+
+.. note::
   If the override file doesn't specify a value or package entry the default
   version will be used.
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -34,6 +34,7 @@ add_cmake_config_test( cpm_package_override-bad-path.cmake SHOULD_FAIL "rapids_c
 add_cmake_config_test( cpm_package_override-before-init.cmake )
 add_cmake_config_test( cpm_package_override-empty.cmake )
 add_cmake_config_test( cpm_package_override-multiple.cmake )
+add_cmake_config_test( cpm_package_override-obey-cpm-source-var.cmake )
 add_cmake_config_test( cpm_package_override-patches.cmake )
 add_cmake_config_test( cpm_package_override-simple.cmake )
 

--- a/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
+++ b/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
@@ -1,0 +1,64 @@
+#=============================================================================
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+rapids_cpm_init()
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages" : {
+    "rmm" : {
+      "git_url" : "new_rmm_url",
+      "git_shallow" : "OFF",
+      "exclude_from_all" : "ON"
+    },
+    "not_in_base" : {
+      "git_url" : "new_rmm_url",
+      "git_shallow" : "OFF",
+      "exclude_from_all" : "ON"
+    }
+  }
+}
+  ]=])
+
+set(CPM_rmm_SOURCE "${CMAKE_CURRENT_BINARY_DIR}")
+set(CPM_not_in_base_SOURCE "${CMAKE_CURRENT_BINARY_DIR}")
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+# Verify that the override doesn't exist due to `CPM_rmm_SOURCE`
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+
+rapids_cpm_package_details(rmm version repository tag shallow exclude)
+if(repository MATCHES "new_rmm_url")
+  message(FATAL_ERROR "custom url field should not be set, due to CPM_rmm_SOURCE")
+endif()
+if(shallow MATCHES "OFF")
+  message(FATAL_ERROR "shallow field should not be set, due to CPM_rmm_SOURCE")
+endif()
+if(CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should not be set, due to CPM_rmm_SOURCE")
+endif()
+
+unset(version)
+unset(repository)
+unset(tag)
+rapids_cpm_package_details(not_in_base version repository tag shallow exclude)
+if(version OR repository OR tag)
+  message(FATAL_ERROR "rapids_cpm_package_details should not return anything for package that doesn't exist")
+endif()


### PR DESCRIPTION

## Description
Since the rapids-cmake cpm overrides hook into fetch content they previously would take priority over `CPM_<pkg>_SOURCE`. Now we don't add overrides when `CPM_<pkg>_SOURCE` exists.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
