### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -77,7 +77,7 @@
       "git_tag" : "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
     },
     "nvcomp" : {
-      "version" : "3.0.5",
+      "version" : "3.0.6",
       "git_url" : "https://github.com/NVIDIA/nvcomp.git",
       "git_tag" : "v2.2.0",
       "proprietary_binary" : {


### PR DESCRIPTION
Manual forward merge from 24.02 to 24.04. This PR should not be squashed. Closes #543.