### PR TITLE
Update cuCollections for CCCL 2.2.0 support.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -21,7 +21,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "e45ae4e3618b254a3be4ed3aa55e22d06407602a"
+      "git_tag" : "f823d30d6b08a60383266db25821074dbdbe5822"
     },
     "fmt" : {
       "version" : "10.1.1",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -21,7 +21,7 @@
       "version" : "0.0.1",
       "git_shallow" : false,
       "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "7c76a124df0c2cd3fd66e3e080b9470a3b4707c6"
+      "git_tag" : "e45ae4e3618b254a3be4ed3aa55e22d06407602a"
     },
     "fmt" : {
       "version" : "10.1.1",


### PR DESCRIPTION
## Description
Part of #502. This updates cuCollections for CCCL 2.2.0 support. This should be merged when the rest of RAPIDS is ready to update to CCCL 2.2.0, just before merging RMM and other library PRs.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
