### PR TITLE
Drop Pascal architecture (60).

### DIFF
--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -51,7 +51,7 @@ Result Variables
 function(rapids_cuda_set_architectures mode)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cuda.set_architectures")
 
-  set(supported_archs "60" "70" "75" "80" "86" "90")
+  set(supported_archs "70" "75" "80" "86" "90")
 
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.1.0)
     list(REMOVE_ITEM supported_archs "86")

--- a/testing/cuda/validate-cuda-rapids.cmake
+++ b/testing/cuda/validate-cuda-rapids.cmake
@@ -22,8 +22,8 @@ if(NOT location EQUAL -1)
 endif()
 
 # Each item should be `number-real` and should be ordered from low to high.
-# In addition the values should map to Pascal+ GPU arch ( 60+ )
-set(previous_value 59)
+# In addition the values should map to Volta+ GPU arch ( 70+ )
+set(previous_value 69)
 foreach(value IN LISTS CMAKE_CUDA_ARCHITECTURES)
   # verify it ends with `-real`
   string(FIND ${value} "-real" location)
@@ -34,13 +34,13 @@ foreach(value IN LISTS CMAKE_CUDA_ARCHITECTURES)
   string(REPLACE "-real" "" value "${value}")
   if( value LESS previous_value )
       message(FATAL_ERROR "CMAKE_CUDA_ARCHITECTURES values should be ordered lowest to highest."
-                          "with lowest >= 60")
+                          "with lowest >= 70")
   endif()
 endforeach()
 
 if( last_value LESS previous_value )
   message(FATAL_ERROR "CMAKE_CUDA_ARCHITECTURES values should be ordered lowest to highest."
-                      "with lowest >= 60")
+                      "with lowest >= 70")
 endif()
 
 list(APPEND CMAKE_CUDA_ARCHITECTURES ${last_value})


### PR DESCRIPTION
## Description
Per RSN 34, we are dropping Pascal support in v24.02: https://docs.rapids.ai/notices/rsn0034/

This PR drops architecture 60 from the list of RAPIDS architectures.

> **Overview**
> RAPIDS team is planning to deprecate support for Pascal GPUs in its v23.12 release and to remove support in its v24.02 release. v23.12 will be the last version of RAPIDS to support Pascal GPUs.
> **Impact**
> Effective RAPIDS v24.02 release, RAPIDS will no longer support Pascal GPUs. GPUs with Compute Capability 7.0 or higher will be required. Users of Pascal GPUs will be able to continue to use RAPIDS v23.12.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
