### PR TITLE
Fix rendering of CPM packages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,7 +48,7 @@ These allow projects to make sure they use the same version and flags for
 dependencies as the rest of RAPIDS. The exact versions that each pre-configured
 package uses :ref:`can be found here. <cpm_versions>`
 
-.. literalinclude:: /packages/packages.rst
+.. include:: /packages/packages.rst
 
 .. _`cython`:
 

--- a/docs/packages/packages.rst
+++ b/docs/packages/packages.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Switches to the appropriate Sphinx directives for the desired rendering.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
