### PR TITLE
Always offer the install target names for nvtx3

### DIFF
--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -114,6 +114,13 @@ function(rapids_cpm_nvtx3)
     endif()
   endif()
 
+  if(NOT TARGET nvtx::nvtx3-c AND TARGET nvtx3-c)
+    add_library(nvtx::nvtx3-c ALIAS nvtx3-c)
+  endif()
+  if(NOT TARGET nvtx::nvtx3-cpp AND TARGET nvtx3-cpp)
+    add_library(nvtx::nvtx3-cpp ALIAS nvtx3-cpp)
+  endif()
+
   # Propagate up variables that CPMFindPackage provide
   set(nvtx3_SOURCE_DIR "${nvtx3_SOURCE_DIR}" PARENT_SCOPE)
   set(nvtx3_BINARY_DIR "${nvtx3_BINARY_DIR}" PARENT_SCOPE)

--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -89,7 +89,7 @@ function(rapids_cpm_nvtx3)
   rapids_cmake_parse_version(MAJOR ${version} ${version})
 
   # Set up install rules Need to be re-entrant safe so only call when `nvtx3_ADDED`
-  if(nvtx3_ADDED)
+  if(nvtx3_ADDED AND TARGET nvtx3-c)
     install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets)
     if(_RAPIDS_BUILD_EXPORT_SET)
       include("${rapids-cmake-dir}/export/export.cmake")
@@ -97,7 +97,7 @@ function(rapids_cpm_nvtx3)
                     VERSION ${version}
                     EXPORT_SET nvtx3-targets
                     GLOBAL_TARGETS nvtx3-c nvtx3-cpp
-                    NAMESPACE nvtx::)
+                    NAMESPACE nvtx3::)
       include("${rapids-cmake-dir}/export/find_package_root.cmake")
       rapids_export_find_package_root(BUILD nvtx3 [=[${CMAKE_CURRENT_LIST_DIR}]=]
                                       EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET})
@@ -110,15 +110,15 @@ function(rapids_cpm_nvtx3)
                     VERSION ${version}
                     EXPORT_SET nvtx3-targets
                     GLOBAL_TARGETS nvtx3-c nvtx3-cpp
-                    NAMESPACE nvtx::)
+                    NAMESPACE nvtx3::)
     endif()
   endif()
 
-  if(NOT TARGET nvtx::nvtx3-c AND TARGET nvtx3-c)
-    add_library(nvtx::nvtx3-c ALIAS nvtx3-c)
+  if(NOT TARGET nvtx3::nvtx3-c AND TARGET nvtx3-c)
+    add_library(nvtx3::nvtx3-c ALIAS nvtx3-c)
   endif()
-  if(NOT TARGET nvtx::nvtx3-cpp AND TARGET nvtx3-cpp)
-    add_library(nvtx::nvtx3-cpp ALIAS nvtx3-cpp)
+  if(NOT TARGET nvtx3::nvtx3-cpp AND TARGET nvtx3-cpp)
+    add_library(nvtx3::nvtx3-cpp ALIAS nvtx3-cpp)
   endif()
 
   # Propagate up variables that CPMFindPackage provide

--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -38,7 +38,7 @@ across all RAPIDS projects.
 
 Result Targets
 ^^^^^^^^^^^^^^
-  nvtx3-c, nvtx3-cpp targets will be created
+  nvtx3::nvtx3-c, nvtx3::nvtx3-cpp targets will be created
 
 Result Variables
 ^^^^^^^^^^^^^^^^

--- a/testing/cpm/cpm_nvtx-build-config-works.cmake
+++ b/testing/cpm/cpm_nvtx-build-config-works.cmake
@@ -30,7 +30,7 @@ find_package(nvtx3 REQUIRED)
 
 file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/stub.cpp\" \" \")
 add_library(uses_nvtx SHARED stub.cpp)
-target_link_libraries(uses_nvtx PRIVATE nvtx::nvtx3-cpp)
+target_link_libraries(uses_nvtx PRIVATE nvtx3::nvtx3-cpp)
 ")
 
 add_custom_target(verify_build_config ALL

--- a/testing/cpm/cpm_nvtx-install-config-works.cmake
+++ b/testing/cpm/cpm_nvtx-install-config-works.cmake
@@ -30,7 +30,7 @@ find_package(nvtx3 REQUIRED)
 
 file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/stub.cpp\" \" \")
 add_library(uses_nvtx SHARED stub.cpp)
-target_link_libraries(uses_nvtx PRIVATE nvtx::nvtx3-cpp)
+target_link_libraries(uses_nvtx PRIVATE nvtx3::nvtx3-cpp)
 ")
 
 add_custom_target(verify_build_config ALL

--- a/testing/cpm/cpm_nvtx-simple.cmake
+++ b/testing/cpm/cpm_nvtx-simple.cmake
@@ -36,4 +36,12 @@ if(NOT TARGET nvtx3-cpp)
   message(FATAL_ERROR "Expected nvtx3-cpp target to exist")
 endif()
 
+if(NOT TARGET nvtx3::nvtx3-c)
+  message(FATAL_ERROR "Expected nvtx3::nvtx3-c target to exist")
+endif()
+
+if(NOT TARGET nvtx3::nvtx3-cpp)
+  message(FATAL_ERROR "Expected nvtx3::nvtx3-cpp target to exist")
+endif()
+
 rapids_cpm_nvtx3()


### PR DESCRIPTION
## Description
This is required so that consumers of `nvtx3` can safely use `nvtx3::nvtx3-cpp` consistently no matter if they are using nvtx3 from source or an installed version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
