### PR TITLE
Support getting rapids-cmake via git clone

### DIFF
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,16 +39,30 @@ endif()
 if(NOT rapids-cmake-url)
   # Construct a default URL if the user doesn't set one
   set(rapids-cmake-url "https://github.com/${rapids-cmake-repo}/")
+
   # In order of specificity
-  if(rapids-cmake-sha)
-    # An exact git SHA takes precedence over anything
-    string(APPEND rapids-cmake-url "archive/${rapids-cmake-sha}.zip")
-  elseif(rapids-cmake-tag)
-    # Followed by a git tag name
-    string(APPEND rapids-cmake-url "archive/refs/tags/${rapids-cmake-tag}.zip")
+  if(rapids-cmake-fetch-via-git)
+    if(rapids-cmake-sha)
+      # An exact git SHA takes precedence over anything
+      set(rapids-cmake-value-to-clone "${rapids-cmake-sha}")
+    elseif(rapids-cmake-tag)
+      # Followed by a git tag name
+      set(rapids-cmake-value-to-clone "${rapids-cmake-tag}")
+    else()
+      # Or if neither of the above two were defined, use a branch
+      set(rapids-cmake-value-to-clone "${rapids-cmake-branch}")
+    endif()
   else()
-    # Or if neither of the above two were defined, use a branch
-    string(APPEND rapids-cmake-url "archive/refs/heads/${rapids-cmake-branch}.zip")
+    if(rapids-cmake-sha)
+      # An exact git SHA takes precedence over anything
+      set(rapids-cmake-value-to-clone "archive/${rapids-cmake-sha}.zip")
+    elseif(rapids-cmake-tag)
+      # Followed by a git tag name
+      set(rapids-cmake-value-to-clone "archive/refs/tags/${rapids-cmake-tag}.zip")
+    else()
+      # Or if neither of the above two were defined, use a branch
+      set(rapids-cmake-value-to-clone "archive/refs/heads/${rapids-cmake-branch}.zip")
+    endif()
   endif()
 endif()
 
@@ -57,7 +71,14 @@ if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 include(FetchContent)
-FetchContent_Declare(rapids-cmake URL "${rapids-cmake-url}")
+if(rapids-cmake-fetch-via-git)
+  FetchContent_Declare(rapids-cmake
+    GIT_REPOSITORY "${rapids-cmake-url}"
+    GIT_TAG "${rapids-cmake-value-to-clone}")
+else()
+  string(APPEND rapids-cmake-url "${rapids-cmake-value-to-clone}")
+  FetchContent_Declare(rapids-cmake URL "${rapids-cmake-url}")
+endif()
 if(POLICY CMP0135)
   cmake_policy(POP)
 endif()

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ At times projects or developers will need to verify ``rapids-cmake`` branches. T
   # Or to override the entire repository URL (e.g. to use a GitLab repo):
   set(rapids-cmake-url "https://gitlab.com/<my_user>/<my_fork>/-/archive/<my_branch>/<my_fork>-<my_branch>.zip")
 
+  # To override the usage of fetching the repository without git info
+  # This only works when specifying
+  #
+  # set(rapids-cmake-fetch-via-git "ON")
+  # set(rapids-cmake-branch "branch-<cal_ver>")
+  #
+  # or
+  # set(rapids-cmake-fetch-via-git "ON")
+  # set(rapids-cmake-url "https://gitlab.com/<my_user>/<private_fork>/")
+  # set(rapids-cmake-sha "ABC123")
+  #
+  set(rapids-cmake-fetch-via-git "ON")
+
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
   include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)

--- a/testing/other/CMakeLists.txt
+++ b/testing/other/CMakeLists.txt
@@ -16,5 +16,8 @@
 add_cmake_config_test( rapids_cmake-multiple-cpm NO_RAPIDS_CMAKE_HOOKS)
 add_cmake_config_test( rapids_cmake-multiple-simple NO_RAPIDS_CMAKE_HOOKS)
 
+add_cmake_config_test( rapids_cmake-fetch-via-git NO_RAPIDS_CMAKE_HOOKS)
+add_cmake_config_test( rapids_cmake-fetch-via-zip NO_RAPIDS_CMAKE_HOOKS)
+
 add_cmake_config_test( FetchContent-legacy NO_RAPIDS_CMAKE_HOOKS)
 add_cmake_config_test( FetchContent-hostile-legacy NO_RAPIDS_CMAKE_HOOKS)

--- a/testing/other/rapids_cmake-fetch-via-git/CMakeLists.txt
+++ b/testing/other/rapids_cmake-fetch-via-git/CMakeLists.txt
@@ -1,0 +1,36 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-test-project LANGUAGES CXX)
+
+cmake_path(GET rapids-cmake-dir PARENT_PATH rapids.cmake-location)
+cmake_path(APPEND rapids.cmake-location "RAPIDS.cmake")
+
+set(rapids-cmake-fetch-via-git ON)
+include("${rapids.cmake-location}")
+
+if(NOT DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "expected variable rapids-cmake_SOURCE_DIR to exist")
+endif()
+
+# make sure we have fetched rapids-cmake with git
+if(NOT EXISTS "${rapids-cmake_SOURCE_DIR}/.git/FETCH_HEAD")
+  message(FATAL_ERROR "expected rapids-cmake to be cloned via git")
+endif()
+
+if(NOT EXISTS "${rapids-cmake_SOURCE_DIR}/init.cmake")
+  message(FATAL_ERROR "expected init.cmake to exist")
+endif()

--- a/testing/other/rapids_cmake-fetch-via-zip/CMakeLists.txt
+++ b/testing/other/rapids_cmake-fetch-via-zip/CMakeLists.txt
@@ -1,0 +1,35 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-test-project LANGUAGES CXX)
+
+cmake_path(GET rapids-cmake-dir PARENT_PATH rapids.cmake-location)
+cmake_path(APPEND rapids.cmake-location "RAPIDS.cmake")
+
+include("${rapids.cmake-location}")
+
+if(NOT DEFINED rapids-cmake_SOURCE_DIR)
+  message(FATAL_ERROR "expected variable rapids-cmake_SOURCE_DIR to exist")
+endif()
+
+# make sure we have fetched rapids-cmake with git
+if(EXISTS "${rapids-cmake_SOURCE_DIR}/.git")
+  message(FATAL_ERROR "expected rapids-cmake to be downloaded via a zip file")
+endif()
+
+if(NOT EXISTS "${rapids-cmake_SOURCE_DIR}/init.cmake")
+  message(FATAL_ERROR "expected init.cmake to exist")
+endif()


### PR DESCRIPTION
## Description
This allows projects that need git information of rapids-cmake to get it while still using `RAPIDS.cmake`.

Fixes #554

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
