### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/rapids-cmake/cpm/patches/nvbench/nvml_with_static_builds.diff
+++ b/rapids-cmake/cpm/patches/nvbench/nvml_with_static_builds.diff
@@ -1,0 +1,39 @@
+diff --git a/nvbench/device_info.cu b/nvbench/device_info.cu
+index 8edad22..a09def3 100644
+--- a/nvbench/device_info.cu
++++ b/nvbench/device_info.cu
+@@ -25,6 +25,10 @@
+
+ #include <cuda_runtime_api.h>
+
++#ifdef NVBENCH_HAS_NVML
++#include <nvbench/internal/nvml.cxx>
++#endif
++
+ #define UNUSED(x) (void)(x)
+
+ namespace nvbench
+@@ -47,6 +51,10 @@ device_info::device_info(int id)
+   NVBENCH_CUDA_CALL(cudaGetDeviceProperties(&m_prop, m_id));
+
+ #ifdef NVBENCH_HAS_NVML
++  // NVML's lifetime should extend for the entirety of the process, so store in a
++  // global.
++  [[maybe_unused]] static auto nvml_lifetime = NVMLLifetimeManager();
++
+   // Retrieve the current device's pci_id as a null-terminated string.
+   // Docs say 13 chars should always be sufficient.
+   constexpr int pci_id_len = 13;
+diff --git a/nvbench/internal/nvml.cxx b/nvbench/internal/nvml.cxx
+index 4f750bc..ce7d874 100644
+--- a/nvbench/internal/nvml.cxx
++++ b/nvbench/internal/nvml.cxx
+@@ -64,8 +64,4 @@ private:
+   bool m_inited{false};
+ };
+
+-// NVML's lifetime should extend for the entirety of the process, so store in a
+-// global.
+-auto nvml_lifetime = NVMLLifetimeManager{};
+-
+ } // namespace

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -59,7 +59,14 @@
       "version" : "0.0",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/nvbench.git",
-      "git_tag" : "b8f0f6b5832dd632006492fd2434c81fdef0f2de"
+      "git_tag" : "b8f0f6b5832dd632006492fd2434c81fdef0f2de",
+      "patches" : [
+        {
+          "file" : "nvbench/nvml_with_static_builds.diff",
+          "issue" : "Add support for nvml with static nvbench [https://github.com/NVIDIA/nvbench/pull/148]",
+          "fixed_in" : ""
+        }
+      ]
     },
     "nvcomp" : {
       "version" : "3.0.4",


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.