### PR TITLE
Disable NVBench CUPTI support by default.

### DIFF
--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -43,6 +43,10 @@ across all RAPIDS projects.
   Will build nvbench statically. No local searching for a previously
   built version will occur.
 
+.. versionchanged:: v24.02.00
+
+NVBench_ENABLE_CUPTI is set to OFF by default.
+
 Result Targets
 ^^^^^^^^^^^^^^
   nvbench::nvbench target will be created

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -93,8 +93,11 @@ function(rapids_cpm_nvbench)
                   GIT_SHALLOW ${shallow}
                   PATCH_COMMAND ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}" "NVBench_ENABLE_EXAMPLES OFF"
-                          "NVBench_ENABLE_TESTING OFF" "NVBench_ENABLE_INSTALL_RULES ${to_install}"
+                  OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}"
+                          "NVBench_ENABLE_CUPTI OFF"
+                          "NVBench_ENABLE_EXAMPLES OFF"
+                          "NVBench_ENABLE_TESTING OFF"
+                          "NVBench_ENABLE_INSTALL_RULES ${to_install}"
                           "BUILD_SHARED_LIBS ${build_shared}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")

--- a/testing/cpm/cpm_nvbench-conda-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-conda-fmt.cmake
@@ -25,7 +25,6 @@ rapids_cuda_set_architectures(RAPIDS)
 
 # Force shared libs so that nvbench doesn't have a chance to use a static fmt
 set(BUILD_SHARED_LIBS ON)
-set(NVBench_ENABLE_CUPTI OFF)
 rapids_cpm_init()
 rapids_cpm_rmm()
 rapids_cpm_nvbench()

--- a/testing/cpm/cpm_nvbench-conda.cmake
+++ b/testing/cpm/cpm_nvbench-conda.cmake
@@ -29,7 +29,6 @@ set(ENV{CONDA_BUILD} "1")
 set(ENV{BUILD_PREFIX} "/usr/local/build_prefix")
 set(ENV{PREFIX} "/opt/local/prefix")
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
-set(NVBench_ENABLE_CUPTI OFF)
 rapids_cpm_init()
 rapids_cpm_nvbench()
 


### PR DESCRIPTION
## Description
This PR disables CUPTI support in NVBench by default.

In essentially all of RAPIDS, we have to set `NVBench_ENABLE_CUPTI OFF`. By default, this is enabled, but it leads to several problems. First, when CUPTI support is enabled, the benchmark executables require the same CUDA major.minor version at runtime, meaning that (for instance) we can't build with CUDA 11.8 and expect that the benchmarks can be run with CUDA 11.5. Generally RAPIDS wants to produce builds that follow rules for CUDA minor version compatibility within a CUDA major version. Secondly, developers (especially new developers building from source) frequently run into issues where CUPTI is not available. We don't make `cuda-cupti-dev` a conda dependency in cudf, specifically because we disable CUPTI support most of the time. However, users building from source or using their own build invocations won't have CUPTI disabled, and run into problems compiling because of this missing dependency.

Examples:
- https://github.com/rapidsai/cudf/blob/d1ba966536e30dc728c09726f6ec595100bfea68/conda/recipes/libcudf/build.sh#L9
- https://github.com/rapidsai/cudf/blob/d1ba966536e30dc728c09726f6ec595100bfea68/.github/workflows/pr.yaml#L140

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
