### PR TITLE
clarify language around how FetchContent is used in RAPIDS.cmake

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -5,8 +5,9 @@ RAPIDS-CMake Basics
 Installation
 ************
 
-The ``rapids-cmake`` module is designed to be acquired via CMake's `Fetch
-Content <https://cmake.org/cmake/help/latest/module/FetchContent.html>`_ into your project.
+The ``rapids-cmake`` module is designed to be acquired at configure time in your project.
+Download the ``RAPIDS.cmake`` script, which handles fetching the rest of the module's content
+via CMake's `FetchContent <https://cmake.org/cmake/help/latest/module/FetchContent.html>`_.
 
 .. code-block:: cmake
 


### PR DESCRIPTION
## Description

Reading through, https://docs.rapids.ai/api/rapids-cmake/stable/basics/, I found this sentence a bit confusing:

> *The rapids-cmake module is designed to be acquired via CMake’s [Fetch Content](https://cmake.org/cmake/help/latest/module/FetchContent.html) into your project.*

Because the code block immediately below it does not actually call `FetchContent()` and friends.

<img width="944" alt="image" src="https://github.com/rapidsai/rapids-cmake/assets/7608904/15937899-f5c7-4ec2-9d0d-efbac4d36473">

This PR proposes a change to that language which I think might make it clearer that `RAPIDS.cmake` is itself using `FetchContent()`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
