### PR TITLE
Bump nvbench version for faster benchmark runs

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -74,7 +74,7 @@
       "version": "0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/nvbench.git",
-      "git_tag": "978d81a0cba97e3f30508e3c0e3cd65ce94fb699"
+      "git_tag": "d8dced8a64d9ce305add92fa6d274fd49b569b7e"
     },
     "nvcomp": {
       "version": "3.0.6",


### PR DESCRIPTION
## Description
This PR bumps the nvbench version to fetch the latest feature added in https://github.com/NVIDIA/nvbench/pull/151 which should largely reduce nvbench runtime.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
