### PR TITLE
rapids-cmake generated C++ files have current copyright year

### DIFF
--- a/rapids-cmake/cmake/detail/compute_git_info.cmake
+++ b/rapids-cmake/cmake/detail/compute_git_info.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/cmake/detail/compute_git_info.cmake
+++ b/rapids-cmake/cmake/detail/compute_git_info.cmake
@@ -49,4 +49,5 @@ if(_RAPIDS_WRITE_VERSION MATCHES dirty)
   set(_RAPIDS_GIT_IS_DIRTY 1)
 endif()
 
+string(TIMESTAMP current_year "%Y" UTC)
 configure_file("${TEMPLATE_FILE}" "${FILE_TO_WRITE}" @ONLY)

--- a/rapids-cmake/cmake/template/git_revision.hpp.in
+++ b/rapids-cmake/cmake/template/git_revision.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) @current_year@, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rapids-cmake/cmake/template/version.hpp.in
+++ b/rapids-cmake/cmake/template/version.hpp.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) @current_year@, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rapids-cmake/cmake/write_version_file.cmake
+++ b/rapids-cmake/cmake/write_version_file.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rapids-cmake/cmake/write_version_file.cmake
+++ b/rapids-cmake/cmake/write_version_file.cmake
@@ -91,6 +91,7 @@ function(rapids_cmake_write_version_file file_path)
     set(_RAPIDS_WRITE_PATCH 0)
   endif()
 
+  string(TIMESTAMP current_year "%Y" UTC)
   configure_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/version.hpp.in" "${output_path}"
                  @ONLY)
 endfunction()

--- a/testing/cmake/write_git_revision-simple/CMakeLists.txt
+++ b/testing/cmake/write_git_revision-simple/CMakeLists.txt
@@ -32,3 +32,23 @@ install(TARGETS write_git_version EXPORT write_git)
 rapids_export(BUILD DEMO
   EXPORT_SET write_git
   )
+
+# write out the cmake file used to verify the copyright
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/verify_copyright.cmake
+[=[
+include(${rapids-cmake-testing-dir}/utils/check_copyright_header.cmake)
+check_copyright_header("${WORKING_DIRECTORY}/demo/demo_git_version.hpp")
+check_copyright_header("${WORKING_DIRECTORY}/nested/nested_git_version.h")
+
+]=])
+
+# Setup a custom build target that verifies that our generated git version header
+# files have the correct copyright year
+add_custom_target(verify_git_info ALL
+                  COMMENT "verify copyright in generate git revision file for write_git_version"
+                  COMMAND ${CMAKE_COMMAND} -DWORKING_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}
+                          -Drapids-cmake-testing-dir=${rapids-cmake-testing-dir}
+                          -P ${CMAKE_CURRENT_BINARY_DIR}/verify_copyright.cmake
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_dependencies(verify_git_info demo_version_compute_git_info)
+add_dependencies(verify_git_info nested_version_compute_git_info)

--- a/testing/cmake/write_version-relative/CMakeLists.txt
+++ b/testing/cmake/write_version-relative/CMakeLists.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 #=============================================================================
 include(${rapids-cmake-dir}/cmake/write_version_file.cmake)
+include(${rapids-cmake-testing-dir}/utils/check_copyright_header.cmake)
 
 cmake_minimum_required(VERSION 3.26.4)
 
@@ -27,3 +28,6 @@ enable_language(CXX)
 add_executable(write_version main.cpp)
 target_include_directories(write_version PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_compile_features(write_version PRIVATE cxx_std_14)
+
+check_copyright_header("${CMAKE_CURRENT_BINARY_DIR}/demo_version.hpp")
+check_copyright_header("${CMAKE_CURRENT_BINARY_DIR}/nested_version.hpp")

--- a/testing/utils/check_copyright_header.cmake
+++ b/testing/utils/check_copyright_header.cmake
@@ -16,8 +16,10 @@
 include_guard(GLOBAL)
 
 function(check_copyright_header file)
+  cmake_path(GET file EXTENSION LAST_ONLY file_ext)
   string(TIMESTAMP current_year "%Y" UTC)
-  string(CONFIGURE [=[#=============================================================================
+  if(file_ext STREQUAL ".txt" OR file_ext STREQUAL ".cmake")
+    string(CONFIGURE [=[#=============================================================================
 # Copyright (c) @current_year@, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +35,24 @@ function(check_copyright_header file)
 # limitations under the License.
 #=============================================================================
 ]=] expected_header @ONLY)
+  else()
+    string(CONFIGURE [=[/*
+ * Copyright (c) @current_year@, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+]=] expected_header @ONLY)
+  endif()
   string(LENGTH "${expected_header}" expected_header_length)
 
   file(READ "${file}" actual_header LIMIT "${expected_header_length}")


### PR DESCRIPTION
## Description

Fixes #657

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
