### PR TITLE
Only apply install rules if we actually downloaded

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -92,7 +92,7 @@ function(rapids_cpm_cccl)
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
-  if(to_install)
+  if(CCCL_SOURCE_DIR AND to_install)
     # CCCL does not currently correctly support installation of cub/thrust/libcudacxx. The only
     # option that makes this work is to manually invoke the install rules until CCCL's CMake is
     # fixed.


### PR DESCRIPTION
## Description
This fixes `rapids_cpm_cccl` to only call the logic for install rules if CCCL was downloaded.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
