### PR TITLE
rapids_test_install_relocatable now handles SOVERSION target properties

### DIFF
--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -195,8 +195,8 @@ function(extract_install_info)
   set(multi_value FILES)
   cmake_parse_arguments(_RAPIDS_TEST "${options}" "${one_value}" "${multi_value}"
                         ${install_contents})
-  if(_RAPIDS_TEST_TYPE STREQUAL "EXECUTABLE " OR _RAPIDS_TEST_TYPE STREQUAL "SHARED_LIBRARY"
-     OR _RAPIDS_TEST_TYPE STREQUAL "STATIC_LIBRARY " OR _RAPIDS_TEST_TYPE STREQUAL "OBJECT_LIBRARY")
+  if(_RAPIDS_TEST_TYPE STREQUAL "EXECUTABLE" OR _RAPIDS_TEST_TYPE STREQUAL "SHARED_LIBRARY"
+     OR _RAPIDS_TEST_TYPE STREQUAL "STATIC_LIBRARY" OR _RAPIDS_TEST_TYPE STREQUAL "OBJECT_LIBRARY")
     foreach(build_loc IN LISTS _RAPIDS_TEST_FILES)
       cmake_path(GET build_loc FILENAME name)
       set_property(GLOBAL PROPERTY ${name}_install ${_RAPIDS_TEST_DESTINATION})

--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -184,13 +184,17 @@ endfunction()
 # =============================================================================
 # ============== Parse Install Location Functions         ====================
 # =============================================================================
-function(extract_install_info)
+function(extract_install_info line)
+  # remove the trailing `)` so that it doesn't get parsed as part of the file name
+  string(REGEX REPLACE "\\)$" "" line "${line}")
+  string(APPEND command_contents "${line}")
+
   # Leverate separate_arguments to parse a space-separated string into a list of items We use
   # `UNIX_COMMAND` as that means args are separated by unquoted whitespace ( single, and double
   # supported).
-  separate_arguments(install_contents UNIX_COMMAND ${ARGN})
+  separate_arguments(install_contents UNIX_COMMAND ${line})
 
-  set(options "file(INSTALL" ")")
+  set(options "file(INSTALL")
   set(one_value DESTINATION TYPE)
   set(multi_value FILES)
   cmake_parse_arguments(_RAPIDS_TEST "${options}" "${one_value}" "${multi_value}"
@@ -224,7 +228,7 @@ function(determine_install_location_of_all_targets)
         # Continue to add the lines of `file(INSTALL` till we hit the closing `)` That allows us to
         # support multiple line file commands
         string(APPEND command_contents "${line}")
-        if(line MATCHES "\\)")
+        if(line MATCHES "\\)$")
           # We have all the lines for this file command, now parse it
           extract_install_info(${command_contents})
 

--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -184,15 +184,14 @@ endfunction()
 # =============================================================================
 # ============== Parse Install Location Functions         ====================
 # =============================================================================
-function(extract_install_info line)
+function(extract_install_info)
   # remove the trailing `)` so that it doesn't get parsed as part of the file name
-  string(REGEX REPLACE "\\)$" "" line "${line}")
-  string(APPEND command_contents "${line}")
+  string(REGEX REPLACE "\\)$" "" line "${ARGN}")
 
   # Leverate separate_arguments to parse a space-separated string into a list of items We use
   # `UNIX_COMMAND` as that means args are separated by unquoted whitespace ( single, and double
   # supported).
-  separate_arguments(install_contents UNIX_COMMAND ${line})
+  separate_arguments(install_contents UNIX_COMMAND "${line}")
 
   set(options "file(INSTALL")
   set(one_value DESTINATION TYPE)

--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -184,20 +184,19 @@ endfunction()
 # =============================================================================
 # ============== Parse Install Location Functions         ====================
 # =============================================================================
-function(extract_install_info )
-  # Leverate separate_arguments to parse a space-separated string into a list of items
-  # We use `UNIX_COMMAND` as that means args are separated by unquoted whitespace ( single, and double supported).
+function(extract_install_info)
+  # Leverate separate_arguments to parse a space-separated string into a list of items We use
+  # `UNIX_COMMAND` as that means args are separated by unquoted whitespace ( single, and double
+  # supported).
   separate_arguments(install_contents UNIX_COMMAND ${ARGN})
 
   set(options "file(INSTALL" ")")
   set(one_value DESTINATION TYPE)
   set(multi_value FILES)
-  cmake_parse_arguments(_RAPIDS_TEST "${options}" "${one_value}"
-                        "${multi_value}" ${install_contents})
-  if( _RAPIDS_TEST_TYPE STREQUAL "EXECUTABLE " OR
-      _RAPIDS_TEST_TYPE STREQUAL "SHARED_LIBRARY" OR
-      _RAPIDS_TEST_TYPE STREQUAL "STATIC_LIBRARY " OR
-      _RAPIDS_TEST_TYPE STREQUAL "OBJECT_LIBRARY")
+  cmake_parse_arguments(_RAPIDS_TEST "${options}" "${one_value}" "${multi_value}"
+                        ${install_contents})
+  if(_RAPIDS_TEST_TYPE STREQUAL "EXECUTABLE " OR _RAPIDS_TEST_TYPE STREQUAL "SHARED_LIBRARY"
+     OR _RAPIDS_TEST_TYPE STREQUAL "STATIC_LIBRARY " OR _RAPIDS_TEST_TYPE STREQUAL "OBJECT_LIBRARY")
     foreach(build_loc IN LISTS _RAPIDS_TEST_FILES)
       cmake_path(GET build_loc FILENAME name)
       set_property(GLOBAL PROPERTY ${name}_install ${_RAPIDS_TEST_DESTINATION})
@@ -214,7 +213,7 @@ function(determine_install_location_of_all_targets)
     file(STRINGS "${file}" contents)
 
     set(parsing_file_command FALSE)
-    set(file_command_contents )
+    set(file_command_contents)
     foreach(line IN LISTS contents)
       if(line MATCHES "INSTALL DESTINATION")
         # We found the first line of `file(INSTALL`
@@ -222,8 +221,8 @@ function(determine_install_location_of_all_targets)
       endif()
 
       if(parsing_file_command)
-        # Continue to add the lines of `file(INSTALL` till we hit the closing `)`
-        # That allows us to support multiple line file commands
+        # Continue to add the lines of `file(INSTALL` till we hit the closing `)` That allows us to
+        # support multiple line file commands
         string(APPEND command_contents "${line}")
         if(line MATCHES "\\)")
           # We have all the lines for this file command, now parse it

--- a/testing/test/install_relocatable-complex/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/CMakeLists.txt
@@ -20,6 +20,12 @@ project(rapids-test-project LANGUAGES CUDA)
 include(${rapids-cmake-dir}/rapids-test.cmake)
 
 add_library(preload SHARED usage.cu)
+
+# Setup a VERSION and SOVERSION so we generate a multi-line file(INSTALL command
+set_target_properties(preload PROPERTIES
+  VERSION 1.1.1
+  SOVERSION 1
+  )
 add_subdirectory(tests)
 
 install(TARGETS preload DESTINATION lib)

--- a/testing/test/install_relocatable-complex/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/test/install_relocatable-complex/tests/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/tests/CMakeLists.txt
@@ -44,7 +44,7 @@ if(is_found EQUAL -1)
 endif()
 
 set(properties_match_strings [===[PROPERTIES ENVIRONMENT "STREAM_MODE]===]
-                             [===[LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libpreload]===])
+                             [===[LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/lib/libpreload.so.1.1.1]===])
 foreach(to_match IN LISTS properties_match_strings)
   string(FIND "${contents}" ${to_match} is_found)
   if(is_found EQUAL -1)


### PR DESCRIPTION
## Description
Previously the `rapids_test_install_relocatable` would presume the `file(INSTALL` command would always be a single line.
But cmake generates a multi line entry when doing the SOVERSION symlinks, and rapids-cmake would crash when encountering them.

Now the  `determine_install_location_of_all_targets` internal function does proper parsing to extract the `file(INSTALL` commands so we can support multi-line entries.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
