### PR TITLE
Mark flaky test as serial

### DIFF
--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -79,7 +79,7 @@ add_cmake_config_test( cpm_nvcomp-proprietary-off.cmake )
 add_cmake_config_test( cpm_nvcomp-proprietary-on.cmake )
 add_cmake_config_test( cpm_nvcomp-simple.cmake )
 add_cmake_config_test( cpm_nvcomp-invalid-arch.cmake )
-add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake )
+add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake SERIAL)
 
 add_cmake_config_test( cpm_proprietary-url-ctk-version-find-ctk.cmake )
 add_cmake_config_test( cpm_proprietary-url-ctk-version.cmake )


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This test may be running into issues with the multi-config generator running in parallel.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
