### PR TITLE
Test CCCL 2.3.0.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -7,8 +7,8 @@
     },
     "CCCL": {
       "version": "2.3.0",
-      "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "branch/2.3.x",
+      "git_url": "https://github.com/miscco/cccl.git",
+      "git_tag": "fix_thrust_addressof",
       "patches": [
         {
           "file": "cccl/bug_fixes.diff",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -6,9 +6,9 @@
       "git_tag": "v${version}"
     },
     "CCCL": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "v${version}",
+      "git_tag": "branch/2.3.x",
       "patches": [
         {
           "file": "cccl/bug_fixes.diff",


### PR DESCRIPTION
## Description
This PR is a test of CCCL 2.3.0. Do not merge.

Additional testing PRs:
- https://github.com/rapidsai/rmm/pull/1418
- https://github.com/rapidsai/cudf/pull/14704
- https://github.com/NVIDIA/cuCollections/pull/420

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
