### PR TITLE
rapids_cpm_gtest(BUILD_STATIC) now doesn't search for a local version

### DIFF
--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -66,7 +66,7 @@ function(rapids_cpm_gtest)
   set(build_shared ON)
   if(BUILD_STATIC IN_LIST ARGN)
     set(build_shared OFF)
-    set(CPM_DOWNLOAD_benchmark ON) # Since we need static we build from source
+    set(CPM_DOWNLOAD_GTest ON) # Since we need static we build from source
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")


### PR DESCRIPTION
## Description
This is important so that we don't pick up static system installs of GTest which don't have `PIC` enabled.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
