### PR TITLE
add rapids-dependency-file-generator pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
     rev: v2.2.2
     hooks:
       - id: codespell
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.8.0
+    hooks:
+        - id: rapids-dependency-file-generator
+          args: ["--clean"]
   - repo: local
     hooks:
       - id: copyright-check


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/46.

Proposes adding a pre-commit hook to run `rapids-dependency-file-generator`.

With that change, local `pre-commit` and CI will raise an error if changes to `dependencies.yaml` cause some error from `rapids-dependency-file-generator`.

If this project checks any files modified by that tool into source control in the future, it'd also raise an error if any of those files change.

This is a bit cheaper way to find out about things like typos, misaligning spacing, etc. than waiting for CI to report it. It's very fast, shouldn't be noticeable in day-to-day development.

### How I tested this

Changed an `output: conda` to `output: condafile` (not a valid output type) in `dependencies.yaml`.

Ran `pre-commit run --all-files`.

Observed the expected failure.

<img width="852" alt="Screenshot 2024-01-31 at 9 14 10 AM" src="https://github.com/rapidsai/rapids-cmake/assets/7608904/bd8dc1d6-8e5c-424c-b493-6fd6d5d10dce">

Reverted that change, ran `pre-commit run --all-files` again, saw everything pass.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
