### PR TITLE
Allow rapids_test to be used without CUDAToolkit

### DIFF
--- a/rapids-cmake/test/detail/generate_resource_spec.cpp
+++ b/rapids-cmake/test/detail/generate_resource_spec.cpp
@@ -23,9 +23,9 @@
 #include <vector>
 
 struct version {
-  version() : major(1), minor(0) {}
-  int major;
-  int minor;
+  version() : json_major(1), json_minor(0) {}
+  int json_major;
+  int json_minor;
 };
 
 struct gpu {

--- a/rapids-cmake/test/detail/generate_resource_spec.cpp
+++ b/rapids-cmake/test/detail/generate_resource_spec.cpp
@@ -40,7 +40,7 @@ struct gpu {
 // https://cmake.org/cmake/help/latest/manual/ctest.1.html#resource-specification-file
 void to_json(std::ostream& buffer, version const& v)
 {
-  buffer << "\"version\": {\"major\": " << v.major << ", \"minor\": " << v.minor << "}";
+  buffer << "\"version\": {\"major\": " << v.json_major << ", \"minor\": " << v.json_minor << "}";
 }
 void to_json(std::ostream& buffer, gpu const& g)
 {

--- a/rapids-cmake/test/detail/generate_resource_spec.cpp
+++ b/rapids-cmake/test/detail/generate_resource_spec.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#ifdef HAVE_CUDA
 #include <cuda_runtime_api.h>
+#endif
 
 #include <iostream>
 #include <string>
@@ -27,7 +29,7 @@ struct version {
 
 struct gpu {
   gpu(int i) : id{i} {};
-  gpu(int i, const cudaDeviceProp& prop) : id{i}, memory{prop.totalGlobalMem}, slots{100} {}
+  gpu(int i, size_t mem) : id{i}, memory{mem}, slots{100} {}
   int id        = 0;
   size_t memory = 0;
   int slots     = 0;
@@ -48,6 +50,8 @@ int main()
 {
   std::vector<gpu> gpus;
   int nDevices = 0;
+
+#ifdef HAVE_CUDA
   cudaGetDeviceCount(&nDevices);
   if (nDevices == 0) {
     gpus.emplace_back(0);
@@ -55,9 +59,12 @@ int main()
     for (int i = 0; i < nDevices; ++i) {
       cudaDeviceProp prop;
       cudaGetDeviceProperties(&prop, i);
-      gpus.emplace_back(i, prop);
+      gpus.emplace_back(i, prop.totalGlobalMem);
     }
   }
+#else
+  gpus.emplace_back(0);
+#endif()
 
   version v{1, 0};
   std::cout << "{\n";

--- a/rapids-cmake/test/detail/generate_resource_spec.cpp
+++ b/rapids-cmake/test/detail/generate_resource_spec.cpp
@@ -23,16 +23,17 @@
 #include <vector>
 
 struct version {
-  int major = 1;
-  int minor = 0;
+  version() : major(1), minor(0) {}
+  int major;
+  int minor;
 };
 
 struct gpu {
-  gpu(int i) : id{i} {};
-  gpu(int i, size_t mem) : id{i}, memory{mem}, slots{100} {}
-  int id        = 0;
-  size_t memory = 0;
-  int slots     = 0;
+  gpu(int i) : id(i), memory(0), slots(0){};
+  gpu(int i, size_t mem) : id(i), memory(mem), slots(100) {}
+  int id;
+  size_t memory;
+  int slots;
 };
 
 // A hard-coded JSON printer that generates a ctest resource-specification file:
@@ -54,19 +55,19 @@ int main()
 #ifdef HAVE_CUDA
   cudaGetDeviceCount(&nDevices);
   if (nDevices == 0) {
-    gpus.emplace_back(0);
+    gpus.push_back(gpu(0));
   } else {
     for (int i = 0; i < nDevices; ++i) {
       cudaDeviceProp prop;
       cudaGetDeviceProperties(&prop, i);
-      gpus.emplace_back(i, prop.totalGlobalMem);
+      gpus.push_back(gpu(i, prop.totalGlobalMem));
     }
   }
 #else
-  gpus.emplace_back(0);
-#endif()
+  gpus.push_back(gpu(0));
+#endif
 
-  version v{1, 0};
+  version v;
   std::cout << "{\n";
   to_json(std::cout, v);
   std::cout << ",\n";

--- a/rapids-cmake/test/generate_resource_spec.cmake
+++ b/rapids-cmake/test/generate_resource_spec.cmake
@@ -81,13 +81,13 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
 
     execute_process(COMMAND "${compiler}" "${eval_file}" ${compile_options} ${link_options} -o
                             "${eval_exe}" OUTPUT_VARIABLE compile_output
-                    ERROR_VARIABLE compile_output COMMAND_ECHO STDOUT)
+                    ERROR_VARIABLE compile_output)
   endif()
 
   if(NOT EXISTS "${eval_exe}")
     message(STATUS "rapids_test_generate_resource_spec failed to build detection executable, presuming no GPUs."
     )
-    message(STATUS "rapids_test_generate_resource_spec compile failure details are ${compile_output}"
+    message(STATUS "rapids_test_generate_resource_spec compile[${compiler} ${compile_options} ${link_options}] failure details are ${compile_output}"
     )
     file(WRITE "${filepath}" "${gpu_json_contents}")
   else()

--- a/rapids-cmake/test/generate_resource_spec.cmake
+++ b/rapids-cmake/test/generate_resource_spec.cmake
@@ -67,7 +67,7 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
   set(error_file ${PROJECT_BINARY_DIR}/rapids-cmake/detect_gpus.stderr.log)
 
   if(NOT EXISTS "${eval_exe}")
-    find_package(CUDAToolkit)
+    find_package(CUDAToolkit QUIET)
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/rapids-cmake/")
 
     if(CUDAToolkit_FOUND)

--- a/rapids-cmake/test/generate_resource_spec.cmake
+++ b/rapids-cmake/test/generate_resource_spec.cmake
@@ -56,7 +56,7 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
 {
 "version": {"major": 1, "minor": 0},
 "local": [{
-  "gpus": [{"id":"0", "slots": 100}]
+  "gpus": [{"id":"0", "slots": 0}]
 }]
 }
 ]=])
@@ -67,10 +67,12 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
   set(error_file ${PROJECT_BINARY_DIR}/rapids-cmake/detect_gpus.stderr.log)
 
   if(NOT EXISTS "${eval_exe}")
-    find_package(CUDAToolkit REQUIRED)
+    find_package(CUDAToolkit)
     file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/rapids-cmake/")
 
-    set(compile_options "-I${CUDAToolkit_INCLUDE_DIRS}")
+    if(CUDAToolkit_FOUND)
+      set(compile_options "-I${CUDAToolkit_INCLUDE_DIRS}" "-DHAVE_CUDA")
+    endif()
     set(link_options ${CUDA_cudart_LIBRARY})
     set(compiler "${CMAKE_CXX_COMPILER}")
     if(NOT DEFINED CMAKE_CXX_COMPILER)
@@ -83,7 +85,7 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
   endif()
 
   if(NOT EXISTS "${eval_exe}")
-    message(STATUS "rapids_test_generate_resource_spec failed to build detection executable, presuming 1 GPU."
+    message(STATUS "rapids_test_generate_resource_spec failed to build detection executable, presuming no GPUs."
     )
     message(STATUS "rapids_test_generate_resource_spec compile failure details are ${compile_output}"
     )

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -49,6 +49,8 @@ add_cmake_config_test(install_relocatable-wrong-component.cmake SHOULD_FAIL "${w
 add_cmake_ctest_test(add-impossible-allocation SHOULD_FAIL "Insufficient resources for test")
 add_cmake_config_test(add-with-install-component.cmake)
 add_cmake_config_test(add-with-no-gpus.cmake)
+
+add_cmake_ctest_test(add-no-cuda-toolkit)
 if(RAPIDS_CMAKE_TESTING_GPU_COUNT GREATER 0)
   add_cmake_ctest_test(add-allocation-simple)
   add_cmake_ctest_test(add-allocation-throws-runtime-error)

--- a/testing/test/add-no-cuda-toolkit/CMakeLists.txt
+++ b/testing/test/add-no-cuda-toolkit/CMakeLists.txt
@@ -1,0 +1,29 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+project(rapids-test-project LANGUAGES CXX)
+
+include(${rapids-cmake-dir}/rapids-test.cmake)
+
+#Disable searching for the CUDA Toolkit so we emulate
+#support for CPU only rapids-cmake-testing support
+set(CMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit True)
+
+rapids_test_init()
+
+add_executable(verify_alloc main.cpp)
+enable_testing()
+rapids_test_add(NAME simple_test COMMAND verify_alloc)

--- a/testing/test/add-no-cuda-toolkit/main.cpp
+++ b/testing/test/add-no-cuda-toolkit/main.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <vector>
+
+int main() { return 0; }


### PR DESCRIPTION
## Description
Fixes #478

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
