### PR TITLE
Remove CCCL::Thrust from GLOBAL_TARGETS.

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -83,7 +83,7 @@ function(rapids_cpm_cccl)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(CCCL ${version} ${ARGN}
-                  GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::Thrust CCCL::CUB CCCL::libcudacxx
+                  GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}


### PR DESCRIPTION
## Description
I saw an error (below) and @robertmaynard helped me identify that this change was needed.

I was building cuGraph ([this branch](https://github.com/rapidsai/cugraph/pull/4052)) with rapids-cmake pointing to [this branch](https://github.com/NVIDIA/cuCollections/pull/404) of cuCollections.
```
-- CPM: Adding package cuco@0.0.1 (cccl-2.2.0)
CMake Error at build/release/_deps/rapids-cmake-src/rapids-cmake/cmake/make_global.cmake:59 (set_target_properties):
  Attempt to promote imported target "CCCL::Thrust" to global scope (by
  setting IMPORTED_GLOBAL) which is not built in this directory.
Call Stack (most recent call first):
  build/release/_deps/rapids-cmake-src/rapids-cmake/cpm/find.cmake:189 (rapids_cmake_make_global)
  build/release/_deps/rapids-cmake-src/rapids-cmake/cpm/cccl.cmake:85 (rapids_cpm_find)
  build/release/_deps/cuco-src/cmake/thirdparty/get_cccl.cmake:18 (rapids_cpm_cccl)
  build/release/_deps/cuco-src/cmake/thirdparty/get_cccl.cmake:21 (find_and_configure_cccl)
  build/release/_deps/cuco-src/CMakeLists.txt:79 (include)
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
