### PR TITLE
Expand rapids_cpm_init to support custom default version files

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -92,6 +92,7 @@
           ]
         },
         "kwargs": {
+          "CUSTOM_DEFAULT_VERSION_FILE": 1,
           "OVERRIDE": 1
         }
       },

--- a/rapids-cmake/cpm/detail/load_preset_versions.cmake
+++ b/rapids-cmake/cpm/detail/load_preset_versions.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ Establish the `CPM` preset package information for the project.
 
 .. code-block:: cmake
 
-  rapids_cpm_load_preset_versions()
+  rapids_cpm_load_preset_versions([PRESET_FILE version_file])
 
 .. note::
   Will be called by the first invocation of :cmake:command:`rapids_cpm_init` or :cmake:command:`rapids_cpm_<pkg>`.
@@ -34,15 +34,32 @@ Establish the `CPM` preset package information for the project.
 function(rapids_cpm_load_preset_versions)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.load_preset_versions")
 
+  set(_rapids_options)
+  set(_rapids_one_value PRESET_FILE)
+  set(_rapids_multi_value)
+  cmake_parse_arguments(_RAPIDS "${_rapids_options}" "${_rapids_one_value}"
+                        "${_rapids_multi_value}" ${ARGN})
+
+  set(_rapids_preset_version_file "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../versions.json")
+  if(_RAPIDS_PRESET_FILE)
+    set(_rapids_preset_version_file "${_RAPIDS_PRESET_FILE}")
+  endif()
+
+  if(NOT EXISTS "${_rapids_preset_version_file}")
+    message(FATAL_ERROR "rapids_cpm can't load '${filepath}' to find package version information, verify it exists"
+    )
+  endif()
+
   # Check if we have been loaded before, if so early terminate
-  get_property(already_loaded GLOBAL PROPERTY rapids_cpm_load_presets SET)
+  get_property(already_loaded GLOBAL PROPERTY rapids_cpm_load_presets_${_rapids_preset_version_file}
+               SET)
   if(already_loaded)
     return()
   endif()
-  set_property(GLOBAL PROPERTY rapids_cpm_load_presets "ON")
+  set_property(GLOBAL PROPERTY rapids_cpm_load_presets_${_rapids_preset_version_file} "ON")
 
-  # Load our json files
-  file(READ "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../versions.json" json_data)
+  # Load our json file
+  file(READ "${_rapids_preset_version_file}" json_data)
 
   # Determine all the projects that exist in the json file
   string(JSON package_count LENGTH "${json_data}" packages)
@@ -54,8 +71,12 @@ function(rapids_cpm_load_preset_versions)
   foreach(index RANGE ${package_count})
     string(JSON package_name MEMBER "${json_data}" packages ${index})
     string(JSON data GET "${json_data}" packages "${package_name}")
-    set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json "${data}")
-    set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json_file "${filepath}")
+
+    get_property(already_exists GLOBAL PROPERTY rapids_cpm_${package_name}_json SET)
+    if(NOT already_exists)
+      set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json "${data}")
+      set_property(GLOBAL PROPERTY rapids_cpm_${package_name}_json_file "${filepath}")
+    endif()
   endforeach()
 
 endfunction()

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -25,7 +25,8 @@ Establish the `CPM` and preset package infrastructure for the project.
 
 .. code-block:: cmake
 
-  rapids_cpm_init( [OVERRIDE <json_override_file_path> ]
+  rapids_cpm_init( [CUSTOM_DEFAULT_VERSION_FILE <json_default_file_path>]
+                   [OVERRIDE <json_override_file_path>]
                    [GENERATE_PINNED_VERSIONS]
                    )
 
@@ -34,11 +35,24 @@ The CPM module will be downloaded based on the state of :cmake:variable:`CPM_SOU
 same download of CPM. If those variables aren't set the file will be cached
 in the build tree of the calling project
 
-.. versionadded:: v24.04.00
-  As part of establishing rapids-cmake CPM the :cmake:command:`rapids_cpm_init` command
-  will call :cmake:command:`rapids_cpm_generate_pinned_versions` to automatically generate
-  `<CMAKE_BINARY_DIR>/rapids-cmake/pinned_versions.json` which will contain all the exact git SHAs
-  used to build cpm dependencies.
+.. versionadded:: v24.06.00
+  ```
+  CUSTOM_DEFAULT_VERSION_FILE
+  ```
+  This is an advanced option that allows projects to specify a custom default `versions.json` file that will
+  be used instead of the one packaged inside rapids-cmake. Since this allows you to specify a new default
+  `versions.json` it must contain information for all the built-in rapids-cmake packages ( cccl, fmt, rmm, etc )
+  that are used by your project.
+
+  Using a built-in rapids-cmake package without an explicit entry in the custom default version file is undefined behavior.
+
+  If multiple calls to `rapids_cpm_init` occur with different default version files being used,
+  each version file will be loaded. If a project is listed in multiple default version files, the first
+  file values will be used, and all later calls for that packaged will be ignored.  This "first to record, wins"
+  approach is used to match FetchContent, and allows parent projects to override child
+  projects.
+
+  The provided json file must follow the `versions.json` format, which is :ref:`documented here<cpm_version_format>`.
 
 .. versionadded:: v21.10.00
   ``OVERRIDE``
@@ -46,6 +60,12 @@ in the build tree of the calling project
   :ref:`rapids_cpm_* <cpm_pre-configured_packages>`, `CPM <https://github.com/cpm-cmake/CPM.cmake>`_,
   and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package. By providing a secondary
   file with extra`CPM` preset package information for the project.
+
+  If multiple calls to `rapids_cpm_init` occur with different OVERRIDE files being used,
+  each version file will be loaded. If a project is listed in multiple override files, the first
+  file values will be used, and all later calls for that packaged will be ignored.  This "first to record, wins"
+  approach is used to match FetchContent, and allows parent projects to override child
+  projects.
 
   The provided json file must follow the `versions.json` format, which is :ref:`documented here<cpm_version_format>`.
 
@@ -67,13 +87,18 @@ function(rapids_cpm_init)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.init")
 
   set(_rapids_options GENERATE_PINNED_VERSIONS)
-  set(_rapids_one_value OVERRIDE)
+  set(_rapids_one_value CUSTOM_DEFAULT_VERSION_FILE OVERRIDE)
   set(_rapids_multi_value)
   cmake_parse_arguments(_RAPIDS "${_rapids_options}" "${_rapids_one_value}"
                         "${_rapids_multi_value}" ${ARGN})
 
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
-  rapids_cpm_load_preset_versions()
+
+  if(_RAPIDS_CUSTOM_DEFAULT_VERSION_FILE)
+    rapids_cpm_load_preset_versions(PRESET_FILE "${_RAPIDS_CUSTOM_DEFAULT_VERSION_FILE}")
+  else()
+    rapids_cpm_load_preset_versions()
+  endif()
 
   if(_RAPIDS_OVERRIDE)
     include("${rapids-cmake-dir}/cpm/package_override.cmake")

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -39,20 +39,20 @@ in the build tree of the calling project
   ```
   CUSTOM_DEFAULT_VERSION_FILE
   ```
-  This is an advanced option that allows projects to specify a custom default `versions.json` file that will
+  This is an advanced option that allows projects to specify a custom default ``versions.json`` file that will
   be used instead of the one packaged inside rapids-cmake. Since this allows you to specify a new default
-  `versions.json` it must contain information for all the built-in rapids-cmake packages ( cccl, fmt, rmm, etc )
+  ``versions.json`` it must contain information for all the built-in rapids-cmake packages ( cccl, fmt, rmm, etc )
   that are used by your project.
 
   Using a built-in rapids-cmake package without an explicit entry in the custom default version file is undefined behavior.
 
-  If multiple calls to `rapids_cpm_init` occur with different default version files being used,
+  If multiple calls to ``rapids_cpm_init`` occur with different default version files being used,
   each version file will be loaded. If a project is listed in multiple default version files, the first
   file values will be used, and all later calls for that packaged will be ignored.  This "first to record, wins"
-  approach is used to match FetchContent, and allows parent projects to override child
+  approach is used to match ``FetchContent``, and allows parent projects to override child
   projects.
 
-  The provided json file must follow the `versions.json` format, which is :ref:`documented here<cpm_version_format>`.
+  The provided json file must follow the ``versions.json`` format, which is :ref:`documented here<cpm_version_format>`.
 
 .. versionadded:: v21.10.00
   ``OVERRIDE``
@@ -61,10 +61,10 @@ in the build tree of the calling project
   and :cmake:module:`FetchContent() <cmake:module:FetchContent>` package. By providing a secondary
   file with extra`CPM` preset package information for the project.
 
-  If multiple calls to `rapids_cpm_init` occur with different OVERRIDE files being used,
+  If multiple calls to ``rapids_cpm_init`` occur with different ``OVERRIDE`` files being used,
   each version file will be loaded. If a project is listed in multiple override files, the first
   file values will be used, and all later calls for that packaged will be ignored.  This "first to record, wins"
-  approach is used to match FetchContent, and allows parent projects to override child
+  approach is used to match ``FetchContent``, and allows parent projects to override child
   projects.
 
   The provided json file must follow the `versions.json` format, which is :ref:`documented here<cpm_version_format>`.

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -34,9 +34,13 @@ add_cmake_build_test( cpm_generate_pins-no-src-dir )
 add_cmake_build_test( cpm_generate_pins-pure-cpm )
 add_cmake_build_test( cpm_generate_pins-simple NO_CPM_CACHE)
 
+add_cmake_config_test( cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm_init can't load")
 add_cmake_config_test( cpm_init-bad-override-path.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")
-add_cmake_config_test( cpm_init-override-multiple.cmake )
+add_cmake_config_test( cpm_init-custom-default-simple.cmake)
+add_cmake_config_test( cpm_init-custom-default-multiple.cmake)
 add_cmake_config_test( cpm_init-override-simple.cmake )
+add_cmake_config_test( cpm_init-override-multiple.cmake )
+
 
 add_cmake_config_test( cpm_package_override-add-new-project.cmake )
 add_cmake_config_test( cpm_package_override-bad-path.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")

--- a/testing/cpm/cpm_init-bad-default-path.cmake
+++ b/testing/cpm/cpm_init-bad-default-path.cmake
@@ -1,0 +1,18 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE ${CMAKE_CURRENT_LIST_DIR}/bad_path.cmake)

--- a/testing/cpm/cpm_init-custom-default-multiple.cmake
+++ b/testing/cpm/cpm_init-custom-default-multiple.cmake
@@ -1,0 +1,85 @@
+#=============================================================================
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+# Need to write out multiple default files
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaultsA.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "nvbench_version",
+      "git_url": "nvbench_url",
+      "git_tag": "nvbench_tag"
+    }
+  }
+}
+  ]=])
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaultsB.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "not_read_version",
+      "git_url": "not_nvbench_url",
+      "git_tag": "not_nvbench_tag"
+    },
+    "rmm": {
+      "version": "rmm_version",
+      "git_url": "rmm_url",
+      "git_tag": "rmm_tag"
+    },
+  }
+}
+  ]=])
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaultsC.json
+  [=[
+{
+  "packages": {
+    "GTest": {
+      "version": "GTest_version",
+      "git_url": "GTest_url",
+      "git_tag": "GTest_tag"
+    }
+  }
+}
+  ]=])
+
+# Emulate multiple projects calling `rapids_cpm_init` with different default files
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaultsA.json")
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaultsB.json")
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaultsC.json")
+
+foreach(proj IN ITEMS rmm nvbench GTest)
+  # Verify that multiple custom defaults work
+  include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+  rapids_cpm_package_details(${proj} version repository tag shallow exclude)
+  if(NOT version STREQUAL "${proj}_version")
+    message(FATAL_ERROR "${proj} default version field was removed.")
+  endif()
+  if(NOT repository STREQUAL "${proj}_url")
+    message(FATAL_ERROR "${proj} default repository field was removed.")
+  endif()
+  if(NOT tag STREQUAL "${proj}_tag")
+    message(FATAL_ERROR "${proj} default tag field was removed.")
+  endif()
+  if(CPM_DOWNLOAD_ALL)
+    message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false since since we just specified a defaults version file'")
+  endif()
+  unset(CPM_DOWNLOAD_ALL)
+endforeach()

--- a/testing/cpm/cpm_init-custom-default-simple.cmake
+++ b/testing/cpm/cpm_init-custom-default-simple.cmake
@@ -1,0 +1,49 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicableexpect_fetch_content_details law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+# Need to write out a custom default file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaults.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "custom_version",
+      "git_url": "my_url",
+      "git_tag": "my_tag"
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaults.json")
+
+# Verify that the custom defaults works
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
+
+if(NOT version STREQUAL "custom_version")
+  message(FATAL_ERROR "custom default version field was ignored. ${version} found instead of custom_version")
+endif()
+if(NOT repository STREQUAL "my_url")
+  message(FATAL_ERROR "custom default git_url field was ignored. ${repository} found instead of my_url")
+endif()
+if(NOT tag STREQUAL "my_tag")
+  message(FATAL_ERROR "custom default git_tag field was ignored. ${tag} found instead of my_tag")
+endif()
+if(CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL shouldn't be set to true when using a custom default")
+endif()


### PR DESCRIPTION
## Description
First step to implelementing https://github.com/rapidsai/rapids-cmake/issues/587.

Exposes a new `CUSTOM_DEFAULT_VERSION_FILE` option to `rapids_cpm_init` that allows projects to specify a new default versions.json to be used instead of the one packaged with rapids-cmake

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
