### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `rapids-cpm` module contains CPM functionality to allow projects to acquire 
 For consistency, all targets brought in via `rapids-cpm` are GLOBAL targets.
 
 - `rapids_cpm_init()` handles initialization of the CPM module.
-- `raipds_cpm_find(<project> name BUILD_EXPORT_SET <name> INSTALL_EXPORT_SET <name>)` Will search for a module and fall back to installing via CPM. Offers support to track dependencies for easy package exporting
+- `rapids_cpm_find(<project> name BUILD_EXPORT_SET <name> INSTALL_EXPORT_SET <name>)` Will search for a module and fall back to installing via CPM. Offers support to track dependencies for easy package exporting
 
 ### cuda
 


### PR DESCRIPTION
## Description

Fixes a typo in the README... `consistentcy -> consistency`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
