### PR TITLE
Add patch for libcudacxx memory resource.

### DIFF
--- a/rapids-cmake/cpm/patches/libcudacxx/memory_resource.diff
+++ b/rapids-cmake/cpm/patches/libcudacxx/memory_resource.diff
@@ -1,0 +1,22 @@
+diff --git a/include/cuda/memory_resource b/include/cuda/memory_resource
+index 4a904cda..32f3f210 100644
+--- a/include/cuda/memory_resource
++++ b/include/cuda/memory_resource
+@@ -525,7 +525,16 @@ public:
+           && (((_Alloc_type == _AllocType::_Default) && resource_with<_Resource, _Properties...>) //
+             ||((_Alloc_type == _AllocType::_Async) && async_resource_with<_Resource, _Properties...>)))) //
+      basic_resource_ref(_Resource& __res) noexcept
+-        : _Resource_ref_base<_Alloc_type>(&__res, &__alloc_vtable<_Alloc_type, _Resource>)
++        : _Resource_ref_base<_Alloc_type>(_CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _Resource>)
++        , _Filtered_vtable<_Properties...>(_Filtered_vtable<_Properties...>::template _Create<_Resource>())
++    {}
++
++    _LIBCUDACXX_TEMPLATE(class _Resource)
++        (requires (!_Is_basic_resource_ref<_Resource>
++          && (((_Alloc_type == _AllocType::_Default) && resource_with<_Resource, _Properties...>) //
++            ||((_Alloc_type == _AllocType::_Async) && async_resource_with<_Resource, _Properties...>)))) //
++     basic_resource_ref(_Resource* __res) noexcept
++        : _Resource_ref_base<_Alloc_type>(__res, &__alloc_vtable<_Alloc_type, _Resource>)
+         , _Filtered_vtable<_Properties...>(_Filtered_vtable<_Properties...>::template _Create<_Resource>())
+     {}
+ 

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -47,6 +47,11 @@
           "file" : "libcudacxx/proclaim_return_type_nv_exec_check_disable.diff",
           "issue" : "Use pragma to disable execution checks in cuda::proclaim_return_type. [https://github.com/NVIDIA/libcudacxx/pull/448]",
           "fixed_in" : "2.2"
+        },
+        {
+          "file" : "libcudacxx/memory_resource.diff",
+          "issue" : "Allow {async_}resource_ref to be constructible from a pointer. [https://github.com/NVIDIA/libcudacxx/pull/439]",
+          "fixed_in" : "2.2"
         }
       ]
     },


### PR DESCRIPTION
## Description
Adds a patch from https://github.com/NVIDIA/libcudacxx/pull/439/ for libcudacxx 2.1.0, to support ongoing memory resource work.

cc: @miscco

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
