### PR TITLE
Pass `GLOBAL_TARGETS` to `rapids_cpm_find()` in `rapids_cpm_bs_thread_pool()`

### DIFF
--- a/rapids-cmake/cpm/bs_thread_pool.cmake
+++ b/rapids-cmake/cpm/bs_thread_pool.cmake
@@ -71,6 +71,7 @@ function(rapids_cpm_bs_thread_pool)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(bs_thread_pool ${version} ${ARGN}
+                  GLOBAL_TARGETS rapids_bs_thread_pool
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}

--- a/testing/cpm/cpm_bs_thread_pool-simple.cmake
+++ b/testing/cpm/cpm_bs_thread_pool-simple.cmake
@@ -32,3 +32,6 @@ if(NOT TARGET BS::thread_pool)
 endif()
 
 rapids_cpm_bs_thread_pool()
+
+include(${rapids-cmake-dir}/cpm/generate_pinned_versions.cmake)
+rapids_cpm_generate_pinned_versions(OUTPUT ${CMAKE_BINARY_DIR}/versions.json)


### PR DESCRIPTION
Because the `GLOBAL_TARGETS` option was not being passed, `rapids_cpm_bs_thread_pool()` was accidentally calling `CPMAddPackage()` twice for `bs_thread_pool`, resulting in invalid pinned versions output. Pass `GLOBAL_TARGETS` to ensure `CPMAddPackage()` is only called once.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
