### PR TITLE
Always download repos when they are being patched

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ function(rapids_cpm_cccl)
   rapids_cpm_package_details(CCCL version repository tag shallow exclude)
 
   set(to_install OFF)
+  cmake_policy(SET CMP0057 NEW)
   if(INSTALL_EXPORT_SET IN_LIST ARGN AND NOT exclude)
     set(to_install ON)
     # Make sure we install CCCL into the `include/rapids` subdirectory instead of the default
@@ -82,13 +83,14 @@ function(rapids_cpm_cccl)
   set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
+  message("The patch command inside is ${patch_command}")
   rapids_cpm_find(CCCL ${version} ${ARGN}
                   GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -66,7 +66,6 @@ function(rapids_cpm_cccl)
   rapids_cpm_package_details(CCCL version repository tag shallow exclude)
 
   set(to_install OFF)
-  cmake_policy(SET CMP0057 NEW)
   if(INSTALL_EXPORT_SET IN_LIST ARGN AND NOT exclude)
     set(to_install ON)
     # Make sure we install CCCL into the `include/rapids` subdirectory instead of the default

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -66,6 +66,7 @@ function(rapids_cpm_cccl)
   rapids_cpm_package_details(CCCL version repository tag shallow exclude)
 
   set(to_install OFF)
+  cmake_policy(SET CMP0057 NEW)
   if(INSTALL_EXPORT_SET IN_LIST ARGN AND NOT exclude)
     set(to_install ON)
     # Make sure we install CCCL into the `include/rapids` subdirectory instead of the default
@@ -87,8 +88,7 @@ function(rapids_cpm_cccl)
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "CCCL_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -82,7 +82,6 @@ function(rapids_cpm_cccl)
   set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  message("The patch command inside is ${patch_command}")
   rapids_cpm_find(CCCL ${version} ${ARGN}
                   GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT

--- a/rapids-cmake/cpm/cuco.cmake
+++ b/rapids-cmake/cpm/cuco.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ function(rapids_cpm_cuco)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${to_exclude}
                   OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
                           "INSTALL_CUCO ${to_install}")

--- a/rapids-cmake/cpm/cuco.cmake
+++ b/rapids-cmake/cpm/cuco.cmake
@@ -80,8 +80,7 @@ function(rapids_cpm_cuco)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${to_exclude}
                   OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF" "BUILD_EXAMPLES OFF"
                           "INSTALL_CUCO ${to_install}")

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -103,7 +103,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
     string(TIMESTAMP current_year "%Y" UTC)
     configure_file(${rapids-cmake-dir}/cpm/patches/command_template.cmake.in "${patch_script}"
                    @ONLY)
-    set(${patch_command} ${CMAKE_COMMAND} -P ${patch_script} PARENT_SCOPE)
+    set(${patch_command} "${CMAKE_COMMAND} -P ${patch_script}" PARENT_SCOPE)
   else()
     # remove any old patch / log files that exist and are no longer needed due to a change in the
     # package version / version.json

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -103,7 +103,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
     string(TIMESTAMP current_year "%Y" UTC)
     configure_file(${rapids-cmake-dir}/cpm/patches/command_template.cmake.in "${patch_script}"
                    @ONLY)
-    set(${patch_command} "PATCH_COMMAND ${CMAKE_COMMAND} -P ${patch_script}" PARENT_SCOPE)
+    set(${patch_command} PATCH_COMMAND ${CMAKE_COMMAND} -P ${patch_script} PARENT_SCOPE)
   else()
     # remove any old patch / log files that exist and are no longer needed due to a change in the
     # package version / version.json

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -103,7 +103,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
     string(TIMESTAMP current_year "%Y" UTC)
     configure_file(${rapids-cmake-dir}/cpm/patches/command_template.cmake.in "${patch_script}"
                    @ONLY)
-    set(${patch_command} "${CMAKE_COMMAND} -P ${patch_script}" PARENT_SCOPE)
+    set(${patch_command} "PATCH_COMMAND ${CMAKE_COMMAND} -P ${patch_script}" PARENT_SCOPE)
   else()
     # remove any old patch / log files that exist and are no longer needed due to a change in the
     # package version / version.json

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -144,8 +144,8 @@ modified version is used.
 function(rapids_cpm_find name version)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.find")
   set(options CPM_ARGS)
-  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
-  set(multi_value COMPONENTS GLOBAL_TARGETS PATCH_COMMAND)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET PATCH_COMMAND)
+  set(multi_value COMPONENTS GLOBAL_TARGETS)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   if(NOT DEFINED _RAPIDS_CPM_ARGS)

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -175,7 +175,8 @@ function(rapids_cpm_find name version)
   endif()
 
   if(package_needs_to_be_added)
-    if(CPM_${name}_SOURCE OR DEFINED _RAPIDS_PATCH_COMMAND)
+    # Any nonempty patch command should trigger CPMAddPackage.
+    if(CPM_${name}_SOURCE OR _RAPIDS_PATCH_COMMAND)
       CPMAddPackage(NAME ${name} VERSION ${version} ${_RAPIDS_UNPARSED_ARGUMENTS})
     else()
       CPMFindPackage(NAME ${name} VERSION ${version} ${_RAPIDS_UNPARSED_ARGUMENTS})

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2020-2023, NVIDIA CORPORATION.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -145,11 +145,16 @@ function(rapids_cpm_find name version)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.find")
   set(options CPM_ARGS)
   set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
-  set(multi_value COMPONENTS GLOBAL_TARGETS)
+  set(multi_value COMPONENTS GLOBAL_TARGETS PATCH_COMMAND)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   if(NOT DEFINED _RAPIDS_CPM_ARGS)
     message(FATAL_ERROR "rapids_cpm_find requires you to specify CPM_ARGS before any CPM arguments")
+  endif()
+
+  # Add the patch command back into the list of commands to forward along.
+  if(DEFINED _RAPIDS_PATCH_COMMAND)
+    list(APPEND _RAPIDS_UNPARSED_ARGUMENTS "PATCH_COMMAND" ${_RAPIDS_PATCH_COMMAND})
   endif()
 
   set(package_needs_to_be_added TRUE)
@@ -170,7 +175,7 @@ function(rapids_cpm_find name version)
   endif()
 
   if(package_needs_to_be_added)
-    if(CPM_${name}_SOURCE)
+    if(CPM_${name}_SOURCE OR DEFINED _RAPIDS_PATCH_COMMAND)
       CPMAddPackage(NAME ${name} VERSION ${version} ${_RAPIDS_UNPARSED_ARGUMENTS})
     else()
       CPMFindPackage(NAME ${name} VERSION ${version} ${_RAPIDS_UNPARSED_ARGUMENTS})

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -159,7 +159,6 @@ function(rapids_cpm_find name version)
   # Add the patch command back into the list of commands to forward along.
   set(has_patch FALSE)
   cmake_policy(SET CMP0057 NEW)
-  message("The unparsed args are ${_RAPIDS_UNPARSED_ARGUMENTS}")
   foreach(unparsed_arg IN LISTS _RAPIDS_UNPARSED_ARGUMENTS)
     if(unparsed_arg MATCHES "PATCH_COMMAND")
       set(has_patch TRUE)

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -156,9 +156,7 @@ function(rapids_cpm_find name version)
     message(FATAL_ERROR "rapids_cpm_find requires you to specify CPM_ARGS before any CPM arguments")
   endif()
 
-  # Add the patch command back into the list of commands to forward along.
   set(has_patch FALSE)
-  cmake_policy(SET CMP0057 NEW)
   foreach(unparsed_arg IN LISTS _RAPIDS_UNPARSED_ARGUMENTS)
     if(unparsed_arg MATCHES "PATCH_COMMAND")
       set(has_patch TRUE)
@@ -184,7 +182,7 @@ function(rapids_cpm_find name version)
   endif()
 
   if(package_needs_to_be_added)
-    # Any nonempty patch command should trigger CPMAddPackage.
+    # Any patch command triggers CPMAddPackage.
     if(CPM_${name}_SOURCE OR has_patch)
       CPMAddPackage(NAME ${name} VERSION ${version} ${_RAPIDS_UNPARSED_ARGUMENTS})
     else()

--- a/rapids-cmake/cpm/fmt.cmake
+++ b/rapids-cmake/cpm/fmt.cmake
@@ -68,8 +68,7 @@ function(rapids_cpm_fmt)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "FMT_INSTALL ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
 

--- a/rapids-cmake/cpm/fmt.cmake
+++ b/rapids-cmake/cpm/fmt.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ function(rapids_cpm_fmt)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "FMT_INSTALL ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
 

--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ function(rapids_cpm_gbench)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "BENCHMARK_ENABLE_GTEST_TESTS OFF" "BENCHMARK_ENABLE_TESTING OFF"
                           "BENCHMARK_ENABLE_INSTALL ${to_install}"

--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -77,8 +77,7 @@ function(rapids_cpm_gbench)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "BENCHMARK_ENABLE_GTEST_TESTS OFF" "BENCHMARK_ENABLE_TESTING OFF"
                           "BENCHMARK_ENABLE_INSTALL ${to_install}"

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ function(rapids_cpm_gtest)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "INSTALL_GTEST ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
 

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -68,8 +68,7 @@ function(rapids_cpm_gtest)
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS "EXACT"
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "INSTALL_GTEST ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
 

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -88,8 +88,7 @@ function(rapids_cpm_libcudacxx)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "libcudacxx_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ function(rapids_cpm_libcudacxx)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "libcudacxx_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -94,8 +94,7 @@ function(rapids_cpm_nvbench)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}"
                           "NVBench_ENABLE_CUPTI OFF"

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ function(rapids_cpm_nvbench)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "NVBench_ENABLE_NVML ${nvbench_with_nvml}"
                           "NVBench_ENABLE_CUPTI OFF"

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -144,8 +144,7 @@ function(rapids_cpm_nvcomp)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  EXCLUDE_FROM_ALL ${to_exclude}
-                  PATCH_COMMAND "${patch_command}"
+                  EXCLUDE_FROM_ALL ${to_exclude} ${patch_command}
                   OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
                           "BUILD_EXAMPLES OFF")
 

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ function(rapids_cpm_nvcomp)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
                   EXCLUDE_FROM_ALL ${to_exclude}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"
                           "BUILD_EXAMPLES OFF")
 

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ function(rapids_cpm_package_override filepath)
                              GIT_REPOSITORY ${repository}
                              GIT_TAG ${tag}
                              GIT_SHALLOW ${shallow}
-                             PATCH_COMMAND ${patch_command} EXCLUDE_FROM_ALL ${exclude})
+                             ${patch_command} EXCLUDE_FROM_ALL ${exclude})
       endif()
     endforeach()
   endif()

--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -77,8 +77,7 @@ function(rapids_cpm_rmm)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${to_exclude}
                   OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF")
 

--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ function(rapids_cpm_rmm)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${to_exclude}
                   OPTIONS "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF")
 

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -129,8 +129,7 @@ function(rapids_cpm_spdlog)
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}")
 

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ function(rapids_cpm_spdlog)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "SPDLOG_INSTALL ${to_install}" "${spdlog_fmt_option}")
 

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND ${patch_command}
+                  PATCH_COMMAND "${patch_command}"
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "THRUST_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -84,8 +84,7 @@ function(rapids_cpm_thrust NAMESPACE namespaces_name)
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}
-                  GIT_SHALLOW ${shallow}
-                  PATCH_COMMAND "${patch_command}"
+                  GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
                   OPTIONS "THRUST_ENABLE_INSTALL_RULES ${to_install}")
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -23,6 +23,7 @@ add_cmake_config_test( cpm_find-existing-target )
 add_cmake_config_test( cpm_find-existing-target-to-export-sets )
 add_cmake_config_test( cpm_find-gtest-no-gmock )
 add_cmake_config_test( cpm_find-options-escaped )
+add_cmake_config_test( cpm_find-patch-command)
 add_cmake_config_test( cpm_find-restore-cpm-vars )
 add_cmake_config_test( cpm_find-version-explicit-install.cmake )
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -23,7 +23,7 @@ add_cmake_config_test( cpm_find-existing-target )
 add_cmake_config_test( cpm_find-existing-target-to-export-sets )
 add_cmake_config_test( cpm_find-gtest-no-gmock )
 add_cmake_config_test( cpm_find-options-escaped )
-add_cmake_config_test( cpm_find-patch-command)
+add_cmake_config_test( cpm_find-patch-command )
 add_cmake_config_test( cpm_find-restore-cpm-vars )
 add_cmake_config_test( cpm_find-version-explicit-install.cmake )
 

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,16 +20,16 @@ cmake_minimum_required(VERSION 3.23.1)
 project(rapids-cpm_find-patch-command-project LANGUAGES CXX)
 
 find_package(Git)
-set(cccl_parent_dir "${CMAKE_CURRENT_BINARY_DIR}/_cccl_dep")
+set(deps_dir "${CMAKE_CURRENT_BINARY_DIR}/_cccl_dep")
 
-if(NOT EXISTS "${cccl_parent_dir}")
-file(MAKE_DIRECTORY "${cccl_parent_dir}")
+if(NOT EXISTS "${deps_dir}")
+file(MAKE_DIRECTORY "${deps_dir}")
 execute_process(
 	COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch v2.2.0 https://github.com/NVIDIA/cccl.git
-	WORKING_DIRECTORY "${cccl_parent_dir}")
+	WORKING_DIRECTORY "${deps_dir}")
 endif()
 
-set(cccl_dir "${cccl_parent_dir}/cccl")
+set(cccl_dir "${deps_dir}/cccl")
 list(APPEND CMAKE_PREFIX_PATH "${cccl_dir}")
 unset(CPM_SOURCE_CACHE)
 unset(CPM_SOURCE_CACHE CACHE)
@@ -37,5 +37,14 @@ rapids_cpm_init()
 rapids_cpm_cccl()
 
 if(NOT "${CCCL_ADDED}")
-    message(FATAL_ERROR "The found CPM was used rather than downloading and patching a new version")
+    message(FATAL_ERROR "The found repo was used rather than downloading and patching a new version")
+endif()
+
+execute_process(
+	COMMAND ${GIT_EXECUTABLE} diff-files --quiet
+    RESULT_VARIABLE REPO_IS_DIRTY
+	WORKING_DIRECTORY "${CPM_SOURCE_DIR}")
+
+if(NOT ${REPO_IS_DIRTY})
+    message(FATAL_ERROR "The repo was downloaded but not patched. The value is ${REPO_IS_DIRTY} in ${CPM_SOURCE_DIR}")
 endif()

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 execute_process(
 	COMMAND ${GIT_EXECUTABLE} diff-files --quiet
     RESULT_VARIABLE REPO_IS_DIRTY
-	WORKING_DIRECTORY "${CPM_SOURCE_DIR}")
+    WORKING_DIRECTORY "${CCCL_SOURCE_DIR}")
 
 if(NOT ${REPO_IS_DIRTY})
-    message(FATAL_ERROR "The repo was downloaded but not patched. The value is ${REPO_IS_DIRTY} in ${CPM_SOURCE_DIR}")
+    message(FATAL_ERROR "The repo was downloaded to ${CCCL_SOURCE_DIR} but not patched.")
 endif()

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -13,26 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-include(${rapids-cmake-dir}/cpm/init.cmake)
-include(${rapids-cmake-dir}/cpm/cccl.cmake)
-
 cmake_minimum_required(VERSION 3.23.1)
 project(rapids-cpm_find-patch-command-project LANGUAGES CXX)
 
-find_package(Git)
 set(deps_dir "${CMAKE_CURRENT_BINARY_DIR}/_cccl_dep")
-
 if(NOT EXISTS "${deps_dir}")
-file(MAKE_DIRECTORY "${deps_dir}")
-execute_process(
-	COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch v2.2.0 https://github.com/NVIDIA/cccl.git
-	WORKING_DIRECTORY "${deps_dir}")
+  file(MAKE_DIRECTORY "${deps_dir}")
+  find_package(Git)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch v2.2.0 https://github.com/NVIDIA/cccl.git
+    WORKING_DIRECTORY "${deps_dir}")
 endif()
 
 set(cccl_dir "${deps_dir}/cccl")
 list(APPEND CMAKE_PREFIX_PATH "${cccl_dir}")
 unset(CPM_SOURCE_CACHE)
 unset(CPM_SOURCE_CACHE CACHE)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
 rapids_cpm_init()
 rapids_cpm_cccl()
 
@@ -41,7 +40,7 @@ if(NOT "${CCCL_ADDED}")
 endif()
 
 execute_process(
-	COMMAND ${GIT_EXECUTABLE} diff-files --quiet
+    COMMAND ${GIT_EXECUTABLE} diff-files --quiet
     RESULT_VARIABLE REPO_IS_DIRTY
     WORKING_DIRECTORY "${CCCL_SOURCE_DIR}")
 

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -16,12 +16,15 @@
 cmake_minimum_required(VERSION 3.23.1)
 project(rapids-cpm_find-patch-command-project LANGUAGES CXX)
 
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+rapids_cpm_package_details(CCCL version repository tag shallow exclude)
+
 set(deps_dir "${CMAKE_CURRENT_BINARY_DIR}/_cccl_dep")
 if(NOT EXISTS "${deps_dir}")
   file(MAKE_DIRECTORY "${deps_dir}")
   find_package(Git)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch v2.2.0 https://github.com/NVIDIA/cccl.git
+    COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch "${tag}" "${repository}"
     WORKING_DIRECTORY "${deps_dir}")
 endif()
 

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -1,0 +1,41 @@
+#=============================================================================
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
+
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-cpm_find-patch-command-project LANGUAGES CXX)
+
+find_package(Git)
+set(cccl_parent_dir "${CMAKE_CURRENT_BINARY_DIR}/_cccl_dep")
+
+if(NOT EXISTS "${cccl_parent_dir}")
+file(MAKE_DIRECTORY "${cccl_parent_dir}")
+execute_process(
+	COMMAND ${GIT_EXECUTABLE} clone --depth 1 --branch v2.2.0 https://github.com/NVIDIA/cccl.git
+	WORKING_DIRECTORY "${cccl_parent_dir}")
+endif()
+
+set(cccl_dir "${cccl_parent_dir}/cccl")
+list(APPEND CMAKE_PREFIX_PATH "${cccl_dir}")
+unset(CPM_SOURCE_CACHE)
+unset(CPM_SOURCE_CACHE CACHE)
+rapids_cpm_init()
+rapids_cpm_cccl()
+
+if(NOT "${CCCL_ADDED}")
+    message(FATAL_ERROR "The found CPM was used rather than downloading and patching a new version")
+endif()

--- a/testing/cpm/cpm_find-patch-command/CMakeLists.txt
+++ b/testing/cpm/cpm_find-patch-command/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ endif()
 
 set(to_match_string "set(files \"${CMAKE_CURRENT_BINARY_DIR}/example.diff;${CMAKE_CURRENT_BINARY_DIR}/example2.diff\")")
 
+string(REPLACE " " ";" patch_command ${patch_command})
 list(POP_BACK patch_command script_to_run)
 file(READ "${script_to_run}" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,7 +58,6 @@ endif()
 
 set(to_match_string "set(files \"${CMAKE_CURRENT_BINARY_DIR}/example.diff;${CMAKE_CURRENT_BINARY_DIR}/example2.diff\")")
 
-string(REPLACE " " ";" patch_command ${patch_command})
 list(POP_BACK patch_command script_to_run)
 file(READ "${script_to_run}" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR updates `rapids_cpm_find` to force downloading of a package whenever a nonempty patch command exists.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
