### PR TITLE
Allow for cpm default and override files via variables

### DIFF
--- a/rapids-cmake/cpm/detail/load_preset_versions.cmake
+++ b/rapids-cmake/cpm/detail/load_preset_versions.cmake
@@ -44,6 +44,9 @@ function(rapids_cpm_load_preset_versions)
   if(_RAPIDS_PRESET_FILE)
     set(_rapids_preset_version_file "${_RAPIDS_PRESET_FILE}")
   endif()
+  if(DEFINED RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE)
+    set(_rapids_preset_version_file "${RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE}")
+  endif()
 
   if(NOT EXISTS "${_rapids_preset_version_file}")
     message(FATAL_ERROR "rapids_cpm can't load '${filepath}' to find package version information, verify it exists"

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -76,6 +76,7 @@ in the build tree of the calling project
   If the override file doesn't specify a value or package entry the default version will be used.
 
   .. versionadded:: v24.06.00
+
   If the variable :cmake:variable:`RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE` is specified it will be used
   in all calls to ``rapids_cpm_init``. Any existing explicit `OVERRIDE` files will be ignored, and
   all other calls will be treated as if this file was specified as the override.

--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -54,6 +54,10 @@ in the build tree of the calling project
 
   The provided json file must follow the ``versions.json`` format, which is :ref:`documented here<cpm_version_format>`.
 
+  If the variable :cmake:variable:`RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE` is specified it will be used
+  in all calls to ``rapids_cpm_init`` instead of any explicit `CUSTOM_DEFAULT_VERSION_FILE` file, or
+  usage of the rapids-cmake default version.json file.
+
 .. versionadded:: v21.10.00
   ``OVERRIDE``
   Allows projects to override the default values for any :cmake:command:`rapids_cpm_find`,
@@ -70,6 +74,11 @@ in the build tree of the calling project
   The provided json file must follow the `versions.json` format, which is :ref:`documented here<cpm_version_format>`.
 
   If the override file doesn't specify a value or package entry the default version will be used.
+
+  .. versionadded:: v24.06.00
+  If the variable :cmake:variable:`RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE` is specified it will be used
+  in all calls to ``rapids_cpm_init``. Any existing explicit `OVERRIDE` files will be ignored, and
+  all other calls will be treated as if this file was specified as the override.
 
 .. versionadded:: v24.04.00
   ```
@@ -100,7 +109,7 @@ function(rapids_cpm_init)
     rapids_cpm_load_preset_versions()
   endif()
 
-  if(_RAPIDS_OVERRIDE)
+  if(_RAPIDS_OVERRIDE OR RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE)
     include("${rapids-cmake-dir}/cpm/package_override.cmake")
     rapids_cpm_package_override("${_RAPIDS_OVERRIDE}")
   endif()

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -35,11 +35,15 @@ add_cmake_build_test( cpm_generate_pins-pure-cpm )
 add_cmake_build_test( cpm_generate_pins-simple NO_CPM_CACHE)
 
 add_cmake_config_test( cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm_init can't load")
+add_cmake_config_test( cpm_init-bad-default-cmake-var.cmake SHOULD_FAIL "rapids_cpm_init can't load")
 add_cmake_config_test( cpm_init-bad-override-path.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")
+add_cmake_config_test( cpm_init-bad-override-cmake-var.cmake SHOULD_FAIL "rapids_cpm_package_override can't load")
 add_cmake_config_test( cpm_init-custom-default-simple.cmake)
 add_cmake_config_test( cpm_init-custom-default-multiple.cmake)
-add_cmake_config_test( cpm_init-override-simple.cmake )
-add_cmake_config_test( cpm_init-override-multiple.cmake )
+add_cmake_config_test( cpm_init-custom-default-via-cmake-var.cmake)
+add_cmake_config_test( cpm_init-override-simple.cmake)
+add_cmake_config_test( cpm_init-override-multiple.cmake)
+add_cmake_config_test( cpm_init-override-via-cmake-var.cmake)
 
 
 add_cmake_config_test( cpm_package_override-add-new-project.cmake )

--- a/testing/cpm/cpm_init-bad-default-cmake-var.cmake
+++ b/testing/cpm/cpm_init-bad-default-cmake-var.cmake
@@ -1,0 +1,19 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+set(RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE ${CMAKE_CURRENT_LIST_DIR}/bad_path.cmake)
+rapids_cpm_init()

--- a/testing/cpm/cpm_init-bad-override-cmake-var.cmake
+++ b/testing/cpm/cpm_init-bad-override-cmake-var.cmake
@@ -1,0 +1,19 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+set(RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE ${CMAKE_CURRENT_LIST_DIR}/bad_path.cmake)
+rapids_cpm_init()

--- a/testing/cpm/cpm_init-custom-default-via-cmake-var.cmake
+++ b/testing/cpm/cpm_init-custom-default-via-cmake-var.cmake
@@ -1,0 +1,67 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicableexpect_fetch_content_details law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+# Need to write out the custom default file that is real
+# but should be ignored
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaults_ignored.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "ignored_custom_version",
+      "git_url": "ignored_url",
+      "git_tag": "ignored_tag"
+    }
+  }
+}
+  ]=])
+
+
+# Need to write out the custom default file that will be used
+# by the CMake var
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaults.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "custom_version",
+      "git_url": "my_url",
+      "git_tag": "my_tag"
+    }
+  }
+}
+  ]=])
+
+set(RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/defaults.json)
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaults_ignored.json")
+
+# Verify that the custom defaults works
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
+
+if(NOT version STREQUAL "custom_version")
+  message(FATAL_ERROR "custom default version field was ignored. ${version} found instead of custom_version")
+endif()
+if(NOT repository STREQUAL "my_url")
+  message(FATAL_ERROR "custom default git_url field was ignored. ${repository} found instead of my_url")
+endif()
+if(NOT tag STREQUAL "my_tag")
+  message(FATAL_ERROR "custom default git_tag field was ignored. ${tag} found instead of my_tag")
+endif()
+if(CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL shouldn't be set to true when using a custom default")
+endif()

--- a/testing/cpm/cpm_init-override-via-cmake-var.cmake
+++ b/testing/cpm/cpm_init-override-via-cmake-var.cmake
@@ -1,0 +1,66 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override_ignored.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "ignored_custom_version",
+      "git_url": "ignored_url",
+      "git_tag": "ignored_tag"
+    }
+  }
+}
+  ]=])
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "custom_version",
+      "git_url": "my_url",
+      "git_tag": "my_tag"
+    }
+  }
+}
+  ]=])
+
+set(RAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE ${CMAKE_CURRENT_BINARY_DIR}/override.json)
+rapids_cpm_init(OVERRIDE "${CMAKE_CURRENT_BINARY_DIR}/override_ignored.json")
+
+# Verify that the override works
+include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
+rapids_cpm_package_details(nvbench version repository tag shallow exclude)
+
+if(NOT version STREQUAL "custom_version")
+  message(FATAL_ERROR "custom version field was ignored. ${version} found instead of custom_version")
+endif()
+if(NOT repository STREQUAL "my_url")
+  message(FATAL_ERROR "custom git_url field was ignored. ${repository} found instead of my_url")
+endif()
+if(NOT tag STREQUAL "my_tag")
+  message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_tag")
+endif()
+if(NOT DEFINED CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be defined when an override exists")
+endif()
+if(NOT CPM_DOWNLOAD_ALL)
+  message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")
+endif()


### PR DESCRIPTION
## Description
Extends https://github.com/rapidsai/rapids-cmake/pull/595 with support for setting the default and override file used by rapids-cmake via the command line.

Fixes #552 #587

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
