### PR TITLE
Remove unneeded whitespace from json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
             ^rapids-cmake/cpm/patches/.*
           )
       - id: check-json
+      - id: pretty-format-json
+        args: ["--autofix", "--no-sort-keys"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v16.0.6
     hooks:

--- a/ci/checks/cmake_config_lint.json
+++ b/ci/checks/cmake_config_lint.json
@@ -1,6 +1,9 @@
 {
   "lint": {
-    "disabled_codes": ["C0301", "C0112"],
+    "disabled_codes": [
+      "C0301",
+      "C0112"
+    ],
     "function_pattern": "[0-9A-z_]+",
     "macro_pattern": "[0-9A-z_]+",
     "global_var_pattern": "[A-z][0-9A-z_]+",

--- a/ci/checks/cmake_config_testing_lint.json
+++ b/ci/checks/cmake_config_testing_lint.json
@@ -1,6 +1,10 @@
 {
   "lint": {
-    "disabled_codes": ["C0301", "C0111","C0112"],
+    "disabled_codes": [
+      "C0301",
+      "C0111",
+      "C0112"
+    ],
     "function_pattern": "[0-9A-z_]+",
     "macro_pattern": "[0-9A-z_]+",
     "global_var_pattern": "[A-z][0-9A-z_]+",

--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -1,7 +1,6 @@
 {
   "parse": {
     "additional_commands": {
-
       "rapids_cmake_build_type": {
         "pargs": {
           "nargs": 1
@@ -10,7 +9,9 @@
       "rapids_cmake_install_lib_dir": {
         "pargs": {
           "nargs": 1,
-          "flags": ["MODIFY_INSTALL_LIBDIR"]
+          "flags": [
+            "MODIFY_INSTALL_LIBDIR"
+          ]
         }
       },
       "rapids_cmake_make_global": {
@@ -36,7 +37,9 @@
       "rapids_cmake_support_conda_env": {
         "pargs": {
           "nargs": 1,
-          "flags": ["MODIFY_PREFIX_PATH"]
+          "flags": [
+            "MODIFY_PREFIX_PATH"
+          ]
         }
       },
       "rapids_cmake_write_git_revision_file": {
@@ -55,8 +58,7 @@
           "PREFIX": 1
         }
       },
-
-     "rapids_cpm_find": {
+      "rapids_cpm_find": {
         "pargs": {
           "nargs": "2+"
         },
@@ -87,7 +89,6 @@
           "nargs": 1
         }
       },
-
       "rapids_cpm_cccl": {
         "pargs": {
           "nargs": 0
@@ -118,7 +119,9 @@
       "rapids_cpm_gbench": {
         "pargs": {
           "nargs": 0,
-          "flags": ["BUILD_STATIC"]
+          "flags": [
+            "BUILD_STATIC"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
@@ -146,7 +149,9 @@
       "rapids_cpm_nvbench": {
         "pargs": {
           "nargs": 0,
-          "flags": ["BUILD_STATIC"]
+          "flags": [
+            "BUILD_STATIC"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
@@ -191,7 +196,6 @@
           "INSTALL_EXPORT_SET": 1
         }
       },
-
       "rapids_cuda_init_architectures": {
         "pargs": {
           "nargs": 1
@@ -212,11 +216,13 @@
           "nargs": 3
         }
       },
-
       "rapids_export_cpm": {
         "pargs": {
           "nargs": "3+",
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         },
         "kwargs": {
           "GLOBAL_TARGETS": "+",
@@ -226,7 +232,10 @@
       "rapids_export": {
         "pargs": {
           "nargs": "2+",
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         },
         "kwargs": {
           "EXPORT_SET": 1,
@@ -243,7 +252,10 @@
       "rapids_export_find_package_file": {
         "pargs": {
           "nargs": "3+",
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         },
         "kwargs": {
           "EXPORT_SET": 1,
@@ -253,7 +265,10 @@
       "rapids_export_find_package_root": {
         "pargs": {
           "nargs": "3+",
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         },
         "kwargs": {
           "EXPORT_SET": 1,
@@ -273,16 +288,21 @@
       "rapids_export_write_dependencies": {
         "pargs": {
           "nargs": 3,
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         }
       },
       "rapids_export_write_language": {
         "pargs": {
           "nargs": 3,
-          "flags": ["INSTALL", "BUILD"]
+          "flags": [
+            "INSTALL",
+            "BUILD"
+          ]
         }
       },
-
       "rapids_find_generate_module": {
         "pargs": {
           "nargs": "1+",
@@ -373,7 +393,9 @@
       "rapids_test_install_relocatable": {
         "pargs": {
           "nargs": "0",
-          "flags": ["INCLUDE_IN_ALL"]
+          "flags": [
+            "INCLUDE_IN_ALL"
+          ]
         },
         "kwargs": {
           "INSTALL_COMPONENT_SET": "1",

--- a/docs/packages/example.json
+++ b/docs/packages/example.json
@@ -1,13 +1,13 @@
 
 {
-  "packages" : {
-    "Thrust" : {
-      "version" : "1.12.0",
-      "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "${version}",
-      "git_shallow" : true,
-      "always_download" : true,
-      "exclude_from_all" : false
+  "packages": {
+    "Thrust": {
+      "version": "1.12.0",
+      "git_url": "https://github.com/NVIDIA/thrust.git",
+      "git_tag": "${version}",
+      "git_shallow": true,
+      "always_download": true,
+      "exclude_from_all": false
     }
   }
 }

--- a/docs/packages/example.json
+++ b/docs/packages/example.json
@@ -1,4 +1,3 @@
-
 {
   "packages": {
     "Thrust": {

--- a/docs/packages/patches.json
+++ b/docs/packages/patches.json
@@ -1,9 +1,9 @@
 {
-  "patches" : [
+  "patches": [
     {
-      "file" : "Thrust/cub_odr.diff",
-      "issue" : "cub kernel dispatch ODR [https://github.com/NVIDIA/cub/issues/545]",
-      "fixed_in" : ""
+      "file": "Thrust/cub_odr.diff",
+      "issue": "cub kernel dispatch ODR [https://github.com/NVIDIA/cub/issues/545]",
+      "fixed_in": ""
     }
   ]
 }

--- a/docs/packages/proprietary_binary.json
+++ b/docs/packages/proprietary_binary.json
@@ -1,4 +1,3 @@
-
 {
   "proprietary_binary": {
     "aarch64-linux": "<url>",

--- a/docs/packages/proprietary_binary.json
+++ b/docs/packages/proprietary_binary.json
@@ -1,7 +1,7 @@
 
 {
-  "proprietary_binary" : {
-    "aarch64-linux" : "<url>",
-    "x86_64-linux" : "<url>"
+  "proprietary_binary": {
+    "aarch64-linux": "<url>",
+    "x86_64-linux": "<url>"
   }
 }

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -1,126 +1,126 @@
 {
-  "packages" : {
-    "benchmark" : {
-      "version" : "1.8.0",
-      "git_url" : "https://github.com/google/benchmark.git",
-      "git_tag" : "v${version}"
+  "packages": {
+    "benchmark": {
+      "version": "1.8.0",
+      "git_url": "https://github.com/google/benchmark.git",
+      "git_tag": "v${version}"
     },
-    "CCCL" : {
-      "version" : "2.2.0",
-      "git_url" : "https://github.com/NVIDIA/cccl.git",
-      "git_tag" : "v${version}",
-      "patches" : [
+    "CCCL": {
+      "version": "2.2.0",
+      "git_url": "https://github.com/NVIDIA/cccl.git",
+      "git_tag": "v${version}",
+      "patches": [
         {
-          "file" : "cccl/bug_fixes.diff",
-          "issue" : "CCCL installs header-search.cmake files in nondeterministic order and has a typo in checking target creation that leads to duplicates",
-          "fixed_in" : "2.3"
+          "file": "cccl/bug_fixes.diff",
+          "issue": "CCCL installs header-search.cmake files in nondeterministic order and has a typo in checking target creation that leads to duplicates",
+          "fixed_in": "2.3"
         },
         {
-          "file" : "cccl/hide_kernels.diff",
-          "issue" : "Mark all cub and thrust kernels with hidden visibility [https://github.com/nvidia/cccl/pulls/443]",
-          "fixed_in" : "2.3"
+          "file": "cccl/hide_kernels.diff",
+          "issue": "Mark all cub and thrust kernels with hidden visibility [https://github.com/nvidia/cccl/pulls/443]",
+          "fixed_in": "2.3"
         },
         {
-          "file" : "cccl/revert_pr_211.diff",
-          "issue" : "thrust::copy introduced a change in behavior that causes failures with cudaErrorInvalidValue.",
-          "fixed_in" : ""
+          "file": "cccl/revert_pr_211.diff",
+          "issue": "thrust::copy introduced a change in behavior that causes failures with cudaErrorInvalidValue.",
+          "fixed_in": ""
         }
       ]
     },
-    "cuco" : {
-      "version" : "0.0.1",
-      "git_shallow" : false,
-      "git_url" : "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag" : "56c53beb6fb0cafd265b7fcc3df78ae487811b22"
+    "cuco": {
+      "version": "0.0.1",
+      "git_shallow": false,
+      "git_url": "https://github.com/NVIDIA/cuCollections.git",
+      "git_tag": "56c53beb6fb0cafd265b7fcc3df78ae487811b22"
     },
-    "fmt" : {
-      "version" : "10.1.1",
-      "git_url" : "https://github.com/fmtlib/fmt.git",
-      "git_tag" : "${version}"
+    "fmt": {
+      "version": "10.1.1",
+      "git_url": "https://github.com/fmtlib/fmt.git",
+      "git_tag": "${version}"
     },
-    "GTest" : {
-      "version" : "1.13.0",
-      "git_url" : "https://github.com/google/googletest.git",
-      "git_tag" : "v${version}"
+    "GTest": {
+      "version": "1.13.0",
+      "git_url": "https://github.com/google/googletest.git",
+      "git_tag": "v${version}"
     },
-    "libcudacxx" : {
-      "version" : "2.1.0",
-      "git_url" : "https://github.com/NVIDIA/libcudacxx.git",
-      "git_tag" : "${version}",
-      "patches" : [
+    "libcudacxx": {
+      "version": "2.1.0",
+      "git_url": "https://github.com/NVIDIA/libcudacxx.git",
+      "git_tag": "${version}",
+      "patches": [
         {
-          "file" : "libcudacxx/install_rules.diff",
-          "issue" : "libcudacxx installs incorrect files [https://github.com/NVIDIA/libcudacxx/pull/428]",
-          "fixed_in" : "2.2"
+          "file": "libcudacxx/install_rules.diff",
+          "issue": "libcudacxx installs incorrect files [https://github.com/NVIDIA/libcudacxx/pull/428]",
+          "fixed_in": "2.2"
         },
         {
-          "file" : "libcudacxx/reroot_support.diff",
-          "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/libcudacxx/pull/490], requires libcudacxx/install_rules.diff.",
-          "fixed_in" : "2.2"
+          "file": "libcudacxx/reroot_support.diff",
+          "issue": "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/libcudacxx/pull/490], requires libcudacxx/install_rules.diff.",
+          "fixed_in": "2.2"
         },
         {
-          "file" : "libcudacxx/proclaim_return_type_nv_exec_check_disable.diff",
-          "issue" : "Use pragma to disable execution checks in cuda::proclaim_return_type. [https://github.com/NVIDIA/libcudacxx/pull/448]",
-          "fixed_in" : "2.2"
+          "file": "libcudacxx/proclaim_return_type_nv_exec_check_disable.diff",
+          "issue": "Use pragma to disable execution checks in cuda::proclaim_return_type. [https://github.com/NVIDIA/libcudacxx/pull/448]",
+          "fixed_in": "2.2"
         },
         {
-          "file" : "libcudacxx/memory_resource.diff",
-          "issue" : "Allow {async_}resource_ref to be constructible from a pointer. [https://github.com/NVIDIA/libcudacxx/pull/439]",
-          "fixed_in" : "2.2"
+          "file": "libcudacxx/memory_resource.diff",
+          "issue": "Allow {async_}resource_ref to be constructible from a pointer. [https://github.com/NVIDIA/libcudacxx/pull/439]",
+          "fixed_in": "2.2"
         }
       ]
     },
-    "nvbench" : {
-      "version" : "0.0",
-      "git_shallow" : false,
-      "git_url" : "https://github.com/NVIDIA/nvbench.git",
-      "git_tag" : "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
+    "nvbench": {
+      "version": "0.0",
+      "git_shallow": false,
+      "git_url": "https://github.com/NVIDIA/nvbench.git",
+      "git_tag": "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
     },
     "nvcomp" : {
-      "version" : "3.0.6",
-      "git_url" : "https://github.com/NVIDIA/nvcomp.git",
-      "git_tag" : "v2.2.0",
-      "proprietary_binary" : {
-        "x86_64-linux" :  "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
-        "aarch64-linux" : "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
+      "version": "3.0.6",
+      "git_url": "https://github.com/NVIDIA/nvcomp.git",
+      "git_tag": "v2.2.0",
+      "proprietary_binary": {
+        "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
+        "aarch64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
       }
     },
-    "rmm" : {
-      "version" : "${rapids-cmake-version}",
-      "git_url" : "https://github.com/rapidsai/rmm.git",
-      "git_tag" : "branch-${version}"
+    "rmm": {
+      "version": "${rapids-cmake-version}",
+      "git_url": "https://github.com/rapidsai/rmm.git",
+      "git_tag": "branch-${version}"
     },
-    "spdlog" : {
-      "version" : "1.12.0",
-      "git_url" : "https://github.com/gabime/spdlog.git",
-      "git_tag" : "v${version}",
-      "patches" : [
+    "spdlog": {
+      "version": "1.12.0",
+      "git_url": "https://github.com/gabime/spdlog.git",
+      "git_tag": "v${version}",
+      "patches": [
         {
-          "file" : "spdlog/nvcc_constexpr_fix.diff",
-          "issue" : "Fix constexpr mismatch between spdlog and fmt [https://github.com/gabime/spdlog/issues/2856]",
-                "fixed_in" : "1.13"
+          "file": "spdlog/nvcc_constexpr_fix.diff",
+          "issue": "Fix constexpr mismatch between spdlog and fmt [https://github.com/gabime/spdlog/issues/2856]",
+                "fixed_in": "1.13"
         }
       ]
     },
-    "Thrust" : {
-      "version" : "1.17.2",
-      "git_url" : "https://github.com/NVIDIA/thrust.git",
-      "git_tag" : "${version}",
-      "patches" : [
+    "Thrust": {
+      "version": "1.17.2",
+      "git_url": "https://github.com/NVIDIA/thrust.git",
+      "git_tag": "${version}",
+      "patches": [
         {
-          "file" : "Thrust/reroot_support.diff",
-          "issue" : "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/thrust/pull/1969]",
-          "fixed_in" : "2.2"
+          "file": "Thrust/reroot_support.diff",
+          "issue": "Support conda-forge usage of CMake rerooting [https://github.com/NVIDIA/thrust/pull/1969]",
+          "fixed_in": "2.2"
         },
         {
-          "file" : "Thrust/transform_iter_with_reduce_by_key.diff",
-          "issue" : "Support transform iterator with reduce by key [https://github.com/NVIDIA/thrust/pull/1805]",
-          "fixed_in" : "2.1"
+          "file": "Thrust/transform_iter_with_reduce_by_key.diff",
+          "issue": "Support transform iterator with reduce by key [https://github.com/NVIDIA/thrust/pull/1805]",
+          "fixed_in": "2.1"
         },
         {
-          "file" : "Thrust/install_rules.diff",
-          "issue" : "Thrust 1.X installs incorrect files [https://github.com/NVIDIA/thrust/issues/1790]",
-          "fixed_in" : "2.0"
+          "file": "Thrust/install_rules.diff",
+          "issue": "Thrust 1.X installs incorrect files [https://github.com/NVIDIA/thrust/issues/1790]",
+          "fixed_in": "2.0"
         }
       ]
     }

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -98,7 +98,7 @@
         {
           "file": "spdlog/nvcc_constexpr_fix.diff",
           "issue": "Fix constexpr mismatch between spdlog and fmt [https://github.com/gabime/spdlog/issues/2856]",
-                "fixed_in": "1.13"
+          "fixed_in": "1.13"
         }
       ]
     },

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -76,7 +76,7 @@
       "git_url": "https://github.com/NVIDIA/nvbench.git",
       "git_tag": "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
     },
-    "nvcomp" : {
+    "nvcomp": {
       "version": "3.0.6",
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
       "git_tag": "v2.2.0",

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,22 +27,22 @@ endif()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "pkg_with_patch" : {
-      "version" : "10.2",
-      "git_tag" : "a_tag",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON",
-      "patches" : [
+  "packages": {
+    "pkg_with_patch": {
+      "version": "10.2",
+      "git_tag": "a_tag",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON",
+      "patches": [
         {
-          "file" : "${current_json_dir}/example.diff",
-          "issue" : "explain",
-          "fixed_in" : ""
+          "file": "${current_json_dir}/example.diff",
+          "issue": "explain",
+          "fixed_in": ""
         },
         {
-          "file" : "${current_json_dir}/example2.diff",
-          "issue" : "explain",
-          "fixed_in" : ""
+          "file": "${current_json_dir}/example2.diff",
+          "issue": "explain",
+          "fixed_in": ""
         }
       ]
     }

--- a/testing/cpm/cpm_generate_patch_command-override.cmake
+++ b/testing/cpm/cpm_generate_patch_command-override.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,30 +27,30 @@ endif()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "pkg_with_patch" : {
-      "version" : "10.2",
-      "git_tag" : "a_tag",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON",
-      "patches" : [
+  "packages": {
+    "pkg_with_patch": {
+      "version": "10.2",
+      "git_tag": "a_tag",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON",
+      "patches": [
         {
-          "file" : "e/example.diff",
-          "issue" : "explain",
-          "fixed_in" : ""
+          "file": "e/example.diff",
+          "issue": "explain",
+          "fixed_in": ""
         }
       ]
     },
-    "pkg_patch_not_applied" : {
-      "version" : "10.2",
-      "git_tag" : "a_tag",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON",
-      "patches" : [
+    "pkg_patch_not_applied": {
+      "version": "10.2",
+      "git_tag": "a_tag",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON",
+      "patches": [
         {
-          "file" : "e/example.diff",
-          "issue" : "explain",
-          "fixed_in" : "3"
+          "file": "e/example.diff",
+          "issue": "explain",
+          "fixed_in": "3"
         }
       ]
     }

--- a/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
+++ b/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
@@ -24,17 +24,17 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "pkg_with_patch" : {
-      "version" : "10.2",
-      "git_tag" : "a_tag",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON",
-      "patches" : [
+  "packages": {
+    "pkg_with_patch": {
+      "version": "10.2",
+      "git_tag": "a_tag",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON",
+      "patches": [
         {
-          "file" : "e/example.diff",
-          "issue" : "explain",
-          "fixed_in" : ""
+          "file": "e/example.diff",
+          "issue": "explain",
+          "fixed_in": ""
         }
       ]
     }

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,16 +42,16 @@ expect_fetch_content_details(GTest NO)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "nvbench" : {
-      "git_tag" : "my_tag",
-      "always_download" : false
+  "packages": {
+    "nvbench": {
+      "git_tag": "my_tag",
+      "always_download": false
     },
-    "rmm" : {
-      "git_tag" : "my_tag"
+    "rmm": {
+      "git_tag": "my_tag"
     },
-    "GTest" : {
-      "version" : "2.99"
+    "GTest": {
+      "version": "2.99"
     }
   }
 }

--- a/testing/cpm/cpm_init-override-simple.cmake
+++ b/testing/cpm/cpm_init-override-simple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ include(${rapids-cmake-dir}/cpm/init.cmake)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "nvbench" : {
-      "version" : "custom_version",
-      "git_url" : "my_url",
-      "git_tag" : "my_tag"
+  "packages": {
+    "nvbench": {
+      "version": "custom_version",
+      "git_url": "my_url",
+      "git_tag": "my_tag"
     }
   }
 }

--- a/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-override-clears-proprietary_binary.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ endif()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "nvcomp" : {
-      "version" : "224",
-      "git_url" : "https://github.com/NVIDIA/nvcomp.git",
+  "packages": {
+    "nvcomp": {
+      "version": "224",
+      "git_url": "https://github.com/NVIDIA/nvcomp.git",
     }
   }
 }

--- a/testing/cpm/cpm_package_override-before-init.cmake
+++ b/testing/cpm/cpm_package_override-before-init.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ include(${rapids-cmake-dir}/cpm/package_override.cmake)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/simple_override.json
   [=[
 {
-  "packages" : {
-    "nvbench" : {
-      "version" : "custom_version",
-      "git_url" : "my_url2",
-      "git_tag" : "my_tag"
+  "packages": {
+    "nvbench": {
+      "version": "custom_version",
+      "git_url": "my_url2",
+      "git_tag": "my_tag"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-empty.cmake
+++ b/testing/cpm/cpm_package_override-empty.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
+  "packages": {
   }
 }
   ]=])

--- a/testing/cpm/cpm_package_override-env-var-support.cmake
+++ b/testing/cpm/cpm_package_override-env-var-support.cmake
@@ -22,11 +22,11 @@ set(ENV{rapids_user} custom_env_user)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "nvbench" : {
-      "version" : "$ENV{rapids_version}",
-      "git_url" : "$ENV{rapids_user}@gitlab.private.com",
-      "git_tag" : "my_tag"
+  "packages": {
+    "nvbench": {
+      "version": "$ENV{rapids_version}",
+      "git_url": "$ENV{rapids_user}@gitlab.private.com",
+      "git_tag": "my_tag"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-multiple.cmake
+++ b/testing/cpm/cpm_package_override-multiple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ rapids_cpm_package_details(rmm rmm_version rmm_repository rmm_tag rmm_shallow rm
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override1.json
   [=[
 {
-  "packages" : {
-    "nvbench" : {
-      "git_tag" : "my_tag"
+  "packages": {
+    "nvbench": {
+      "git_tag": "my_tag"
     },
-    "GTest" : {
-      "version" : "2.99"
+    "GTest": {
+      "version": "2.99"
     }
   }
 }
@@ -42,12 +42,12 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override1.json
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override2.json
   [=[
 {
-  "packages" : {
-    "rmm" : {
-      "git_tag" : "new_rmm_tag"
+  "packages": {
+    "rmm": {
+      "git_tag": "new_rmm_tag"
     },
-    "GTest" : {
-      "version" : "3.99"
+    "GTest": {
+      "version": "3.99"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
+++ b/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,18 +22,18 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "rmm" : {
-      "git_url" : "new_rmm_url",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON"
+  "packages": {
+    "rmm": {
+      "git_url": "new_rmm_url",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON"
     },
-    "not_in_base" : {
-      "version" : "1.0",
-      "git_url" : "new_rmm_url",
-      "git_tag" : "main",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON"
+    "not_in_base": {
+      "version": "1.0",
+      "git_url": "new_rmm_url",
+      "git_tag": "main",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-patches.cmake
+++ b/testing/cpm/cpm_package_override-patches.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,13 +22,13 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "rmm" : {
-      "patches" : [
+  "packages": {
+    "rmm": {
+      "patches": [
         {
-          "file" : "rmm_patch_install_rules.diff",
-          "issue" : "Fake install rule patch file",
-          "fixed_in" : "39.99.0"
+          "file": "rmm_patch_install_rules.diff",
+          "issue": "Fake install rule patch file",
+          "fixed_in": "39.99.0"
         }
       ]
     }

--- a/testing/cpm/cpm_package_override-simple.cmake
+++ b/testing/cpm/cpm_package_override-simple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,14 +22,14 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "rmm" : {
-      "git_url" : "new_rmm_url",
-      "git_shallow" : "OFF",
-      "exclude_from_all" : "ON"
+  "packages": {
+    "rmm": {
+      "git_url": "new_rmm_url",
+      "git_shallow": "OFF",
+      "exclude_from_all": "ON"
     },
-    "GTest" : {
-      "version" : "3.00.A1"
+    "GTest": {
+      "version": "3.00.A1"
     }
   }
 }

--- a/testing/cpm/cpm_proprietary-url-ctk-version-find-ctk.cmake
+++ b/testing/cpm/cpm_proprietary-url-ctk-version-find-ctk.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "test_binary" : {
-      "version" : "2.6.1",
-      "proprietary_binary" : {
-        "x86_64-linux" :  "https://fake.url.com/${version}/${cuda-toolkit-version}/x86_64_${cuda-toolkit-version-major}.tgz",
-        "aarch64-linux" : "https://fake.url.com/${version}/${cuda-toolkit-version}/aarch64_${cuda-toolkit-version-major}.tgz",
+  "packages": {
+    "test_binary": {
+      "version": "2.6.1",
+      "proprietary_binary": {
+        "x86_64-linux":  "https://fake.url.com/${version}/${cuda-toolkit-version}/x86_64_${cuda-toolkit-version-major}.tgz",
+        "aarch64-linux": "https://fake.url.com/${version}/${cuda-toolkit-version}/aarch64_${cuda-toolkit-version-major}.tgz",
       }
     }
   }

--- a/testing/cpm/cpm_proprietary-url-ctk-version.cmake
+++ b/testing/cpm/cpm_proprietary-url-ctk-version.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "test_binary" : {
-      "version" : "2.6.1",
-      "proprietary_binary" : {
-        "x86_64-linux" :  "https://fake.url.com/${version}/${cuda-toolkit-version}/x86_64_${cuda-toolkit-version-major}.tgz",
-        "aarch64-linux" : "https://fake.url.com/${version}/${cuda-toolkit-version}/aarch64_${cuda-toolkit-version-major}.tgz",
+  "packages": {
+    "test_binary": {
+      "version": "2.6.1",
+      "proprietary_binary": {
+        "x86_64-linux":  "https://fake.url.com/${version}/${cuda-toolkit-version}/x86_64_${cuda-toolkit-version-major}.tgz",
+        "aarch64-linux": "https://fake.url.com/${version}/${cuda-toolkit-version}/aarch64_${cuda-toolkit-version-major}.tgz",
       }
     }
   }

--- a/testing/cpm/cpm_proprietary-url-no-ctk-parsing.cmake
+++ b/testing/cpm/cpm_proprietary-url-no-ctk-parsing.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ rapids_cpm_init()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   [=[
 {
-  "packages" : {
-    "test_binary" : {
-      "version" : "2.6.1",
-      "proprietary_binary" : {
-        "x86_64-linux" :  "https://fake.url.com/x86_${version}.tgz",
-        "aarch64-linux" : "https://fake.url.com/aarch_${version}.tgz",
+  "packages": {
+    "test_binary": {
+      "version": "2.6.1",
+      "proprietary_binary": {
+        "x86_64-linux":  "https://fake.url.com/x86_${version}.tgz",
+        "aarch64-linux": "https://fake.url.com/aarch_${version}.tgz",
       }
     }
   }


### PR DESCRIPTION
## Description
While the JSON spec allows whitespace before or after any structural character, some json linters complain about it. So we remove the 'offending' whitespace.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
