### PR TITLE
Remove scikit-build from dependency list

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -143,7 +143,6 @@ dependencies:
       - output_types: [conda, requirements]
         packages:
           - cython>=0.29,<0.30
-          - scikit-build>=0.13.1
           - libpng
           - zlib
       - output_types: [conda]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This dependency shouldn't be necessary, all of our tests of rapids-cython[-core] just spoof that they're being run via the Python interface while actually running as raw CMake.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
