### PR TITLE
`rapids_cython_create_modules()`: Generate Cython dependency file

### DIFF
--- a/rapids-cmake/cython-core/create_modules.cmake
+++ b/rapids-cmake/cython-core/create_modules.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/rapids-cmake/cython-core/create_modules.cmake
+++ b/rapids-cmake/cython-core/create_modules.cmake
@@ -106,6 +106,7 @@ function(rapids_cython_create_modules)
     cmake_path(GET cython_filename FILENAME cython_module)
     cmake_path(REPLACE_EXTENSION cython_module "${_ext}" OUTPUT_VARIABLE cpp_filename)
     cmake_path(REMOVE_EXTENSION cython_module)
+    cmake_path(SET depfile NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/${cpp_filename}.dep")
 
     # Save the name of the module without the provided prefix so that we can control the output.
     set(cython_module_filename "${cython_module}")
@@ -117,9 +118,10 @@ function(rapids_cython_create_modules)
     add_custom_command(OUTPUT ${cpp_filename}
                        DEPENDS ${cython_filename}
                        VERBATIM
-                       COMMAND "${CYTHON}" ARGS "${_language_flag}" -3 ${CYTHON_FLAGS_LIST}
+                       COMMAND "${CYTHON}" ARGS ${_language_flag} -3 ${CYTHON_FLAGS_LIST}
                                "${CMAKE_CURRENT_SOURCE_DIR}/${cython_filename}" --output-file
-                               "${CMAKE_CURRENT_BINARY_DIR}/${cpp_filename}"
+                               "${CMAKE_CURRENT_BINARY_DIR}/${cpp_filename}" --depfile
+                       DEPFILE ${depfile}
                        COMMENT "Transpiling ${cython_filename} to ${cpp_filename}")
 
     python_add_library(${cython_module} MODULE "${CMAKE_CURRENT_BINARY_DIR}/${cpp_filename}"

--- a/testing/cython-core/CMakeLists.txt
+++ b/testing/cython-core/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ add_cmake_config_test(rapids-cython-core.cmake)
 add_cmake_config_test(cython-core_init.cmake)
 add_cmake_config_test(cython-core_create_modules_errors.cmake SHOULD_FAIL "You must call rapids_cython_init before calling this function")
 
-add_cmake_config_test(cython-core_create_modules)
+add_cmake_build_test(cython-core_create_modules)
 add_cmake_config_test(cython-core_create_modules_with_library)
 add_cmake_config_test(cython-core_create_modules_with_prefix)
 

--- a/testing/cython-core/cython-core_create_modules/CMakeLists.txt
+++ b/testing/cython-core/cython-core_create_modules/CMakeLists.txt
@@ -37,10 +37,8 @@ endif()
 
 # Test that the dependency file was created properly.
 cmake_path(SET depfile NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/test.c.dep")
-if(NOT EXISTS "${depfile}")
-  message(
-    FATAL_ERROR
-    "rapids_cython_create_modules didn't create the dependency file. "
-    "Expected dependency file: ${depfile}"
-  )
-endif()
+add_custom_target(check_depfile_exists ALL DEPENDS test)
+add_custom_command(TARGET check_depfile_exists POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -DDEPFILE="${depfile}"
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/check_depfile_exists.cmake
+  COMMENT "Checking for existence of dependency file")

--- a/testing/cython-core/cython-core_create_modules/CMakeLists.txt
+++ b/testing/cython-core/cython-core_create_modules/CMakeLists.txt
@@ -34,3 +34,13 @@ rapids_cython_create_modules(
 if(NOT TARGET test)
   message(FATAL_ERROR "rapids_cython_create_modules didn't create the target `test`")
 endif()
+
+# Test that the dependency file was created properly.
+cmake_path(SET depfile NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/test.c.dep")
+if(NOT EXISTS "${depfile}")
+  message(
+    FATAL_ERROR
+    "rapids_cython_create_modules didn't create the dependency file. "
+    "Expected dependency file: ${depfile}"
+  )
+endif()

--- a/testing/cython-core/cython-core_create_modules/CMakeLists.txt
+++ b/testing/cython-core/cython-core_create_modules/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cython-core/cython-core_create_modules/check_depfile_exists.cmake
+++ b/testing/cython-core/cython-core_create_modules/check_depfile_exists.cmake
@@ -1,0 +1,27 @@
+#=============================================================================
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+if(NOT DEFINED DEPFILE)
+  message(FATAL_ERROR "Must pass DEPFILE")
+endif()
+
+if(NOT EXISTS "${DEPFILE}")
+  message(
+    FATAL_ERROR
+    "rapids_cython_create_modules didn't create the dependency file. "
+    "Expected dependency file: ${DEPFILE}"
+  )
+endif()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
rapids_cython_create_modules() should instruct Cython to create dependency files for each `.pyx`.
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
