### PR TITLE
Set default value for PARALLEL_LEVEL to nproc

### DIFF
--- a/conda/recipes/rapids_core_dependencies/build.sh
+++ b/conda/recipes/rapids_core_dependencies/build.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 # Script assumes the script is executed from the root of the repo directory
 

--- a/conda/recipes/rapids_core_dependencies/build.sh
+++ b/conda/recipes/rapids_core_dependencies/build.sh
@@ -8,7 +8,7 @@ SOURCE_DIR=${REPO_DIR}/conda/recipes/rapids_core_dependencies
 BUILD_DIR=${BUILD_DIR:=${REPO_DIR}/build}
 
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$BUILD_DIR/install}}}
-export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 # If the dir to clean is a mounted dir in a container, the
 # contents should be removed but the mounted dirs will remain.

--- a/conda/recipes/rapids_core_dependencies/build.sh
+++ b/conda/recipes/rapids_core_dependencies/build.sh
@@ -8,7 +8,7 @@ SOURCE_DIR=${REPO_DIR}/conda/recipes/rapids_core_dependencies
 BUILD_DIR=${BUILD_DIR:=${REPO_DIR}/build}
 
 INSTALL_PREFIX=${INSTALL_PREFIX:=${PREFIX:=${CONDA_PREFIX:=$BUILD_DIR/install}}}
-export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
+export PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc --all)}
 
 # If the dir to clean is a mounted dir in a container, the
 # contents should be removed but the mounted dirs will remain.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The `PARALLEL_LEVEL` variable is used in CI to set parallel level while building. Currently this variable is set on the GHA runners to `nproc`, but as this is a RAPIDS specific variable, this variable will soon be removed from the runners, so RAPIDS projects must explicitly set this variable to `nproc`. This PR is setting the default value of `PARALLEL_LEVEL` to `nproc` to match what is done by other RAPIDS projects

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
