### PR TITLE
rapids_cpm_cccl preserve install location details from first invocation.

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -92,9 +92,10 @@ function(rapids_cpm_cccl)
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
-  # rapids_cpm_cccl can be called multiple times from the same scope such as from cudf/CMakeLists.txt
-  # and cudf's call to find_package(rmm). In these situations, subsequent invocations will still have
-  # `CCCL_SOURCE_DIR` set due to how `rapids_cpm_find` early termination sets up variables
+  # rapids_cpm_cccl can be called multiple times from the same scope such as from
+  # cudf/CMakeLists.txt and cudf's call to find_package(rmm). In these situations, subsequent
+  # invocations will still have `CCCL_SOURCE_DIR` set due to how `rapids_cpm_find` early termination
+  # sets up variables
   #
   # So to properly preserve any custom install location values from the first invocation we need a
   # global property that we use to track that the cccl install rules have been called

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -92,7 +92,7 @@ function(rapids_cpm_cccl)
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
-  # rapids_cpm_ccl can be called multiple times from the same scope such as from cudf/CMakeLists.txt
+  # rapids_cpm_cccl can be called multiple times from the same scope such as from cudf/CMakeLists.txt
   # and cudf's call to find_package(rmm). In these situations, subsequent invocations will still have
   # `CCCL_SOURCE_DIR` set due to how `rapids_cpm_find` early termination sets up variables
   #

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -93,7 +93,7 @@ function(rapids_cpm_cccl)
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
   # rapids_cpm_ccl can be called multiple times from the same scope such as from cudf/CMakeLists.txt
-  # and cudfs call to find_package(rmm) In these situations the second+ invocations will still have
+  # and cudf's call to find_package(rmm). In these situations, subsequent invocations will still have
   # `CCCL_SOURCE_DIR` set due to how `rapids_cpm_find` early termination sets up variables
   #
   # So to properly preserve any custom install location values from the first invocation we need a

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -92,10 +92,19 @@ function(rapids_cpm_cccl)
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 
-  if(CCCL_SOURCE_DIR AND to_install)
+  # rapids_cpm_ccl can be called multiple times from the same scope such as from cudf/CMakeLists.txt
+  # and cudfs call to find_package(rmm) In these situations the second+ invocations will still have
+  # `CCCL_SOURCE_DIR` set due to how `rapids_cpm_find` early termination sets up variables
+  #
+  # So to properly preserve any custom install location values from the first invocation we need a
+  # global property that we use to track that the cccl install rules have been called
+  get_property(rapids_cccl_install_rules_already_called GLOBAL
+               PROPERTY rapids_cmake_cccl_install_rules SET)
+  if(CCCL_SOURCE_DIR AND to_install AND NOT rapids_cccl_install_rules_already_called)
     # CCCL does not currently correctly support installation of cub/thrust/libcudacxx. The only
     # option that makes this work is to manually invoke the install rules until CCCL's CMake is
     # fixed.
+    set_property(GLOBAL PROPERTY rapids_cmake_cccl_install_rules ON)
     set(Thrust_SOURCE_DIR "${CCCL_SOURCE_DIR}/thrust")
     set(CUB_SOURCE_DIR "${CCCL_SOURCE_DIR}/cub")
     set(libcudacxx_SOURCE_DIR "${CCCL_SOURCE_DIR}/libcudacxx")

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -45,6 +45,7 @@ add_cmake_config_test( cpm_generate_patch_command-current_json_dir.cmake )
 
 add_cmake_config_test( cpm_cccl-simple.cmake )
 add_cmake_config_test( cpm_cccl-export.cmake )
+add_cmake_build_test( cpm_cccl-preserve-custom-install-loc )
 
 add_cmake_config_test( cpm_cuco-simple.cmake )
 add_cmake_config_test( cpm_cuco-export.cmake )

--- a/testing/cpm/cpm_cccl-preserve-custom-install-loc/CMakeLists.txt
+++ b/testing/cpm/cpm_cccl-preserve-custom-install-loc/CMakeLists.txt
@@ -1,0 +1,74 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.23)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
+
+project(fake LANGUAGES CXX VERSION 3.1.4)
+
+rapids_cpm_init()
+
+include(GNUInstallDirs)
+
+function(call_cccl_with_custom_install_loc)
+  set(CMAKE_INSTALL_LIBDIR "custom/lib/aarch64")
+  set(CMAKE_INSTALL_INCLUDEDIR "custom/include/aarch64")
+  rapids_cpm_cccl(INSTALL_EXPORT_SET export_set)
+endfunction()
+
+# We will install with the custom install location set in this file
+call_cccl_with_custom_install_loc()
+
+# Call for `cccl` again but ensure we don't re-invoke the install
+# rules overwriting the custom install location in files
+# like thrust-header-search.cmake
+rapids_cpm_cccl(INSTALL_EXPORT_SET export_set)
+
+# Install our project so we can verify `cccl`/`thrust` has preserved
+# the correct install location
+add_custom_target(install_project ALL
+  COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}" --prefix check_thrust/install/
+  )
+
+# Add a custom command that verifies that the expect files have
+# been installed for each component
+file(WRITE "${CMAKE_BINARY_DIR}/check_thrust/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.20)
+project(verify_install_targets LANGUAGES CXX)
+
+set(computed_dir "${CMAKE_CURRENT_SOURCE_DIR}/install/custom/lib/aarch64/rapids/cmake/thrust/")
+set(header_search_file "${computed_dir}/thrust-header-search.cmake")
+
+if(NOT EXISTS ${header_search_file})
+  message(FATAL_ERROR "Failed to compute thrust-header-search.cmake location")
+endif()
+
+include("${header_search_file}")
+# The `from_install_prefix` should be "custom/lib/aarch64/rapids/cmake/thrust" which
+# will be transformed into `../../../../../../`
+set(expected "../../../../../../")
+if(NOT from_install_prefix STREQUAL expected)
+  message(FATAL_ERROR "thrust-header-search.cmake contains the wrong 'from_install_prefix'. Expected '${expected}' but found '${from_install_prefix}'")
+endif()
+]=])
+
+
+add_custom_target(verify_thrust_header_search ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/check_thrust/build"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_BINARY_DIR}/check_thrust" -B="${CMAKE_BINARY_DIR}/install/build"
+)
+add_dependencies(verify_thrust_header_search install_project)


### PR DESCRIPTION
## Description
Previously we would run the install rules each time rapids_cpm_cccl was called, since we checked for `CCCL_SOURCE_DIR` and that could have been defined by an earlier invocation at the same scope.

This causes issue when the first invocation of `rapids_cpm_cccl` used a custom install location.
CMake's install rules would use the first location, but CCCL install files would contain the second location since they got re-configured on each execution.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
