### PR TITLE
use latest cuco with insert_or_apply CAS fix

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "git_shallow": false,
       "always_download": true,
       "git_url": "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag": "e7b5a389b823bebe465cefe63ad7b0e95f7fb450"
+      "git_tag": "ee5c10456c7ad584c254152411ba3dc114537a6f"
     },
     "fmt": {
       "version": "10.1.1",


### PR DESCRIPTION
This PR fetches latest **cuco** with a fix in `insert_or_apply` for **static_map** that solves CAS bug when `value_type size > 8`.
This PR just has one commit update and it is **non-breaking**, as this is a new feature and not used anywhere else. 