### PR TITLE
Support CMAKE_INSTALL_MESSAGE + rapids_test_install_relocatable

### DIFF
--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -195,8 +195,8 @@ function(extract_install_info line)
   # item 1 is the install location item 2 is the filter if valid item 3+ are the lists of files
   # being installed
   list(GET line 2 type)
-  if(type STREQUAL " TYPE SHARED_LIBRARY FILES " OR type STREQUAL " TYPE STATIC_LIBRARY FILES "
-     OR type STREQUAL " TYPE OBJECT_LIBRARY FILES " OR type STREQUAL " TYPE EXECUTABLE FILES ")
+  if(type MATCHES " TYPE EXECUTABLE " OR type MATCHES " TYPE SHARED_LIBRARY "
+     OR type MATCHES " TYPE STATIC_LIBRARY " OR type MATCHES " TYPE OBJECT_LIBRARY ")
     list(GET line 1 install_loc)
     list(GET line 3 build_loc)
     cmake_path(GET build_loc FILENAME name)

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -44,6 +44,8 @@ add_cmake_build_test(install_relocatable-labels.cmake)
 add_cmake_build_test(install_relocatable-no-tests.cmake)
 add_cmake_build_test(install_relocatable-simple.cmake)
 add_cmake_build_test(install_relocatable-complex)
+add_cmake_build_test(install_relocatable-installed-tests-run)
+add_cmake_build_test(install_relocatable-installed-tests-run-lazy-msg)
 add_cmake_config_test(install_relocatable-wrong-component.cmake SHOULD_FAIL "${wrong_component_message}")
 
 add_cmake_ctest_test(add-impossible-allocation SHOULD_FAIL "Insufficient resources for test")

--- a/testing/test/install_relocatable-installed-tests-run-lazy-msg/CMakeLists.txt
+++ b/testing/test/install_relocatable-installed-tests-run-lazy-msg/CMakeLists.txt
@@ -35,6 +35,6 @@ rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/te
 
 add_custom_target(install_testing_component ALL
   COMMAND ${CMAKE_COMMAND} --install "${CMAKE_CURRENT_BINARY_DIR}" --component testing --prefix install/
-  COMMAND ctest --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
+  COMMAND ${CMAKE_CTEST_COMMAND} --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
   )
 add_dependencies(install_testing_component verify_)

--- a/testing/test/install_relocatable-installed-tests-run-lazy-msg/CMakeLists.txt
+++ b/testing/test/install_relocatable-installed-tests-run-lazy-msg/CMakeLists.txt
@@ -1,0 +1,40 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+set(CMAKE_CONFIGURATION_TYPES Debug)
+project(rapids-test-project LANGUAGES CUDA)
+
+include(${rapids-cmake-dir}/rapids-test.cmake)
+
+set(CMAKE_INSTALL_MESSAGE LAZY)
+enable_testing()
+rapids_test_init()
+
+add_executable(verify_ main.cu)
+rapids_test_add(
+  NAME verify
+  COMMAND verify_
+  GPUS 1
+  PERCENT 100
+  INSTALL_COMPONENT_SET testing
+)
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/tests/to_verify/)
+
+add_custom_target(install_testing_component ALL
+  COMMAND ${CMAKE_COMMAND} --install "${CMAKE_CURRENT_BINARY_DIR}" --component testing --prefix install/
+  COMMAND ctest --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
+  )
+add_dependencies(install_testing_component verify_)

--- a/testing/test/install_relocatable-installed-tests-run-lazy-msg/main.cu
+++ b/testing/test/install_relocatable-installed-tests-run-lazy-msg/main.cu
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int main() { return 0; }

--- a/testing/test/install_relocatable-installed-tests-run/CMakeLists.txt
+++ b/testing/test/install_relocatable-installed-tests-run/CMakeLists.txt
@@ -1,0 +1,39 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.20)
+set(CMAKE_CONFIGURATION_TYPES Debug)
+project(rapids-test-project LANGUAGES CUDA)
+
+include(${rapids-cmake-dir}/rapids-test.cmake)
+
+enable_testing()
+rapids_test_init()
+
+add_executable(verify_ main.cu)
+rapids_test_add(
+  NAME verify
+  COMMAND verify_
+  GPUS 1
+  PERCENT 100
+  INSTALL_COMPONENT_SET testing
+)
+rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/tests/to_verify/)
+
+add_custom_target(install_testing_component ALL
+  COMMAND ${CMAKE_COMMAND} --install "${CMAKE_CURRENT_BINARY_DIR}" --component testing --prefix install/
+  COMMAND ctest --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
+  )
+add_dependencies(install_testing_component verify_)

--- a/testing/test/install_relocatable-installed-tests-run/CMakeLists.txt
+++ b/testing/test/install_relocatable-installed-tests-run/CMakeLists.txt
@@ -34,6 +34,6 @@ rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing DESTINATION bin/te
 
 add_custom_target(install_testing_component ALL
   COMMAND ${CMAKE_COMMAND} --install "${CMAKE_CURRENT_BINARY_DIR}" --component testing --prefix install/
-  COMMAND ctest --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
+  COMMAND ${CMAKE_CTEST_COMMAND} --test-dir install/bin/tests/to_verify/ --output-on-failure --no-tests=error
   )
 add_dependencies(install_testing_component verify_)

--- a/testing/test/install_relocatable-installed-tests-run/main.cu
+++ b/testing/test/install_relocatable-installed-tests-run/main.cu
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int main() { return 0; }


### PR DESCRIPTION
## Description
Corrects an issue where the modes of `CMAKE_INSTALL_MESSAGE` would alter the install rules generated by CMake in such a way that it would subtly break `rapids_test_install_relocatable`. 

This is problematic as this breakage is silent to users / developers and only apparent when trying to run the generated installed test package.

Fixes #https://github.com/rapidsai/rapids-cmake/issues/603

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
