### PR TITLE
Remove deprecated function usages

### DIFF
--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -104,7 +104,7 @@ function(rapids_cpm_libcudacxx)
   if(libcudacxx_SOURCE_DIR)
     # Store where CMake can find our custom libcudacxx
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD libcudacxx "${libcudacxx_SOURCE_DIR}/lib/cmake" FOR
+    rapids_export_find_package_root(BUILD libcudacxx "${libcudacxx_SOURCE_DIR}/lib/cmake"
                                     EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
     rapids_export_find_package_root(INSTALL libcudacxx
                                     [=[${CMAKE_CURRENT_LIST_DIR}/../../rapids/cmake/libcudacxx]=]

--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -211,19 +211,11 @@ function(rapids_find_generate_module name)
   endif()
 
   # Record what export sets this module is part of
-  if(_RAPIDS_BUILD_EXPORT_SET)
-    include("${rapids-cmake-dir}/export/find_package_file.cmake")
-    rapids_export_find_package_file(BUILD
-                                    "${CMAKE_BINARY_DIR}/cmake/find_modules/Find${name}.cmake"
-                                    ${_RAPIDS_BUILD_EXPORT_SET})
-  endif()
-
-  if(_RAPIDS_INSTALL_EXPORT_SET)
-    include("${rapids-cmake-dir}/export/find_package_file.cmake")
-    rapids_export_find_package_file(INSTALL
-                                    "${CMAKE_BINARY_DIR}/cmake/find_modules/Find${name}.cmake"
-                                    ${_RAPIDS_INSTALL_EXPORT_SET})
-  endif()
+  include("${rapids-cmake-dir}/export/find_package_file.cmake")
+  rapids_export_find_package_file(BUILD "${CMAKE_BINARY_DIR}/cmake/find_modules/Find${name}.cmake"
+                                  EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
+  rapids_export_find_package_file(INSTALL "${CMAKE_BINARY_DIR}/cmake/find_modules/Find${name}.cmake"
+                                  EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET})
 endfunction()
 
 cmake_policy(POP)

--- a/testing/export/write_dependencies-root-dirs.cmake
+++ b/testing/export/write_dependencies-root-dirs.cmake
@@ -16,7 +16,7 @@
 include(${rapids-cmake-dir}/export/find_package_root.cmake)
 include(${rapids-cmake-dir}/export/write_dependencies.cmake)
 
-rapids_export_find_package_root(BUILD RMM [=[${CMAKE_CURRENT_LIST_DIR}/fake/build/path]=] test_set)
+rapids_export_find_package_root(BUILD RMM [=[${CMAKE_CURRENT_LIST_DIR}/fake/build/path]=] EXPORT_SET test_set)
 rapids_export_write_dependencies(build test_set "${CMAKE_CURRENT_BINARY_DIR}/build_export_set.cmake")
 
 rapids_export_find_package_root(BUILD RMM "/bad/install/path" EXPORT_SET ${unknown_var}) #ignored
@@ -32,11 +32,11 @@ if(is_found EQUAL -1)
 endif()
 
 rapids_export_find_package_root(install RMM "/first/install/path" EXPORT_SET test_set)
-rapids_export_find_package_root(INSTALL RMM "/second/install/path" test_set)
+rapids_export_find_package_root(INSTALL RMM "/second/install/path" EXPORT_SET test_set)
 set(to_install FALSE)
 rapids_export_find_package_root(INSTALL RMM "/bad/install/path" EXPORT_SET test_set CONDITION to_install) #ignored
 
-rapids_export_find_package_root(install PKG2 "/pkg2/install/path" test_set)
+rapids_export_find_package_root(install PKG2 "/pkg2/install/path" EXPORT_SET test_set)
 rapids_export_write_dependencies(INSTALL test_set "${CMAKE_CURRENT_BINARY_DIR}/install_export_set.cmake")
 
 set(install_to_match_string_1 [=[set(RMM_ROOT "/first/install/path;/second/install/path"]=])


### PR DESCRIPTION
## Description
Remove usage of function signatures that are no longer supported in 23.04

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
