### PR TITLE
add ASSOCIATED_TARGETS to function signature in rapids_cython_create_modules() docs

### DIFF
--- a/rapids-cmake/cython-core/create_modules.cmake
+++ b/rapids-cmake/cython-core/create_modules.cmake
@@ -28,7 +28,8 @@ Generate C(++) from Cython and create Python modules.
                                [SOURCE_FILES <src1> <src2> ...]
                                [LINKED_LIBRARIES <lib1> <lib2> ... ]
                                [INSTALL_DIR <install_path>]
-                               [MODULE_PREFIX <module_prefix>])
+                               [MODULE_PREFIX <module_prefix>]
+                               [ASSOCIATED_TARGETS <target1> <target2> ...])
 
 Creates a Cython target for each provided source file, then adds a
 corresponding Python extension module. Each built library has its RPATH set to


### PR DESCRIPTION
## Description

`rapids_cython_create_modules()` accepts an argument `ASSOCIATED_TARGETS` which is missing from the function signature in its docs.

This fixes that.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst

## Notes for Reviewers

Started looking into this function based on the conversation in https://github.com/rapidsai/rmm/pull/1644.