### PR TITLE
Update to CPM v0.38.5

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,8 +42,8 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.35.6)
-  set(CPM_DOWNLOAD_MD5_HASH c15cd4b7f511bc625c92ee6580821726)
+  set(CPM_DOWNLOAD_VERSION 0.38.5)
+  set(CPM_DOWNLOAD_MD5_HASH d6d5d0d5abca0b9ffe253353f75befc704e81bec)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -43,7 +43,7 @@ function(rapids_cpm_download)
 
   # When changing version verify no new variables needs to be propagated
   set(CPM_DOWNLOAD_VERSION 0.38.5)
-  set(CPM_DOWNLOAD_MD5_HASH d6d5d0d5abca0b9ffe253353f75befc704e81bec)
+  set(CPM_DOWNLOAD_MD5_HASH c98d14a13dfd1952e115979c095f6794)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)


### PR DESCRIPTION
## Description
Update to CPM [v0.38.5](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.38.5).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [x] I have added new files under rapids-cmake/
   - [x] I have added include guards (`include_guard(GLOBAL)`)
   - [x] I have added the associated docs/ rst file and update the api.rst
