### PR TITLE
Use CUDA compiler if available for generate_resource_spec

### DIFF
--- a/rapids-cmake/test/generate_resource_spec.cmake
+++ b/rapids-cmake/test/generate_resource_spec.cmake
@@ -60,7 +60,7 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
 
     set(compiler "${CMAKE_CXX_COMPILER}")
     set(lang CXX)
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
+    if(DEFINED CMAKE_CUDA_COMPILER)
       set(compiler "${CMAKE_CUDA_COMPILER}")
       set(lang CUDA)
     endif()


### PR DESCRIPTION
## Description
This ensures consistent detection of CUDAToolkit between the main project and the try_compile().

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
