### PR TITLE
fix docs for rapids_export_ functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -145,8 +145,8 @@ Export Set Generation
 These `rapids_export` functions allow projects to generate correct build and install tree `Project-Config.cmake` modules including required dependencies.
 
 For the vast majority of projects :cmake:command:`rapids_export` should be sufficient. But when
-not projects may use commands such as :cmake:command:`rapids_write_dependencies` and
-cmake:command:`rapids_write_language` to create a custom `Project-Config.cmake`.
+not projects may use commands such as :cmake:command:`rapids_export_write_dependencies` and
+:cmake:command:`rapids_export_write_language` to create a custom `Project-Config.cmake`.
 
 
 .. toctree::


### PR DESCRIPTION
## Description

Reading through https://docs.rapids.ai/api/rapids-cmake/stable/api/ today, I noticed two apparent typos

* `rapids_write_dependencies` (should be `rapids_export_write_dependencies`)
* `rapids_write_language` (should be `rapids_export_write_language`)

This fixes those, along with another formatting error causing one of them to not be rendered as inline code.

<img width="1321" alt="Screenshot 2024-04-22 at 12 31 27 PM" src="https://github.com/rapidsai/rapids-cmake/assets/7608904/d0be372e-983d-4d7a-a863-e3a664eacbf7">

## Notes for Reviewers

I'd expect to see typos like this caught by `sphinx`... but I don't see any warnings raised in the most recent docs build for this repo ([build link](https://github.com/rapidsai/rapids-cmake/actions/runs/8784482118/job/24102801497)). So I'm not sure how to easily prevent such things in CI in the future. 

Maybe something like a CI job that does link-checking across RAPIDS would be able to catch things like this in the future. Linking the relevant issue tracking that idea: https://github.com/rapidsai/build-planning/issues/9

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
