### PR TITLE
Set CUDA_RUNTIME_LIBRARY to documented case style

### DIFF
--- a/rapids-cmake/cuda/set_runtime.cmake
+++ b/rapids-cmake/cuda/set_runtime.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,10 +62,10 @@ function(rapids_cuda_set_runtime target use_static value)
   endif()
 
   if(${value})
-    set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)
+    set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY Static)
     target_link_libraries(${target} ${mode} $<TARGET_NAME_IF_EXISTS:CUDA::cudart_static>)
   else()
-    set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY SHARED)
+    set_target_properties(${target} PROPERTIES CUDA_RUNTIME_LIBRARY Shared)
     target_link_libraries(${target} ${mode} $<TARGET_NAME_IF_EXISTS:CUDA::cudart>)
   endif()
 

--- a/testing/cuda/set_runtime-shared.cmake
+++ b/testing/cuda/set_runtime-shared.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,11 +21,11 @@ rapids_cuda_set_runtime(uses_cuda USE_STATIC FALSE)
 
 
 get_target_property(runtime_state uses_cuda CUDA_RUNTIME_LIBRARY)
-if( NOT runtime_state STREQUAL "SHARED")
+if( NOT runtime_state STREQUAL "Shared")
   message(FATAL_ERROR "rapids_cuda_set_runtime didn't correctly set CUDA_RUNTIME_LIBRARY")
 endif()
 
 get_target_property(linked_libs uses_cuda LINK_LIBRARIES)
 if(NOT "$<TARGET_NAME_IF_EXISTS:CUDA::cudart>" IN_LIST linked_libs)
-  message(FATAL_ERROR "rapids_cuda_set_runtime didn't privately link to CUDA::cudart_static")
+  message(FATAL_ERROR "rapids_cuda_set_runtime didn't privately link to CUDA::cudart")
 endif()

--- a/testing/cuda/set_runtime-static.cmake
+++ b/testing/cuda/set_runtime-static.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ add_library(uses_cuda SHARED ${CMAKE_CURRENT_BINARY_DIR}/empty.cpp)
 rapids_cuda_set_runtime(uses_cuda USE_STATIC TRUE)
 
 get_target_property(runtime_state uses_cuda CUDA_RUNTIME_LIBRARY)
-if( NOT runtime_state STREQUAL "STATIC")
+if( NOT runtime_state STREQUAL "Static")
   message(FATAL_ERROR "rapids_cuda_set_runtime didn't correctly set CUDA_RUNTIME_LIBRARY")
 endif()
 


### PR DESCRIPTION
CMake documentation lists "Shared" and "Static", not "SHARED" and "STATIC". Set the value with the documented casing.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
