### PR TITLE
Handle CMake 3.28 new EXCLUDE_FROM_ALL option of `FetchContent`

### DIFF
--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -95,11 +95,15 @@ function(rapids_cpm_package_override filepath)
         include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
         rapids_cpm_generate_patch_command(${package_name} ${version} patch_command)
 
+        unset(exclude_from_all)
+        if(exclude AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.28.0)
+          set(exclude_from_all EXCLUDE_FROM_ALL)
+        endif()
         FetchContent_Declare(${package_name}
                              GIT_REPOSITORY ${repository}
                              GIT_TAG ${tag}
                              GIT_SHALLOW ${shallow}
-                             ${patch_command} EXCLUDE_FROM_ALL ${exclude})
+                             ${patch_command} ${exclude_from_all})
       endif()
     endforeach()
   endif()

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -38,6 +38,7 @@ add_cmake_config_test( cpm_init-bad-override-path.cmake SHOULD_FAIL "rapids_cpm_
 add_cmake_config_test( cpm_init-override-multiple.cmake )
 add_cmake_config_test( cpm_init-override-simple.cmake )
 
+add_cmake_config_test( cpm_package_override-add-new-project.cmake )
 add_cmake_config_test( cpm_package_override-bad-path.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")
 add_cmake_config_test( cpm_package_override-before-init.cmake )
 add_cmake_config_test( cpm_package_override-empty.cmake )

--- a/testing/cpm/cpm_package_override-add-new-project.cmake
+++ b/testing/cpm/cpm_package_override-add-new-project.cmake
@@ -26,7 +26,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   "packages": {
     "custom_package_never_in_rapids" : {
       "version" : "3.1.0",
-      "git_url" : "https://github.com/nvidia/nvtx/",
+      "git_url" : "https://github.com/NVIDIA/NVTX",
       "git_tag" : "96aeb0d8702981972fac0f6e485fea7acbfd5446",
       "git_shallow" : false,
       "exclude_from_all" : true

--- a/testing/cpm/cpm_package_override-add-new-project.cmake
+++ b/testing/cpm/cpm_package_override-add-new-project.cmake
@@ -1,0 +1,50 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/find.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+rapids_cpm_init()
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages": {
+    "custom_package_never_in_rapids" : {
+      "version" : "3.1.0",
+      "git_url" : "https://github.com/nvidia/nvtx/",
+      "git_tag" : "96aeb0d8702981972fac0f6e485fea7acbfd5446",
+      "git_shallow" : false,
+      "exclude_from_all" : true
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+# Verify that the override works
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+
+rapids_cpm_package_details(custom_package_never_in_rapids version repository tag shallow exclude)
+if(NOT version STREQUAL "3.1.0")
+  message(FATAL_ERROR "expected version field wasn't found. ${version} was found instead")
+endif()
+
+# Make sure we can clone without getting an error when
+# parsing the EXCLUDE_FROM_ALL tag
+rapids_cpm_find(custom_package_never_in_rapids 3.1)


### PR DESCRIPTION
## Description
Previously we sent `EXCLUDE_FROM_ALL ON/OFF` which was ignored by fetch content and did nothing. But now `FetchContent` parses `EXCLUDE_FROM_ALL` and this mode breaks CMake 3.28+

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
