### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/rapids-cmake/cpm/patches/command_template.cmake.in
+++ b/rapids-cmake/cpm/patches/command_template.cmake.in
@@ -68,7 +68,7 @@ function(rapids_cpm_run_git_patch file issue)
   set(msg_state ${msg_state} PARENT_SCOPE)
 endfunction()
 
-set(files @patch_files_to_run@)
+set(files "@patch_files_to_run@")
 set(issues "@patch_issues_to_ref@")
 set(output_file "@log_file@")
 foreach(file issue IN ZIP_LISTS files issues)

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
           "file" : "${current_json_dir}/example.diff",
           "issue" : "explain",
           "fixed_in" : ""
+        },
+        {
+          "file" : "${current_json_dir}/example2.diff",
+          "issue" : "explain",
+          "fixed_in" : ""
         }
       ]
     }
@@ -51,7 +56,7 @@ if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
 endif()
 
-set(to_match_string "set(files ${CMAKE_CURRENT_BINARY_DIR}/example.diff)")
+set(to_match_string "set(files \"${CMAKE_CURRENT_BINARY_DIR}/example.diff;${CMAKE_CURRENT_BINARY_DIR}/example2.diff\")")
 
 list(POP_BACK patch_command script_to_run)
 file(READ "${script_to_run}" contents)


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.