### PR TITLE
Update rapids_test_install_relocatable to be aware of CMake 3.29

### DIFF
--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -19,6 +19,10 @@ cmake_policy(SET CMP0007 NEW) # allow empty list entries
 cmake_policy(SET CMP0009 NEW) # don't follow symlinks
 cmake_policy(SET CMP0057 NEW) # allow `if( IN_LIST )`
 
+if(POLICY CMP0159)
+  cmake_policy(SET CMP0159 NEW)
+endif()
+
 #[=[
 The goal of this script is to re-parse the `CTestTestfile`
 and record each test and relevant properties for execution

--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -15,13 +15,7 @@
 #=============================================================================
 include_guard(GLOBAL)
 
-cmake_policy(SET CMP0007 NEW) # allow empty list entries
-cmake_policy(SET CMP0009 NEW) # don't follow symlinks
-cmake_policy(SET CMP0057 NEW) # allow `if( IN_LIST )`
-
-if(POLICY CMP0159)
-  cmake_policy(SET CMP0159 NEW)
-endif()
+cmake_minimum_required(VERSION 3.26...3.29)
 
 #[=[
 The goal of this script is to re-parse the `CTestTestfile`


### PR DESCRIPTION
## Description
Fixes #583

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
