### PR TITLE
Fix CPM package docs.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,10 @@
-
 #cmake code owners
 **/CMakeLists.txt     @rapidsai/rapids-cmake-codeowners
 *.cmake               @rapidsai/rapids-cmake-codeowners
+/docs/                @rapidsai/rapids-cmake-codeowners
+/example/             @rapidsai/rapids-cmake-codeowners
+/rapids-cmake/        @rapidsai/rapids-cmake-codeowners
+/testing/             @rapidsai/rapids-cmake-codeowners
 
 #CI code owners
 /.github/                @rapidsai/ci-codeowners

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,9 +46,9 @@ RAPIDS dependencies.
 
 These allow projects to make sure they use the same version and flags for
 dependencies as the rest of RAPIDS. The exact versions that each pre-configured
-package uses :ref:`can be found here. <cpm_versions>`
+package uses :ref:`can be found here <cpm_versions>`.
 
-.. literalinclude:: /packages/packages.rst
+.. include:: /packages/packages.rst
 
 .. _`cython`:
 

--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -11,7 +11,7 @@ rapids-cmake provides a collection of pre-defined packages to ensure that all co
 the same version of dependencies. The exact versions that each pre-configured package uses
 can be found at the bottom of the page.
 
-.. literalinclude:: /packages/packages.rst
+.. include:: /packages/packages.rst
 
 rapids-cmake package override
 #############################

--- a/docs/packages/packages.rst
+++ b/docs/packages/packages.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
## Description
Fixes the documentation to list CPM packages.

I also updated the codeowners to request reviews on docs, examples, all of `rapids-cmake/`, and testing code.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
