### PR TITLE
Adopt CI/packaging codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,10 +3,14 @@
 **/CMakeLists.txt     @rapidsai/rapids-cmake-codeowners
 *.cmake               @rapidsai/rapids-cmake-codeowners
 
-#build/ops code owners
-.github/              @rapidsai/ops-codeowners
-ci/                   @rapidsai/ops-codeowners
-conda/                @rapidsai/ops-codeowners
-**/Dockerfile         @rapidsai/ops-codeowners
-**/.dockerignore      @rapidsai/ops-codeowners
-docker/               @rapidsai/ops-codeowners
+#CI code owners
+/.github/                @rapidsai/ci-codeowners
+/ci/                     @rapidsai/ci-codeowners
+/.pre-commit-config.yaml @rapidsai/ci-codeowners
+
+#packaging code owners
+/.devcontainer/    @rapidsai/packaging-codeowners
+/conda/            @rapidsai/packaging-codeowners
+/dependencies.yaml @rapidsai/packaging-codeowners
+/build.sh          @rapidsai/packaging-codeowners
+pyproject.toml     @rapidsai/packaging-codeowners


### PR DESCRIPTION
## Description
This PR overhauls how `ops-codeowners` reviews are handled.

`ops-codeowners` is replaced by `ci-codeowners` & `packaging-codeowners`. The coverage of files is expanded as well.

Additionally, the process will change: reviews will be assigned to a member of the teams instead of a manual request to `ops-codeowners`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
