### PR TITLE
Move rapids_cpm_package_override to CPM section of docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,6 +33,7 @@ tracking of these dependencies for correct export support.
 
    /command/rapids_cpm_init
    /command/rapids_cpm_find
+   /command/rapids_cpm_package_override
 
 CPM Pre-Configured Packages
 ***************************
@@ -57,7 +58,6 @@ package uses :ref:`can be found here. <cpm_versions>`
    /packages/rapids_cpm_rmm
    /packages/rapids_cpm_spdlog
    /packages/rapids_cpm_thrust
-   /command/rapids_cpm_package_override
 
 .. _`cython`:
 


### PR DESCRIPTION
## Description

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
