### PR TITLE
Quote the list of patch files in case they have spaces in their paths

### DIFF
--- a/rapids-cmake/cpm/patches/command_template.cmake.in
+++ b/rapids-cmake/cpm/patches/command_template.cmake.in
@@ -68,7 +68,7 @@ function(rapids_cpm_run_git_patch file issue)
   set(msg_state ${msg_state} PARENT_SCOPE)
 endfunction()
 
-set(files @patch_files_to_run@)
+set(files "@patch_files_to_run@")
 set(issues "@patch_issues_to_ref@")
 set(output_file "@log_file@")
 foreach(file issue IN ZIP_LISTS files issues)

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
           "file" : "${current_json_dir}/example.diff",
           "issue" : "explain",
           "fixed_in" : ""
+        },
+        {
+          "file" : "${current_json_dir}/example2.diff",
+          "issue" : "explain",
+          "fixed_in" : ""
         }
       ]
     }
@@ -51,7 +56,7 @@ if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
 endif()
 
-set(to_match_string "set(files ${CMAKE_CURRENT_BINARY_DIR}/example.diff)")
+set(to_match_string "set(files \"${CMAKE_CURRENT_BINARY_DIR}/example.diff;${CMAKE_CURRENT_BINARY_DIR}/example2.diff\")")
 
 list(POP_BACK patch_command script_to_run)
 file(READ "${script_to_run}" contents)


### PR DESCRIPTION
## Description
The rapids cpm scripts fail when populating a dependency with patches if the build directory contains spaces in its path name. The reason is because the paths are not properly quoted in the cmake patch script generated from `command_template.cmake.in`.

This PR properly quotes the list of patch file names.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
