### PR TITLE
Use `CMAKE_CUDA_ARCHITECTURES` value when ENV{CUDAARCHS} is set

### DIFF
--- a/rapids-cmake/cuda/init_architectures.cmake
+++ b/rapids-cmake/cuda/init_architectures.cmake
@@ -72,8 +72,11 @@ function(rapids_cuda_init_architectures project_name)
   # If `CMAKE_CUDA_ARCHITECTURES` is not defined, build for all supported architectures. If
   # `CMAKE_CUDA_ARCHITECTURES` is set to an empty string (""), build for only the current
   # architecture. If `CMAKE_CUDA_ARCHITECTURES` is specified by the user, use user setting.
-  if(CMAKE_CUDA_ARCHITECTURES STREQUAL "RAPIDS" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
-    set(cuda_arch_mode "${CMAKE_CUDA_ARCHITECTURES}")
+  if(DEFINED CMAKE_CUDA_ARCHITECTURES)
+    # Don't ever look at `ENV{CUDAARCHS}` if a `CMAKE_CUDA_ARCHITECTURES` has been specified
+    if(CMAKE_CUDA_ARCHITECTURES STREQUAL "RAPIDS" OR CMAKE_CUDA_ARCHITECTURES STREQUAL "NATIVE")
+      set(cuda_arch_mode "${CMAKE_CUDA_ARCHITECTURES}")
+    endif()
   elseif(DEFINED ENV{CUDAARCHS} AND ("$ENV{CUDAARCHS}" STREQUAL "RAPIDS" OR "$ENV{CUDAARCHS}"
                                                                             STREQUAL "NATIVE"))
     set(cuda_arch_mode "$ENV{CUDAARCHS}")

--- a/testing/cuda/CMakeLists.txt
+++ b/testing/cuda/CMakeLists.txt
@@ -32,6 +32,7 @@ add_cmake_config_test( init_arch-rapids.cmake )
 add_cmake_config_test( init_arch-rapids-via-env.cmake )
 add_cmake_config_test( init_arch-user.cmake )
 add_cmake_config_test( init_arch-user-via-env.cmake )
+add_cmake_config_test( init_arch-user-over-env.cmake )
 add_cmake_config_test( init_arch-var-over-env.cmake )
 
 add_cmake_config_test( patch_toolkit.cmake )

--- a/testing/cuda/init_arch-user-over-env.cmake
+++ b/testing/cuda/init_arch-user-over-env.cmake
@@ -1,0 +1,32 @@
+#=============================================================================
+# Copyright (c) 2024, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cuda/init_architectures.cmake)
+
+cmake_minimum_required(VERSION 3.23.1)
+
+set(CMAKE_CUDA_ARCHITECTURES 80-real)
+set(ENV{CUDAARCHS} "9000")
+
+rapids_cuda_init_architectures(rapids-project)
+project(rapids-project LANGUAGES CUDA)
+
+if(CMAKE_CUDA_ARCHITECTURES STREQUAL "9000")
+  message(FATAL_ERROR "rapids_cuda_init_architectures didn't init CUDA_ARCHITECTURES")
+endif()
+
+if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "80-real")
+  message(FATAL_ERROR "rapids_cuda_init_architectures didn't preserve users CUDA_ARCHITECTURES value")
+endif()


### PR DESCRIPTION
## Description
When a user has both the env variable and CMake command line cache value specified we need to ensure that the users cache value is used.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
