### PR TITLE
rapids cpm patches now support differences in white space.

### DIFF
--- a/rapids-cmake/cpm/patches/command_template.cmake.in
+++ b/rapids-cmake/cpm/patches/command_template.cmake.in
@@ -37,7 +37,7 @@ function(rapids_cpm_run_git_patch file issue)
   set(result 1)
   if(ext STREQUAL "diff")
     execute_process(
-      COMMAND ${git_command} apply ${file}
+      COMMAND ${git_command} apply --whitespace=fix ${file}
       RESULT_VARIABLE result
       ERROR_VARIABLE repo_error_info
     )


### PR DESCRIPTION
## Description
Sometimes projects trim trailing whitespace from diffs, which causes them to not match the source. This allows us to handle those diff files

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
