### PR TITLE
rapids-cmake allow GENERATE_PINNED_VERSIONS via CMake variable

### DIFF
--- a/rapids-cmake/cpm/init.cmake
+++ b/rapids-cmake/cpm/init.cmake
@@ -89,6 +89,14 @@ in the build tree of the calling project
   This allows for reproducible builds using the exact same state.
   The pinning file will be located at `<CMAKE_BINARY_DIR>/rapids-cmake/pinned_versions.json`
 
+  .. versionadded:: v24.06.00
+
+  If the variable :cmake:variable:`RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE` exists it will be treated
+  as if all calls to ``rapids_cpm_init`` are requesting generation of a pinned versions file.
+  In addition to any existing explicit `GENERATE_PINNED_VERSIONS` files, the file path contained
+  in :cmake:variable:`RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE` will be used as a destination to
+  write the pinned versions.json content.
+
 .. note::
   Must be called before any invocation of :cmake:command:`rapids_cpm_find`.
 
@@ -119,6 +127,11 @@ function(rapids_cpm_init)
     include("${rapids-cmake-dir}/cpm/generate_pinned_versions.cmake")
     rapids_cpm_generate_pinned_versions(
       OUTPUT "${CMAKE_BINARY_DIR}/rapids-cmake/pinned_versions.json")
+  endif()
+
+  if(DEFINED RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE)
+    include("${rapids-cmake-dir}/cpm/generate_pinned_versions.cmake")
+    rapids_cpm_generate_pinned_versions(OUTPUT "${RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE}")
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/download.cmake")

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -29,10 +29,12 @@ add_cmake_config_test( cpm_find-version-explicit-install.cmake )
 
 add_cmake_build_test( cpm_generate_pins-format-patches NO_CPM_CACHE)
 add_cmake_build_test( cpm_generate_pins-nested NO_CPM_CACHE)
-add_cmake_build_test( cpm_generate_pins-override NO_CPM_CACHE)
 add_cmake_build_test( cpm_generate_pins-no-src-dir )
+add_cmake_build_test( cpm_generate_pins-override NO_CPM_CACHE)
 add_cmake_build_test( cpm_generate_pins-pure-cpm )
 add_cmake_build_test( cpm_generate_pins-simple NO_CPM_CACHE)
+add_cmake_build_test( cpm_generate_pins-simple-via-variable NO_CPM_CACHE)
+add_cmake_build_test( cpm_generate_pins-var-and-arg NO_CPM_CACHE)
 
 add_cmake_config_test( cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm_init can't load")
 add_cmake_config_test( cpm_init-bad-default-cmake-var.cmake SHOULD_FAIL "rapids_cpm_init can't load")

--- a/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
@@ -1,0 +1,31 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-test-project LANGUAGES CXX)
+
+set(RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE "${CMAKE_CURRENT_BINARY_DIR}/custom_path/pinned_versions.json")
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
+
+rapids_cpm_init()
+rapids_cpm_rmm()
+
+include("${rapids-cmake-testing-dir}/cpm/verify_generated_pins.cmake")
+verify_generated_pins(verify_pins
+    PROJECTS rmm fmt spdlog CCCL
+    PIN_FILE "${RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE}")

--- a/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
@@ -1,0 +1,34 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.23.1)
+project(rapids-test-project LANGUAGES CXX)
+
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
+
+set(RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE "${CMAKE_CURRENT_BINARY_DIR}/custom_path/pinned_versions.json")
+rapids_cpm_init(GENERATE_PINNED_VERSIONS)
+rapids_cpm_rmm()
+
+include("${rapids-cmake-testing-dir}/cpm/verify_generated_pins.cmake")
+verify_generated_pins(verify_pins_A
+    PROJECTS rmm fmt spdlog CCCL
+    PIN_FILE "${RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE}")
+
+verify_generated_pins(verify_pins_B
+    PROJECTS rmm fmt spdlog CCCL
+    PIN_FILE "${CMAKE_BINARY_DIR}/rapids-cmake/pinned_versions.json")


### PR DESCRIPTION

## Description
Fixes #552


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
