### PR TITLE
Update cuco git tag

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -9,7 +9,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "5186b39522e13a3681c0eb591db4eaacbf969485"
+      "git_tag" : "7c76a124df0c2cd3fd66e3e080b9470a3b4707c6"
     },
     "fmt" : {
       "version" : "9.1.0",


### PR DESCRIPTION
## Description
This PR updates the version of cuCollections to include a bugfix that is needed for G+H bringup.

Test PRs in downstream projects:
- [x] rapidsai/cudf#14306
- [x] rapidsai/cugraph#3946
- [x] rapidsai/cuml#5626 -> Python tests are failing for some (maybe unrelated) reason but cpp tests run fine
- [x] rapidsai/raft#1917
- … can someone come up with other projects that use cuco

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst

CC @PointKernel 