### PR TITLE
Always download CCCL.

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,6 +81,9 @@ function(rapids_cpm_cccl)
   # https://github.com/NVIDIA/cccl/pull/1182
   set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
 
+  # Always download CCCL to avoid getting a CCCL 2.2.0 from the CUDA Toolkit (12.2). A local package
+  # will not have the CMake patches that we need.
+  set(CPM_DOWNLOAD_CCCL ON)
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(CCCL ${version} ${ARGN}
                   GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx


### PR DESCRIPTION
## Description
I saw an issue in https://github.com/rapidsai/raft/pull/2092 that can be fixed by always downloading CCCL, so that we can get the required patches for `CCCL::Thrust` install rules. This affects CUDA 12.2 builds because that CTK version ships CCCL 2.2.0 (therefore it has a matching local package).

xref: https://github.com/rapidsai/raft/pull/2092#issuecomment-1888077099

Note: This PR should target 24.02 even if we slip [CUDA 12.2 conda/wheel builds](https://github.com/rapidsai/build-planning/issues/6) to 24.04, since it fixes an issue with source builds using CUDA 12.2.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
