### PR TITLE
Add missing nvcomp targets

### DIFF
--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -155,7 +155,11 @@ function(rapids_cpm_nvcomp)
   # provide consistent targets between a found nvcomp and one building from source
   if(NOT TARGET nvcomp::nvcomp AND TARGET nvcomp)
     add_library(nvcomp::nvcomp ALIAS nvcomp)
+  endif()
+  if(NOT TARGET nvcomp::nvcomp_gdeflate AND TARGET nvcomp_gdeflate)
     add_library(nvcomp::nvcomp_gdeflate ALIAS nvcomp_gdeflate)
+  endif()
+  if(NOT TARGET nvcomp::nvcomp_bitcomp AND TARGET nvcomp_bitcomp)
     add_library(nvcomp::nvcomp_bitcomp ALIAS nvcomp_bitcomp)
   endif()
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The list of targets marked as global when finding nvcomp is incomplete and should include the gdeflate and bitcomp libs as well.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
