### PR TITLE
Ensure nvcomps build and install layouts are consistent

### DIFF
--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -103,7 +103,7 @@ add_cmake_config_test( cpm_nvcomp-simple.cmake )
 add_cmake_config_test( cpm_nvcomp-invalid-arch.cmake )
 add_cmake_config_test( cpm_nvcomp-always-download-proprietary_binary.cmake SERIAL)
 add_cmake_config_test( cpm_nvcomp-override-clears-proprietary_binary.cmake SERIAL)
-add_cmake_build_test( cpm_nvcomp-proprietary_binary-lib-location.cmake SERIAL)
+add_cmake_build_test( cpm_nvcomp-proprietary_binary-lib-location.cmake SERIAL NO_CPM_CACHE)
 
 add_cmake_config_test( cpm_proprietary-url-ctk-version-find-ctk.cmake )
 add_cmake_config_test( cpm_proprietary-url-ctk-version.cmake )

--- a/testing/cpm/cpm_nvcomp-proprietary_binary-lib-location.cmake
+++ b/testing/cpm/cpm_nvcomp-proprietary_binary-lib-location.cmake
@@ -33,7 +33,7 @@ endif()
 
 # Check the contents of the nvcomp-targets-release.cmake file to ensure that
 # every line containing "_IMPORT_PREFIX" also contains "lib64"
-file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/_deps/nvcomp_proprietary_binary-src/lib/cmake/nvcomp/nvcomp-targets-release.cmake" nvcomp_targets_release_contents)
+file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/_deps/nvcomp_proprietary_binary-src/lib64/cmake/nvcomp/nvcomp-targets-release.cmake" nvcomp_targets_release_contents)
 foreach(line IN LISTS nvcomp_targets_release_contents)
   string(FIND "${line}" "_IMPORT_PREFIX" _IMPORT_PREFIX_INDEX)
   if(_IMPORT_PREFIX_INDEX EQUAL -1)
@@ -63,6 +63,14 @@ message(\"Checking for lib64 directory in ${expected_install_dir}\")
 if (NOT EXISTS ${expected_install_dir}/lib64)
   message(FATAL_ERROR \"The lib64 directory didn't exist!\")
 endif()
+
+set(nvcomp_ROOT \"${expected_install_dir}/lib64/cmake/nvcomp\")
+find_package(nvcomp REQUIRED)
+
+file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/stub.cpp\" \" \")
+add_library(uses_nvcomp SHARED stub.cpp)
+target_link_libraries(uses_nvcomp PRIVATE nvcomp::nvcomp)
+
 ")
 
 add_custom_target(verify_nvcomp_lib_dir ALL


### PR DESCRIPTION
## Description
Corrects a bug where the nvcomp packages from the build directory would reference the `lib64` layout in the cmake file since that would be the correct layout at install time but not build time.

We now transform the layout of nvcomp to be consistent between build and install

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
