### PR TITLE
Update to CPM 0.40.2 to fix CMake 3.30 deprecation warnings

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -42,8 +42,8 @@ function(rapids_cpm_download)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.download")
 
   # When changing version verify no new variables needs to be propagated
-  set(CPM_DOWNLOAD_VERSION 0.40.0)
-  set(CPM_DOWNLOAD_MD5_HASH 6c9866a0aa0f804a36fe8c3866fb8a2c)
+  set(CPM_DOWNLOAD_VERSION 0.40.2)
+  set(CPM_DOWNLOAD_MD5_HASH 4d51aa9dab6104fad39c5b7a692d5e1c)
 
   if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)


### PR DESCRIPTION
## Description
Updated to CPM version 0.40.2 so that we don't se any policy CMP0169 ( `FetchContent_Populate() is deprecated` ) warnings 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
