### PR TITLE
Ensure that `ctest` is called with `--no-tests=error`.

### DIFF
--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 
 set -euo pipefail
 

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -35,7 +35,7 @@ EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
-ctest -j20 --schedule-random --output-on-failure
+ctest -j20 --schedule-random --output-on-failure --no-tests=error
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}


### PR DESCRIPTION
This PR ensures that all calls to `ctest` include the flag `--no-tests=error`. See https://github.com/rapidsai/build-planning/issues/18.
