### PR TITLE
Remove invalid argument to find_package_root

### DIFF
--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -104,7 +104,7 @@ function(rapids_cpm_libcudacxx)
   if(libcudacxx_SOURCE_DIR)
     # Store where CMake can find our custom libcudacxx
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD libcudacxx "${libcudacxx_SOURCE_DIR}/lib/cmake" FOR
+    rapids_export_find_package_root(BUILD libcudacxx "${libcudacxx_SOURCE_DIR}/lib/cmake"
                                     EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
     rapids_export_find_package_root(INSTALL libcudacxx
                                     [=[${CMAKE_CURRENT_LIST_DIR}/../../rapids/cmake/libcudacxx]=]


### PR DESCRIPTION
## Description
Remove an invalid argument to rapids_export_find_package_root

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
