### PR TITLE
Deprecate rapids_cpm_libcudacxx and rapids_cpm_thrust.

### DIFF
--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -27,6 +27,11 @@ tracking of these dependencies for correct export support.
 Uses the version of libcudacxx :ref:`specified in the version file <cpm_versions>` for consistency
 across all RAPIDS projects.
 
+.. deprecated:: v24.04.00
+  ``rapids_cpm_thrust`` uses Thrust 1.x. Users should migrate to
+  ``rapids_cpm_cccl`` which uses CCCL 2.x, including new versions of Thrust,
+  CUB, and libcudacxx.
+
 .. code-block:: cmake
 
   rapids_cpm_libcudacxx( [BUILD_EXPORT_SET <export-name>]
@@ -50,6 +55,12 @@ Result Variables
 #]=======================================================================]
 function(rapids_cpm_libcudacxx)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.libcudacxx")
+
+  include("${rapids-cmake-dir}/cmake/detail/policy.cmake")
+  rapids_cmake_policy(DEPRECATED_IN 24.04
+                      REMOVED_IN 24.10
+                      MESSAGE [=[Usage of `rapids_cpm_libcudacxx` has been deprecated in favor of `rapids_cpm_cccl`.]=]
+  )
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(libcudacxx version repository tag shallow exclude)

--- a/rapids-cmake/cpm/libcudacxx.cmake
+++ b/rapids-cmake/cpm/libcudacxx.cmake
@@ -28,7 +28,7 @@ Uses the version of libcudacxx :ref:`specified in the version file <cpm_versions
 across all RAPIDS projects.
 
 .. deprecated:: v24.04.00
-  ``rapids_cpm_thrust`` uses Thrust 1.x. Users should migrate to
+  ``rapids_cpm_libcudacxx`` uses libcudacxx 2.1.0. Users should migrate to
   ``rapids_cpm_cccl`` which uses CCCL 2.x, including new versions of Thrust,
   CUB, and libcudacxx.
 

--- a/rapids-cmake/cpm/thrust.cmake
+++ b/rapids-cmake/cpm/thrust.cmake
@@ -27,6 +27,11 @@ tracking of these dependencies for correct export support.
 Uses the version of Thrust :ref:`specified in the version file <cpm_versions>` for consistency
 across all RAPIDS projects.
 
+.. deprecated:: v24.04.00
+  ``rapids_cpm_thrust`` uses Thrust 1.x. Users should migrate to
+  ``rapids_cpm_cccl`` which uses CCCL 2.x, including new versions of Thrust,
+  CUB, and libcudacxx.
+
 .. code-block:: cmake
 
   rapids_cpm_thrust( NAMESPACE <namespace>
@@ -62,6 +67,12 @@ Result Variables
 # cmake-lint: disable=R0915
 function(rapids_cpm_thrust NAMESPACE namespaces_name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.thrust")
+
+  include("${rapids-cmake-dir}/cmake/detail/policy.cmake")
+  rapids_cmake_policy(DEPRECATED_IN 24.04
+                      REMOVED_IN 24.10
+                      MESSAGE [=[Usage of `rapids_cpm_thrust` has been deprecated in favor of `rapids_cpm_cccl`.]=]
+  )
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(Thrust version repository tag shallow exclude)


### PR DESCRIPTION
## Description
Some users of Thrust have been confused about whether to use `rapids_cpm_thrust` or `rapids_cpm_cccl`. Deprecating the old CPM functions for Thrust and libcudacxx would make the messaging clearer that we intend to support primarily CCCL going forward.

It's fine if we need to extend the deprecation period for an arbitrary length of time -- but adding this notice will help push users to adopt the new CCCL monorepo.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
