### PR TITLE
proprietary_binary_cuda_version_mapping allows for better CUDA version mapping

### DIFF
--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -251,10 +251,24 @@ as needed.
         - ``${version}`` will be evaluated to the contents of the ``version`` field.
         - ``${cuda-toolkit-version}`` will be evaluated to 'major.minor' of the current CUDA Toolkit version.
         - ``${cuda-toolkit-version-major}`` will be evaluated to 'major' of the current CUDA Toolkit version.
+        - ``${cuda-toolkit-version-mapping}`` will be evaluated to the contents of the json `cuda_version_mapping` entry
+          of the current CUDA Toolkit major version value
         - ``$ENV{variable}`` will be evaluated to the contents of the listed environment variable
 
     If this field exists in the default package, the value will be ignored when an override file
     entry exists for the package. This ensures that the git url or `proprietary_binary` entry in the override will be used.
+
+``proprietary_binary_cuda_version_mapping``
+
+    An optional dictionary of CUDA major version keys to arbitrary values that are needed to compute download urls for a pre-built proprietary binaries
+    in the ``proprietary_binary`` dictionary
+
+    .. literalinclude:: /packages/cuda_version_mapping.json
+        :language: json
+
+    As this represents meta information needed by the proprietary binary dictionary only the following packages support this entry:
+        - nvcomp
+
 
 rapids-cmake package versions
 #############################

--- a/docs/packages/cuda_version_mapping.json
+++ b/docs/packages/cuda_version_mapping.json
@@ -1,0 +1,10 @@
+{
+  "proprietary_binary_cuda_version_mapping": {
+    "11": "11.8",
+    "12": "12.3"
+  },
+  "proprietary_binary": {
+    "aarch64-linux": "<url>/binary_${cuda-toolkit-version-mapping}.tar.gz",
+    "x86_64-linux": "<url>/binary_${cuda-toolkit-version-mapping}.tar.gz"
+  }
+}

--- a/rapids-cmake/cpm/detail/get_proprietary_binary_url.cmake
+++ b/rapids-cmake/cpm/detail/get_proprietary_binary_url.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,15 @@ function(rapids_cpm_get_proprietary_binary_url package_name version url_var)
     find_package(CUDAToolkit REQUIRED)
     set(cuda-toolkit-version ${CUDAToolkit_VERSION_MAJOR}.${CUDAToolkit_VERSION_MINOR})
     set(cuda-toolkit-version-major ${CUDAToolkit_VERSION_MAJOR})
+
+    # See if we have a CUDA Toolkit version mapping entry and load it as needed
+    string(JSON cuda-toolkit-version-mapping ERROR_VARIABLE have_error_mapping GET
+           "${override_json_data}" "proprietary_binary_cuda_version_mapping"
+           "${cuda-toolkit-version-major}")
+    if(have_error_mapping)
+      string(JSON cuda-toolkit-version-mapping ERROR_VARIABLE have_error_mapping GET "${json_data}"
+             "proprietary_binary_cuda_version_mapping" "${cuda-toolkit-version-major}")
+    endif()
   endif()
 
   # Evaluate any magic placeholders in the proprietary_binary value including the

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -72,9 +72,13 @@
       "version": "3.0.6",
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
       "git_tag": "v2.2.0",
+      "proprietary_binary_cuda_version_mapping": {
+        "11": "11.x",
+        "12": "12.x"
+      },
       "proprietary_binary": {
-        "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
-        "aarch64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"
+        "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-mapping}.tgz",
+        "aarch64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-mapping}.tgz"
       }
     },
     "nvtx3": {


### PR DESCRIPTION
## Description
Allows us to support download urls that have unique mappings per CUDA major version

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.