### PR TITLE
Upgrade nvCOMP to 3.0.5

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -55,7 +55,7 @@
       "git_tag" : "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
     },
     "nvcomp" : {
-      "version" : "3.0.4",
+      "version" : "3.0.5",
       "git_url" : "https://github.com/NVIDIA/nvcomp.git",
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {


### PR DESCRIPTION
## Description
Upgrading to nvCOMP 3.0.5 which fixes some memcheck errors.
Reference: https://github.com/rapidsai/cudf/pull/14581 and https://github.com/rapidsai/cudf/issues/14440

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
