### PR TITLE
Add rapids_cpm_nvtx3 to cmake-format-rapids-cmake.json

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -183,6 +183,16 @@
           "USE_PROPRIETARY_BINARY": 1
         }
       },
+      "rapids_cpm_nvtx3": {
+        "pargs": {
+          "nargs": 0
+        },
+        "kwargs": {
+          "BUILD_EXPORT_SET": 1,
+          "INSTALL_EXPORT_SET": 1,
+          "USE_PROPRIETARY_BINARY": 1
+        }
+      },
       "rapids_cpm_rmm": {
         "pargs": {
           "nargs": 0

--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -189,8 +189,7 @@
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
-          "INSTALL_EXPORT_SET": 1,
-          "USE_PROPRIETARY_BINARY": 1
+          "INSTALL_EXPORT_SET": 1
         }
       },
       "rapids_cpm_rmm": {

--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -52,7 +52,7 @@ function(rapids_cpm_nvtx3)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.nvtx3")
 
   set(options)
-  set(one_value USE_PROPRIETARY_BINARY BUILD_EXPORT_SET INSTALL_EXPORT_SET)
+  set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 


### PR DESCRIPTION
## Description
Noticed while working on https://github.com/rapidsai/rapids-cmake/pull/651.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
