### PR TITLE
Bump NVBench version for new `main` hooks.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -86,7 +86,7 @@
       "version": "0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/nvbench.git",
-      "git_tag": "d8dced8a64d9ce305add92fa6d274fd49b569b7e"
+      "git_tag": "555d628e9b250868c9da003e4407087ff1982e8e"
     },
     "nvcomp": {
       "version": "3.0.6",


### PR DESCRIPTION
## Description
Updates nvbench for rapidsai/cudf#15492

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [N/a] New or existing tests cover these changes.
- [N/a] The documentation is up to date with these changes.
- [X] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
