### PR TITLE
Only output CUDA architectures we are building for once

### DIFF
--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
   if(EXISTS "${eval_exe}")
     execute_process(COMMAND "${eval_exe}" OUTPUT_VARIABLE __gpu_archs
                     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_FILE "${error_file}")
-    message(STATUS "Auto detection of gpu-archs: ${__gpu_archs}")
+    message(STATUS "Using auto detection of gpu-archs: ${__gpu_archs}")
   else()
     message(STATUS "Failed auto detection of gpu-archs. Falling back to using ${__gpu_archs}.")
   endif()

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -79,9 +79,11 @@ function(rapids_cuda_set_architectures mode)
     list(TRANSFORM CMAKE_CUDA_ARCHITECTURES APPEND "-real")
   endif()
 
-  string(REPLACE ";" "\n  " _cuda_architectures_pretty "${CMAKE_CUDA_ARCHITECTURES}")
-  message(STATUS "${CMAKE_PROJECT_NAME} CUDA architectures building for:\n  ${_cuda_architectures_pretty}"
-  )
+  if(PROJECT_IS_TOP_LEVEL)
+    string(REPLACE ";" "\n  " _cuda_architectures_pretty "${CMAKE_CUDA_ARCHITECTURES}")
+    message(STATUS "${CMAKE_PROJECT_NAME} CUDA architectures building for:\n  ${_cuda_architectures_pretty}"
+    )
+  endif()
   set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} PARENT_SCOPE)
 
 endfunction()

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -79,11 +79,17 @@ function(rapids_cuda_set_architectures mode)
     list(TRANSFORM CMAKE_CUDA_ARCHITECTURES APPEND "-real")
   endif()
 
-  if(PROJECT_IS_TOP_LEVEL)
+  # cache the cuda archs.
+  get_property(cached_value GLOBAL PROPERTY rapids_cuda_architectures)
+  if(NOT cached_value)
+    set_property(GLOBAL PROPERTY rapids_cuda_architectures "${CMAKE_CUDA_ARCHITECTURES}")
+  endif()
+  if(NOT cached_value STREQUAL CMAKE_CUDA_ARCHITECTURES)
     string(REPLACE ";" "\n  " _cuda_architectures_pretty "${CMAKE_CUDA_ARCHITECTURES}")
-    message(STATUS "${CMAKE_PROJECT_NAME} CUDA architectures building for:\n  ${_cuda_architectures_pretty}"
+    message(STATUS "Project ${PROJECT_NAME} is building for CUDA architectures:\n  ${_cuda_architectures_pretty}"
     )
   endif()
+
   set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
## Description
When multiple projects inside the root level all use rapids-cmake we would previously output the CUDA architectures which would all have the same values.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
