### PR TITLE
rapids_cpm_gtest adds support for BUILD_STATIC

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -141,7 +141,10 @@
       },
       "rapids_cpm_gtest": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "BUILD_STATIC"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -31,10 +31,17 @@ across all RAPIDS projects.
 
   rapids_cpm_gtest( [BUILD_EXPORT_SET <export-name>]
                     [INSTALL_EXPORT_SET <export-name>]
+                    [BUILD_STATIC]
                     [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: GTest
 .. include:: common_package_args.txt
+
+.. versionadded:: v24.06.00
+
+``BUILD_STATIC``
+  Will build `Google Test` statically. No local searching for a previously
+  built version will occur.
 
 Result Targets
 ^^^^^^^^^^^^^^
@@ -56,6 +63,12 @@ function(rapids_cpm_gtest)
     set(to_install ON)
   endif()
 
+  set(build_shared ON)
+  if(BUILD_STATIC IN_LIST ARGN)
+    set(build_shared OFF)
+    set(CPM_DOWNLOAD_benchmark ON) # Since we need static we build from source
+  endif()
+
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details(GTest version repository tag shallow exclude)
 
@@ -70,7 +83,8 @@ function(rapids_cpm_gtest)
                   GIT_TAG ${tag}
                   GIT_SHALLOW ${shallow} ${patch_command}
                   EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "INSTALL_GTEST ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON")
+                  OPTIONS "INSTALL_GTEST ${to_install}" "CMAKE_POSITION_INDEPENDENT_CODE ON"
+                          "BUILD_SHARED_LIBS ${build_shared}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(GTest)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -74,6 +74,7 @@ add_cmake_config_test( cpm_gbench-explicit-static.cmake)
 add_cmake_config_test( cpm_gtest-export.cmake )
 add_cmake_config_test( cpm_gtest-simple.cmake )
 add_cmake_config_test( cpm_gtest-static.cmake )
+add_cmake_config_test( cpm_gtest-explicit-static.cmake )
 
 add_cmake_config_test( cpm_libcudacxx-after_cpmfind.cmake SERIAL)
 add_cmake_config_test( cpm_libcudacxx-export.cmake )

--- a/testing/cpm/cpm_gtest-explicit-static.cmake
+++ b/testing/cpm/cpm_gtest-explicit-static.cmake
@@ -1,0 +1,41 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/gtest.cmake)
+
+rapids_cpm_init()
+rapids_cpm_gtest(BUILD_STATIC)
+
+get_target_property(type gtest TYPE)
+if(NOT type STREQUAL STATIC_LIBRARY)
+  message(FATAL_ERROR "rapids_cpm_gtest failed to get a static version of gtest")
+endif()
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/use_gtest.cpp" [=[
+#include <gtest/gtest.h>
+
+// The fixture for testing class Foo.
+class FooTest : public testing::Test {
+
+  FooTest() {}
+  ~FooTest() override { }
+
+  void SetUp() override {}
+  void TearDown() override {}
+};
+]=])
+add_library(uses_gtest SHARED ${CMAKE_CURRENT_BINARY_DIR}/use_gtest.cpp)
+target_link_libraries(uses_gtest PRIVATE GTest::gtest)


### PR DESCRIPTION
## Description
Extends the `BUILD_STATIC` option from GBench and NVBench to GTest. This will allow RAPIDS projects to package tests without any testing dependency libraries.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
