### PR TITLE
refactor CUDA versions in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,8 @@ files:
     output: none
     includes:
       - build
-      - cudatoolkit
+      - cuda
+      - cuda_version
       - docs
       - py_version
       - test
@@ -17,7 +18,7 @@ files:
   docs:
     output: none
     includes:
-      - cudatoolkit
+      - cuda_version
       - docs
 channels:
   - rapidsai
@@ -80,9 +81,8 @@ dependencies:
           - matrix:
               cuda: "12.0"
             packages:
-              - cuda-version=12.0
               - cuda-nvcc
-  cudatoolkit:
+  cuda_version:
     specific:
       - output_types: conda
         matrices:
@@ -90,41 +90,63 @@ dependencies:
               cuda: "11.2"
             packages:
               - cuda-version=11.2
+          - matrix:
+              cuda: "11.4"
+            packages:
+              - cuda-version=11.4
+          - matrix:
+              cuda: "11.5"
+            packages:
+              - cuda-version=11.5
+          - matrix:
+              cuda: "11.6"
+            packages:
+              - cuda-version=11.6
+          - matrix:
+              cuda: "11.8"
+            packages:
+              - cuda-version=11.8
+          - matrix:
+              cuda: "12.0"
+            packages:
+              - cuda-version=12.0
+  cuda:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.2"
+            packages:
               - cudatoolkit
               - gcc<11.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "11.4"
             packages:
-              - cuda-version=11.4
               - cudatoolkit
               - gcc<11.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "11.5"
             packages:
-              - cuda-version=11.5
               - cudatoolkit
               - gcc<11.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "11.6"
             packages:
-              - cuda-version=11.6
               - cudatoolkit
               - gcc<12.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "11.8"
             packages:
-              - cuda-version=11.8
               - cudatoolkit
               - gcc<12.0.0
               - sysroot_linux-64==2.17
           - matrix:
               cuda: "12.0"
             packages:
-              - cuda-version=12.0
               - cuda-cupti-dev
               - gcc<13.0.0
               - sysroot_linux-64==2.17

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,7 +35,6 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - make
-          - sysroot_linux-64==2.17
     specific:
       - output_types: conda
         matrices:
@@ -51,6 +50,16 @@ dependencies:
               cuda: "12.*"
             packages:
               - gcc<13.0.0
+      - output_types: conda
+        matrices:
+          - matrix:
+              arch: x86_64
+            packages:
+              - sysroot_linux-64==2.17
+          - matrix:
+              arch: aarch64
+            packages:
+              - sysroot_linux-aarch64==2.17
       - output_types: conda
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,7 +35,22 @@ dependencies:
           - c-compiler
           - cxx-compiler
           - make
+          - sysroot_linux-64==2.17
     specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              cuda: "11.[245]"
+            packages:
+              - gcc<11.0.0
+          - matrix:
+              cuda: "11.[68]"
+            packages:
+              - gcc<12.0.0
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - gcc<13.0.0
       - output_types: conda
         matrices:
           - matrix:
@@ -115,41 +130,13 @@ dependencies:
       - output_types: conda
         matrices:
           - matrix:
-              cuda: "11.2"
+              cuda: "11.*"
             packages:
               - cudatoolkit
-              - gcc<11.0.0
-              - sysroot_linux-64==2.17
           - matrix:
-              cuda: "11.4"
-            packages:
-              - cudatoolkit
-              - gcc<11.0.0
-              - sysroot_linux-64==2.17
-          - matrix:
-              cuda: "11.5"
-            packages:
-              - cudatoolkit
-              - gcc<11.0.0
-              - sysroot_linux-64==2.17
-          - matrix:
-              cuda: "11.6"
-            packages:
-              - cudatoolkit
-              - gcc<12.0.0
-              - sysroot_linux-64==2.17
-          - matrix:
-              cuda: "11.8"
-            packages:
-              - cudatoolkit
-              - gcc<12.0.0
-              - sysroot_linux-64==2.17
-          - matrix:
-              cuda: "12.0"
+              cuda: "12.*"
             packages:
               - cuda-cupti-dev
-              - gcc<13.0.0
-              - sysroot_linux-64==2.17
   docs:
     common:
       - output_types: [conda]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/7.

Proposes splitting the `cuda-version` dependency in `dependencies.yaml` out to its own thing, separate from the bits of the CUDA Toolkit this project needs.

### Benefits of this change

* prevents accidental inclusion of multiple `cuda-version` version in environments
* reduces update effort (via enabling more use of globs like `"12.*"`)
* improves the chance that errors like "`conda` recipe is missing a dependency" are caught in CI

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst