### PR TITLE
nvcomp try proprietary binary when 'always_download' is on

### DIFF
--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -112,7 +112,7 @@ function(rapids_cpm_nvcomp)
     if(nvcomp_url)
       rapids_cpm_download_proprietary_binary(nvcomp ${nvcomp_url})
 
-      # unset CPM_DOWNLOAD_ALL if we have a proprietary binary enabled this ensure we actually use
+      # Unset CPM_DOWNLOAD_ALL if we have a proprietary binary enabled. This ensures we actually use
       # the proprietary binary
       unset(CPM_DOWNLOAD_ALL)
     endif()

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -112,8 +112,8 @@ function(rapids_cpm_nvcomp)
     if(nvcomp_url)
       rapids_cpm_download_proprietary_binary(nvcomp ${nvcomp_url})
 
-      # unset CPM_DOWNLOAD_ALL if we have a proprietary binary enabled
-      # this ensure we actually use the proprietary binary
+      # unset CPM_DOWNLOAD_ALL if we have a proprietary binary enabled this ensure we actually use
+      # the proprietary binary
       unset(CPM_DOWNLOAD_ALL)
     endif()
 

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -111,6 +111,10 @@ function(rapids_cpm_nvcomp)
     rapids_cpm_get_proprietary_binary_url(nvcomp ${version} nvcomp_url)
     if(nvcomp_url)
       rapids_cpm_download_proprietary_binary(nvcomp ${nvcomp_url})
+
+      # unset CPM_DOWNLOAD_ALL if we have a proprietary binary enabled
+      # this ensure we actually use the proprietary binary
+      unset(CPM_DOWNLOAD_ALL)
     endif()
 
     # Record the nvcomp_DIR so that if USE_PROPRIETARY_BINARY is disabled we can safely clear the

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -92,6 +92,7 @@ add_cmake_config_test( cpm_nvcomp-proprietary-off.cmake )
 add_cmake_config_test( cpm_nvcomp-proprietary-on.cmake )
 add_cmake_config_test( cpm_nvcomp-simple.cmake )
 add_cmake_config_test( cpm_nvcomp-invalid-arch.cmake )
+add_cmake_config_test( cpm_nvcomp-always-download-proprietary_binary.cmake SERIAL)
 add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake SERIAL)
 
 add_cmake_config_test( cpm_proprietary-url-ctk-version-find-ctk.cmake )

--- a/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
@@ -51,6 +51,6 @@ if(NOT nvcomp_proprietary_binary)
   message(FATAL_ERROR "Ignored nvcomp override file failed to get proprietary binary version")
 endif()
 
-if(NOT EXISTS "${nvcomp_SOURCE_DIR}/lib/")
-
+if(NOT "${nvcomp_SOURCE_DIR}/CMakeLists.txt")
+  message(FATAL_ERROR "Ignored nvcomp override file failed to get proprietary binary version")
 endif()

--- a/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
@@ -51,6 +51,6 @@ if(NOT nvcomp_proprietary_binary)
   message(FATAL_ERROR "Ignored nvcomp override file failed to get proprietary binary version")
 endif()
 
-if(NOT "${nvcomp_SOURCE_DIR}/CMakeLists.txt")
+if(EXISTS "${nvcomp_SOURCE_DIR}/CMakeLists.txt")
   message(FATAL_ERROR "Ignored nvcomp override file failed to get proprietary binary version")
 endif()

--- a/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
@@ -1,0 +1,56 @@
+#=============================================================================
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/nvcomp.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+
+rapids_cpm_init()
+
+if(TARGET nvcomp::nvcomp)
+  message(FATAL_ERROR "Expected nvcomp::nvcomp not to exist")
+endif()
+
+# Need to write out an nvcomp override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages": {
+    "nvcomp": {
+      "always_download" : true,
+      "version": "3.0.6",
+      "git_url": "https://github.com/NVIDIA/nvcomp.git",
+      "git_tag": "v2.2.0",
+      "proprietary_binary": {
+        "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
+        "aarch64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
+      }
+    }
+  }
+}
+]=])
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+#
+rapids_cpm_nvcomp(USE_PROPRIETARY_BINARY ON)
+
+if(NOT nvcomp_proprietary_binary)
+  message(FATAL_ERROR "Ignored nvcomp override file failed to get proprietary binary version")
+endif()
+
+if(NOT EXISTS "${nvcomp_SOURCE_DIR}/lib/")
+
+endif()


### PR DESCRIPTION
## Description

The nvcomp package will ignore the downloaded proprietary binary, and build from source when `"always_download" : true` is in the `versions.json` file.

This was found when using a pinned override file, as it failed to use the correct nvcomp version. 

Merging this unblocks spark-rapids

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
