### PR TITLE
Generate template copyright year at build time. (#325)

### DIFF
--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -100,6 +100,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   set(patch_script "${CMAKE_BINARY_DIR}/rapids-cmake/patches/${package_name}/patch.cmake")
   set(log_file "${CMAKE_BINARY_DIR}/rapids-cmake/patches/${package_name}/log")
   if(patch_files_to_run)
+    string(TIMESTAMP current_year "%Y" UTC)
     configure_file(${rapids-cmake-dir}/cpm/patches/command_template.cmake.in "${patch_script}"
                    @ONLY)
     set(${patch_command} ${CMAKE_COMMAND} -P ${patch_script} PARENT_SCOPE)

--- a/rapids-cmake/cpm/patches/command_template.cmake.in
+++ b/rapids-cmake/cpm/patches/command_template.cmake.in
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) @current_year@, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/export/cpm.cmake
+++ b/rapids-cmake/export/cpm.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,6 +74,7 @@ function(rapids_export_cpm type name export_set)
     endif()
   endif()
 
+  string(TIMESTAMP current_year "%Y" UTC)
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/cpm.cmake.in"
                  "${CMAKE_BINARY_DIR}/rapids-cmake/${export_set}/${type}/cpm_${name}.cmake" @ONLY)
 

--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -282,6 +282,7 @@ if EXPORT_NAME isn't set for the export targets.")
 
     set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/${project_name}")
 
+    string(TIMESTAMP current_year "%Y" UTC)
     configure_package_config_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/config.cmake.in"
                                   "${scratch_dir}/${project_name}-config.cmake"
                                   INSTALL_DESTINATION "${install_location}")
@@ -322,6 +323,7 @@ if EXPORT_NAME isn't set for the export targets.")
 
   else()
     set(install_location "${PROJECT_BINARY_DIR}")
+    string(TIMESTAMP current_year "%Y" UTC)
     configure_package_config_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/config.cmake.in"
                                   "${install_location}/${project_name}-config.cmake"
                                   INSTALL_DESTINATION "${install_location}")

--- a/rapids-cmake/export/template/config.cmake.in
+++ b/rapids-cmake/export/template/config.cmake.in
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) @current_year@, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/export/template/cpm.cmake.in
+++ b/rapids-cmake/export/template/cpm.cmake.in
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) @current_year@, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/export/write_dependencies.cmake
+++ b/rapids-cmake/export/write_dependencies.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ endif()\n")
 
   string(APPEND _RAPIDS_EXPORT_CONTENTS "set(rapids_global_targets ${global_targets})\n")
 
+  string(TIMESTAMP current_year "%Y" UTC)
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/dependencies.cmake.in" "${file_path}"
                  @ONLY)
 endfunction()

--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -201,6 +201,7 @@ function(rapids_find_generate_module name)
   endif()
 
   # Need to generate the module
+  string(TIMESTAMP current_year "%Y" UTC)
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/find_module.cmake.in"
                  "${CMAKE_BINARY_DIR}/cmake/find_modules/Find${name}.cmake" @ONLY)
 

--- a/rapids-cmake/find/template/find_module.cmake.in
+++ b/rapids-cmake/find/template/find_module.cmake.in
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) @current_year@, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ add_cmake_config_test( cpm_package_override-simple.cmake )
 add_cmake_config_test( cpm_generate_patch_command-invalid.cmake )
 add_cmake_config_test( cpm_generate_patch_command-override.cmake )
 add_cmake_config_test( cpm_generate_patch_command-current_json_dir.cmake )
+add_cmake_config_test( cpm_generate_patch_command-verify-copyright-header.cmake )
 
 add_cmake_config_test( cpm_cccl-simple.cmake )
 add_cmake_config_test( cpm_cccl-export.cmake )

--- a/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
+++ b/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
@@ -1,0 +1,51 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
+include(${rapids-cmake-testing-dir}/utils/check_copyright_header.cmake)
+
+rapids_cpm_init()
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages" : {
+    "pkg_with_patch" : {
+      "version" : "10.2",
+      "git_tag" : "a_tag",
+      "git_shallow" : "OFF",
+      "exclude_from_all" : "ON",
+      "patches" : [
+        {
+          "file" : "e/example.diff",
+          "issue" : "explain",
+          "fixed_in" : ""
+        }
+      ]
+    }
+  }
+}
+  ]=])
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+if(NOT patch_command)
+  message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
+endif()
+
+check_copyright_header("${CMAKE_BINARY_DIR}/rapids-cmake/patches/pkg_with_patch/patch.cmake")

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ add_cmake_config_test( export-verify-file-names.cmake )
 add_cmake_config_test( export-verify-implicit-disabled-version.cmake )
 add_cmake_config_test( export-verify-implicit-major-version-only-matching.cmake )
 add_cmake_config_test( export-verify-version.cmake )
+add_cmake_config_test( export-verify-copyright-header.cmake )
 
 add_cmake_config_test( export_component-build )
 

--- a/testing/export/export-verify-copyright-header.cmake
+++ b/testing/export/export-verify-copyright-header.cmake
@@ -1,0 +1,46 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/export/cpm.cmake)
+include(${rapids-cmake-dir}/export/export.cmake)
+include(${rapids-cmake-dir}/export/write_dependencies.cmake)
+include(${rapids-cmake-testing-dir}/utils/check_copyright_header.cmake)
+
+cmake_minimum_required(VERSION 3.23.1)
+project(FakEProJecT LANGUAGES CXX VERSION 3.1.4)
+
+add_library(fakeLib INTERFACE)
+install(TARGETS fakeLib EXPORT fake_set)
+
+rapids_export_cpm(BUILD RaFT FakEProJecT
+                  CPM_ARGS
+                    FAKE_PACKAGE_ARGS TRUE
+                  )
+
+rapids_export_write_dependencies(BUILD FakEProJecT dependencies.cmake)
+
+rapids_export(BUILD FakEProJecT
+  EXPORT_SET fake_set
+  NAMESPACE test::
+  )
+rapids_export(INSTALL FakEProJecT
+  EXPORT_SET fake_set
+  NAMESPACE test::
+  )
+
+check_copyright_header("${CMAKE_BINARY_DIR}/fakeproject-config.cmake")
+check_copyright_header("${CMAKE_BINARY_DIR}/rapids-cmake/fakeproject/export/fakeproject/fakeproject-config.cmake")
+check_copyright_header("${CMAKE_BINARY_DIR}/rapids-cmake/FakEProJecT/build/cpm_RaFT.cmake")
+check_copyright_header("${CMAKE_BINARY_DIR}/dependencies.cmake")

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,3 +44,5 @@ add_cmake_config_test( find_generate_module-header-only )
 add_cmake_config_test( find_generate_module-code-blocks )
 add_cmake_config_test( find_generate_module-back-initial-code-block-var.cmake SHOULD_FAIL "INITIAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test( find_generate_module-back-final-code-block-var.cmake SHOULD_FAIL "FINAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
+
+add_cmake_config_test( find_generate_module-verify-copyright-header.cmake )

--- a/testing/find/find_generate_module-verify-copyright-header.cmake
+++ b/testing/find/find_generate_module-verify-copyright-header.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) @current_year@, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+include(${rapids-cmake-dir}/find/generate_module.cmake)
+include(${rapids-cmake-testing-dir}/utils/check_copyright_header.cmake)
 
-include(CMakeFindDependencyMacro)
+rapids_find_generate_module( RapidsTest
+  HEADER_NAMES rapids-cmake-test-header_only.hpp
+  INSTALL_EXPORT_SET test_set
+  )
 
-@_RAPIDS_EXPORT_CONTENTS@
-
-foreach(target IN LISTS rapids_global_targets)
-  if(TARGET ${target})
-    get_target_property(_is_imported ${target} IMPORTED)
-    get_target_property(_already_global ${target} IMPORTED_GLOBAL)
-    if(_is_imported AND NOT _already_global)
-        set_target_properties(${target} PROPERTIES IMPORTED_GLOBAL TRUE)
-    endif()
-  endif()
-endforeach()
-
-unset(rapids_global_targets)
-unset(rapids_clear_cpm_cache)
+check_copyright_header("${CMAKE_BINARY_DIR}/cmake/find_modules/FindRapidsTest.cmake")

--- a/testing/utils/check_copyright_header.cmake
+++ b/testing/utils/check_copyright_header.cmake
@@ -1,0 +1,42 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include_guard(GLOBAL)
+
+function(check_copyright_header file)
+  string(TIMESTAMP current_year "%Y" UTC)
+  string(CONFIGURE [=[#=============================================================================
+# Copyright (c) @current_year@, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+]=] expected_header @ONLY)
+  string(LENGTH "${expected_header}" expected_header_length)
+
+  file(READ "${file}" actual_header LIMIT "${expected_header_length}")
+  if(NOT actual_header STREQUAL expected_header)
+    message(FATAL_ERROR "File ${file} did not have expected copyright header")
+  endif()
+endfunction()


### PR DESCRIPTION
Rather than hard-coding the copyright year in each template file, get the current year at build time and write it in the template.

## Description
closes #325

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
