### PR TITLE
Set CCCL_TOPLEVEL_PROJECT to ON.

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -90,7 +90,8 @@ function(rapids_cpm_cccl)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
+                  OPTIONS "CCCL_TOPLEVEL_PROJECT ON" "CCCL_ENABLE_TESTING OFF"
+                          "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(CCCL)

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -91,7 +91,7 @@ function(rapids_cpm_cccl)
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_TOPLEVEL_PROJECT ON" "CCCL_ENABLE_TESTING OFF"
-                          "CCCL_ENABLE_INSTALL_RULES ${to_install}")
+                          "CCCL_ENABLE_EXAMPLES OFF" "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(CCCL)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -45,6 +45,7 @@ add_cmake_config_test( cpm_generate_patch_command-current_json_dir.cmake )
 
 add_cmake_config_test( cpm_cccl-simple.cmake )
 add_cmake_config_test( cpm_cccl-export.cmake )
+add_cmake_build_test( cpm_cccl-verify-install-custom-libdir )
 
 add_cmake_config_test( cpm_cuco-simple.cmake )
 add_cmake_config_test( cpm_cuco-export.cmake )

--- a/testing/cpm/cpm_cccl-verify-install-custom-libdir/CMakeLists.txt
+++ b/testing/cpm/cpm_cccl-verify-install-custom-libdir/CMakeLists.txt
@@ -36,13 +36,13 @@ rapids_export(INSTALL fake
   NAMESPACE test::
   )
 
-# Install our project so we can verify `libcudacxx` can be found
+# Install our project so we can verify CCCL can be found
 # from a custom install location
 add_custom_target(install_project ALL
   COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix install/fake/
   )
 
-# Add a custom command that verifies that the expect files have
+# Add a custom command that verifies that the expected files have
 # been installed for each component
 file(WRITE "${CMAKE_BINARY_DIR}/install/CMakeLists.txt" [=[
 cmake_minimum_required(VERSION 3.20)

--- a/testing/cpm/cpm_cccl-verify-install-custom-libdir/CMakeLists.txt
+++ b/testing/cpm/cpm_cccl-verify-install-custom-libdir/CMakeLists.txt
@@ -1,0 +1,62 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/export/export.cmake)
+
+project(fake LANGUAGES CXX VERSION 3.1.4)
+
+rapids_cpm_init()
+
+set(CMAKE_INSTALL_LIBDIR "lib/aarch64")
+rapids_cpm_cccl(INSTALL_EXPORT_SET fake_set)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+target_link_libraries(fakeLib INTERFACE CCCL::CCCL)
+
+rapids_export(INSTALL fake
+  EXPORT_SET fake_set
+  NAMESPACE test::
+  )
+
+# Install our project so we can verify `libcudacxx` can be found
+# from a custom install location
+add_custom_target(install_project ALL
+  COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix install/fake/
+  )
+
+# Add a custom command that verifies that the expect files have
+# been installed for each component
+file(WRITE "${CMAKE_BINARY_DIR}/install/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.20)
+project(verify_install_targets LANGUAGES CXX)
+
+set(computed_path "${CMAKE_CURRENT_SOURCE_DIR}/fake/lib/aarch64/cmake/fake/")
+find_package(fake REQUIRED NO_DEFAULT_PATH HINTS ${computed_path})
+if(NOT TARGET CCCL::CCCL)
+  message(FATAL_ERROR "Failed to import CCCL dependency")
+endif()
+]=])
+
+add_custom_target(verify_install_cccl_works ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/install/build"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_BINARY_DIR}/install" -B="${CMAKE_BINARY_DIR}/install/build"
+)
+add_dependencies(verify_install_cccl_works install_project)


### PR DESCRIPTION
## Description
This helps fix some CCCL issues observed in https://github.com/rapidsai/rmm/pull/1404.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
