### PR TITLE
`write_language` now properly walks up the `add_subdirectory` call stack

### DIFF
--- a/testing/export/write_language-nested-dirs/A/C/CMakeLists.txt
+++ b/testing/export/write_language-nested-dirs/A/C/CMakeLists.txt
@@ -16,6 +16,13 @@
 
 include(${rapids-cmake-dir}/export/write_language.cmake)
 
-add_subdirectory(../C C)
+function(enable_nested_language file_path)
+  #replicates CPM including the file
+  include("${file_path}")
+endfunction()
 
-add_library(B STATIC static.cu)
+set(path "${CMAKE_CURRENT_BINARY_DIR}/enable_cuda_language.cmake")
+rapids_export_write_language(INSTALL CUDA "${path}")
+enable_nested_language("${path}")
+
+add_library(C STATIC static.cu)

--- a/testing/export/write_language-nested-dirs/A/C/static.cu
+++ b/testing/export/write_language-nested-dirs/A/C/static.cu
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
+
+int static_launch_kernelC(int x, int y)
+{
+  int r;
+  example_cuda_kernel<<<1, 1>>>(r, x, y);
+  return r;
+}


### PR DESCRIPTION
## Description
Instead of assuming the filesystem directory layout matches `add_subdirectory` calls, we now walk the CMake
`PARENT_DIRECTORY` property.

This allows us to handle more custom layouts of CMake projects

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
