### PR TITLE
rapids_cpm_cccl now works as expected when given `DOWNLOAD_ONLY ON`

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -143,20 +143,22 @@ function(rapids_cpm_cccl)
                                     EXPORT_SET ${_RAPIDS_INSTALL_EXPORT_SET} CONDITION to_install)
   endif()
 
-  # Can be removed once we move to CCCL 2.3
-  #
-  target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
-  target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
-  set(post_find_code
-      [=[
-  target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
-  target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
-  ]=])
-  include("${rapids-cmake-dir}/export/detail/post_find_package_code.cmake")
-  rapids_export_post_find_package_code(BUILD CCCL "${post_find_code}" EXPORT_SET
-                                       ${_RAPIDS_BUILD_EXPORT_SET})
-  rapids_export_post_find_package_code(INSTALL CCCL "${post_find_code}" EXPORT_SET
-                                       ${_RAPIDS_INSTALL_EXPORT_SET} CONDITION to_install)
+  if(TARGET CCCL::CCCL)
+    # Can be removed once we move to CCCL 2.3
+    #
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
+    set(post_find_code
+        [=[
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
+    ]=])
+    include("${rapids-cmake-dir}/export/detail/post_find_package_code.cmake")
+    rapids_export_post_find_package_code(BUILD CCCL "${post_find_code}" EXPORT_SET
+                                         ${_RAPIDS_BUILD_EXPORT_SET})
+    rapids_export_post_find_package_code(INSTALL CCCL "${post_find_code}" EXPORT_SET
+                                         ${_RAPIDS_INSTALL_EXPORT_SET} CONDITION to_install)
+  endif()
 
   # Propagate up variables that CPMFindPackage provides
   set(CCCL_SOURCE_DIR "${CCCL_SOURCE_DIR}" PARENT_SCOPE)


### PR DESCRIPTION
## Description
Only try to modify the CCCL::CCCL target when it exists, so we properly support `DOWNLOAD_ONLY ON` as is used by the rapids-cmake testing infra.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
