### PR TITLE
Update to CPM v0.40.0

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,8 +42,8 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.38.5)
-  set(CPM_DOWNLOAD_MD5_HASH c98d14a13dfd1952e115979c095f6794)
+  set(CPM_DOWNLOAD_VERSION 0.40.0)
+  set(CPM_DOWNLOAD_MD5_HASH 7b354f3a5976c4626c876850c93944e5)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -43,7 +43,7 @@ function(rapids_cpm_download)
 
   # When changing version verify no new variables needs to be propagated
   set(CPM_DOWNLOAD_VERSION 0.40.0)
-  set(CPM_DOWNLOAD_MD5_HASH 7b354f3a5976c4626c876850c93944e5)
+  set(CPM_DOWNLOAD_MD5_HASH 6c9866a0aa0f804a36fe8c3866fb8a2c)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Update to latest CPM version. While this doesn't fix cmake deprecation warnings, it does give us latest CPM bug fixes

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
