### PR TITLE
Fix docs references to API sections.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,6 +35,8 @@ tracking of these dependencies for correct export support.
    /command/rapids_cpm_find
    /command/rapids_cpm_package_override
 
+.. _`cpm_pre-configured_packages`:
+
 CPM Pre-Configured Packages
 ***************************
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -31,13 +31,13 @@ Usage
 ``rapids-cmake`` is designed for projects to use only the subset of features that they need. To enable
 this `rapids-cmake` comprises the following primary components:
 
-- `cmake <api.html#common>`__
-- `cpm <api.html#cpm>`__
-- `cython <api.html#cython>`__
-- `cuda <api.html#cuda>`__
-- `export <api.html#export>`__
-- `find <api.html#find>`__
-- `testing <api.html#testing>`__
+- :ref:`cmake <common>`
+- :ref:`cpm <cpm>`
+- :ref:`cython <cython>`
+- :ref:`cuda <cuda>`
+- :ref:`export <export>`
+- :ref:`find <find>`
+- :ref:`testing <testing>`
 
 There are two ways projects can use ``rapids-cmake`` functions.
 

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -132,7 +132,7 @@ Overriding
 ^^^^^^^^^^
 
 The :cmake:command:`rapids_cpm_package_override` command provides a way
-for projects to override the default values for any :cmake:command:`rapids_cpm_find`, `rapids_cpm_* <../api.html#cpm-pre-configured-packages>`__,
+for projects to override the default values for any :cmake:command:`rapids_cpm_find`, :ref:`rapids_cpm_* <cpm_pre-configured_packages>`,
 `CPM <https://github.com/cpm-cmake/CPM.cmake>`_, and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package.
 
 By default when an override for a project is provided no local search

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -21,7 +21,7 @@ rapids_cpm_package_override
 
 .. versionadded:: v21.10.00
 
-Overrides the :cmake:command:`rapids_cpm_find`, `rapids_cpm_* <../api.html#cpm-pre-configured-packages>`__,
+Overrides the :cmake:command:`rapids_cpm_find`, :ref:`rapids_cpm_* <cpm_pre-configured_packages>`,
 `CPM <https://github.com/cpm-cmake/CPM.cmake>`_, and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package information for the project.
 
 .. code-block:: cmake
@@ -29,7 +29,7 @@ Overrides the :cmake:command:`rapids_cpm_find`, `rapids_cpm_* <../api.html#cpm-p
   rapids_cpm_package_override(<json_file_path>)
 
 Allows projects to override the default values for any :cmake:command:`rapids_cpm_find`,
-`rapids_cpm_* <../api.html#cpm-pre-configured-packages>`__, `CPM <https://github.com/cpm-cmake/CPM.cmake>`_, and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package.
+:ref:`rapids_cpm_* <cpm_pre-configured_packages>`, `CPM <https://github.com/cpm-cmake/CPM.cmake>`_, and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package.
 
 The user provided json file must follow the `versions.json` format,
 which is :ref:`documented here<cpm_version_format>`  and shown in the below


### PR DESCRIPTION
## Description
The links in this section are broken: https://docs.rapids.ai/api/rapids-cmake/stable/basics/#usage

This PR fixes them. We have to use `:ref:` instead of raw HTML links because the HTML structure is different on the public docs website. (like `/api/` instead of `api.html`).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
