### PR TITLE
Always link against cudart_static

### DIFF
--- a/rapids-cmake/test/detail/generate_resource_spec/CMakeLists.txt
+++ b/rapids-cmake/test/detail/generate_resource_spec/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 3.23.1)
 project(generate_resource_spec ${lang})
 
 set(CMAKE_CUDA_ARCHITECTURES all)
+set(CMAKE_CUDA_RUNTIME_LIBRARY STATIC)
 
 add_executable(generate_ctest_json generate_resource_spec.cpp)
 if(cuda_toolkit)


### PR DESCRIPTION
## Description
We want to always build `generate_resource_spec` with `libcudart_static`, regardless of what the parent project has set.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
