### PR TITLE
Ensure support_conda_env uses `isystem`

### DIFF
--- a/rapids-cmake/cmake/support_conda_env.cmake
+++ b/rapids-cmake/cmake/support_conda_env.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,12 @@ Establish a target that holds the CONDA include and link directories.
 
 Creates a global interface target called `target_name` that holds
 the CONDA include and link directories, when executed.
+
+.. versionadded:: v24.06.00
+
+The include directories that `target_name` holds will be `-isystem` to match
+the behavior of conda when it builds projects.
+
 
 Also offers the ability to modify :cmake:variable:`CMAKE_PREFIX_PATH <cmake:variable:CMAKE_PREFIX_PATH>` to
 include the following paths based on the current conda environment:
@@ -136,8 +142,8 @@ function(rapids_cmake_support_conda_env target)
         set(targetsDir "targets/sbsa-linux")
       endif()
 
-      target_include_directories(${target} INTERFACE "$ENV{PREFIX}/include"
-                                                     "$ENV{BUILD_PREFIX}/include")
+      target_include_directories(${target} SYSTEM INTERFACE "$ENV{PREFIX}/include"
+                                                            "$ENV{BUILD_PREFIX}/include")
       target_link_directories(${target} INTERFACE "$ENV{PREFIX}/lib" "$ENV{BUILD_PREFIX}/lib")
 
       if(DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG
@@ -163,7 +169,7 @@ function(rapids_cmake_support_conda_env target)
       endif()
 
     elseif(in_conda_prefix)
-      target_include_directories(${target} INTERFACE "$ENV{CONDA_PREFIX}/include")
+      target_include_directories(${target} SYSTEM INTERFACE "$ENV{CONDA_PREFIX}/include")
       target_link_directories(${target} INTERFACE "$ENV{CONDA_PREFIX}/lib")
       if(DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG
          OR DEFINED CMAKE_SHARED_LIBRARY_RPATH_LINK_CXX_FLAG)

--- a/testing/cmake/conda_env-build-envvar.cmake
+++ b/testing/cmake/conda_env-build-envvar.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-build.cmake
+++ b/testing/cmake/conda_env-build.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-cross-build-arm-envvar.cmake
+++ b/testing/cmake/conda_env-cross-build-arm-envvar.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-cross-build-arm.cmake
+++ b/testing/cmake/conda_env-cross-build-arm.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-cross-build-x86-envvar.cmake
+++ b/testing/cmake/conda_env-cross-build-x86-envvar.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-cross-build-x86.cmake
+++ b/testing/cmake/conda_env-cross-build-x86.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-prefix-envvar.cmake
+++ b/testing/cmake/conda_env-prefix-envvar.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
 
 rapids_cmake_support_conda_env(conda_env)
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Not expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()

--- a/testing/cmake/conda_env-prefix.cmake
+++ b/testing/cmake/conda_env-prefix.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
 
 rapids_cmake_support_conda_env(conda_env)
 
-get_target_property(include_dirs conda_env INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Not expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")
 endif()


### PR DESCRIPTION
## Description
Conda injects the path to the conda include directory as a system include when building via `CXXFLAGS` / `CFLAGS`  / etc. We need to match this behavior so that we have consistent search order, since system includes are used last compared to user includes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
