### PR TITLE
Prevent path conflict in builds

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -14,6 +14,7 @@ export CMAKE_GENERATOR=Ninja
 rapids-print-env
 
 rapids-logger "Begin cpp build"
+conda config --set path_conflict prevent
 
 rapids-conda-retry mambabuild conda/recipes/rapids_core_dependencies
 


### PR DESCRIPTION
This will make builds fail when there are path conflicts
