### PR TITLE
rapids_cmake_support_conda_env adds `-O0` to debug compile lines

### DIFF
--- a/rapids-cmake/cmake/support_conda_env.cmake
+++ b/rapids-cmake/cmake/support_conda_env.cmake
@@ -21,20 +21,25 @@ rapids_cmake_support_conda_env
 
 .. versionadded:: v21.06.00
 
-Establish a target that holds the CONDA include and link directories.
+Establish a target that holds the necessary compile and link information
+to properly support building in CONDA envs.
 
   .. code-block:: cmake
 
     rapids_cmake_support_conda_env( <target_name> [MODIFY_PREFIX_PATH] )
 
 Creates a global interface target called `target_name` that holds
-the CONDA include and link directories, when executed.
+the CONDA compile options, include directories, and link directories when executed.
 
 .. versionadded:: v24.06.00
 
 The include directories that `target_name` holds will be `-isystem` to match
 the behavior of conda when it builds projects.
 
+.. versionadded:: v24.08.00
+
+The `target_name` target will add the required compile flags to ensure debug builds
+are generated with `-O0` instead of the conda env default of `-O2`.
 
 Also offers the ability to modify :cmake:variable:`CMAKE_PREFIX_PATH <cmake:variable:CMAKE_PREFIX_PATH>` to
 include the following paths based on the current conda environment:
@@ -182,5 +187,10 @@ function(rapids_cmake_support_conda_env target)
         modify_cmake_prefix_path(PATHS "$ENV{CONDA_PREFIX}")
       endif()
     endif()
+
+    # The conda env will have setup `CXXFLAGS`, etc to contain `-O2` which we need to override to
+    # get proper debug information for local variables, etc. Since `target_compile_options` values
+    # are appended after `CXXFLAGS` we know that this will properly override the conda `-O2`
+    target_compile_options(${target} INTERFACE "$<$<CONFIG:Debug>:-O0>")
   endif()
 endfunction()

--- a/testing/cmake/conda_env-build.cmake
+++ b/testing/cmake/conda_env-build.cmake
@@ -26,6 +26,11 @@ if(NOT TARGET conda_env)
   message(FATAL_ERROR "Expected target conda_env to exist")
 endif()
 
+get_target_property(compile_options conda_env INTERFACE_COMPILE_OPTIONS)
+if( NOT "$<$<CONFIG:Debug>:-O0>" IN_LIST compile_options)
+  message(FATAL_ERROR "Expected $<$<CONFIG:Debug>>:-O0> to be in the compile options of `conda_env`")
+endif()
+
 get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( NOT "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)
   message(FATAL_ERROR "Expected env{BUILD_PREFIX} to be in the include dirs of `conda_env`")

--- a/testing/cmake/conda_env-prefix.cmake
+++ b/testing/cmake/conda_env-prefix.cmake
@@ -21,6 +21,14 @@ set(ENV{PREFIX} "/opt/local/prefix")
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix")
 
 rapids_cmake_support_conda_env(conda_env)
+if(NOT TARGET conda_env)
+  message(FATAL_ERROR "Expected target conda_env to exist")
+endif()
+
+get_target_property(compile_options conda_env INTERFACE_COMPILE_OPTIONS)
+if( NOT "$<$<CONFIG:Debug>:-O0>" IN_LIST compile_options)
+  message(FATAL_ERROR "Expected $<$<CONFIG:Debug>>:-O0> to be in the compile options of `conda_env`")
+endif()
 
 get_target_property(include_dirs conda_env INTERFACE_SYSTEM_INCLUDE_DIRECTORIES)
 if( "$ENV{BUILD_PREFIX}/include" IN_LIST include_dirs)


### PR DESCRIPTION
## Description
When building in a conda env the default CXXFLAGS, CFLAGS, etc will inject -O2 on the compile line making Debug bugs significantly less useful. `rapids_cmake_support_conda_env` now injects a `-O0` to override the `-O2` set by conda to make debug builds usable.

Fixes #634

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
