### PR TITLE
rapids-cmake tests no longer download CPM when `NO_CPM_CACHE` is set.

### DIFF
--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -27,8 +27,18 @@ Does the downloading of the `CPM` module
 
   rapids_cpm_download()
 
-The CPM module will be downloaded based on the state of :cmake:variable:`CPM_SOURCE_CACHE` and
-:cmake:variable:`ENV{CPM_SOURCE_CACHE}`.
+The CPM module will be downloaded based on the following.
+
+.. versionadded:: v24.10.00
+
+If :cmake:variable:`CPM_DOWNLOAD_LOCATION` is defined that location will be used
+as the download location. If a file already exists at that location no download will occur
+
+If the :cmake:variable:`CPM_SOURCE_CACHE` or :cmake:variable:`ENV{CPM_SOURCE_CACHE}` are
+defined those will be used to compute a location for the file.
+
+If none of the above variables are defined, rapids-cmake will download the file
+to `cmake` directory under :cmake:variable:`CMAKE_BINARY_DIR`.
 
 .. note::
   Use `rapids_cpm_init` instead of this function, as this is an implementation detail

--- a/rapids-cmake/cpm/detail/download.cmake
+++ b/rapids-cmake/cpm/detail/download.cmake
@@ -45,28 +45,30 @@ function(rapids_cpm_download)
   set(CPM_DOWNLOAD_VERSION 0.40.0)
   set(CPM_DOWNLOAD_MD5_HASH 6c9866a0aa0f804a36fe8c3866fb8a2c)
 
-  if(CPM_SOURCE_CACHE)
-    # Expand relative path. This is important if the provided path contains a tilde (~)
-    cmake_path(ABSOLUTE_PATH CPM_SOURCE_CACHE)
+  if(NOT DEFINED CPM_DOWNLOAD_LOCATION)
+    if(CPM_SOURCE_CACHE)
+      # Expand relative path. This is important if the provided path contains a tilde (~)
+      cmake_path(ABSOLUTE_PATH CPM_SOURCE_CACHE)
 
-    # default to the same location that cpm computes
-    set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-    if(EXISTS "${CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-      # Also support the rapids-cmake download location ( cmake/ vs cpm/ )
-      set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+      # default to the same location that cpm computes
+      set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+      if(EXISTS "${CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+        # Also support the rapids-cmake download location ( cmake/ vs cpm/ )
+        set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+      endif()
+
+    elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+
+      # default to the same location that cpm computes
+      set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+      if(EXISTS "$ENV{CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+        # Also support the rapids-cmake download location ( cmake/ vs cpm/ )
+        set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+      endif()
+
+    else()
+      set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
     endif()
-
-  elseif(DEFINED ENV{CPM_SOURCE_CACHE})
-
-    # default to the same location that cpm computes
-    set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-    if(EXISTS "$ENV{CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-      # Also support the rapids-cmake download location ( cmake/ vs cpm/ )
-      set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
-    endif()
-
-  else()
-    set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
   endif()
 
   if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))

--- a/testing/cpm/cpm_generate_pins-format-patches/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-format-patches/CMakeLists.txt
@@ -44,5 +44,5 @@ if(NOT EXISTS "${cuco_SOURCE_DIR}/git_file_1.txt")
 endif()
 
 add_custom_target(verify_generated_pins ALL
-  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}" -D"CPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
 )

--- a/testing/cpm/cpm_generate_pins-format-patches/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-format-patches/CMakeLists.txt
@@ -44,5 +44,5 @@ if(NOT EXISTS "${cuco_SOURCE_DIR}/git_file_1.txt")
 endif()
 
 add_custom_target(verify_generated_pins ALL
-  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}" -D"CPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
+  COMMAND ${CMAKE_COMMAND} "-S${CMAKE_SOURCE_DIR}/verify/" "-B${CMAKE_BINARY_DIR}/verify_build" "-Drapids-cmake-dir=${rapids-cmake-dir}" "-DCPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
 )

--- a/testing/cpm/cpm_generate_pins-override/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-override/CMakeLists.txt
@@ -38,5 +38,5 @@ include(${rapids-cmake-dir}/cpm/rmm.cmake)
 rapids_cpm_rmm(DOWNLOAD_ONLY ON)
 
 add_custom_target(verify_generated_pins ALL
-  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}" -D"CPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
+  COMMAND ${CMAKE_COMMAND} "-S${CMAKE_SOURCE_DIR}/verify/" "-B${CMAKE_BINARY_DIR}/verify_build" "-Drapids-cmake-dir=${rapids-cmake-dir}" "-DCPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
 )

--- a/testing/cpm/cpm_generate_pins-override/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-override/CMakeLists.txt
@@ -38,5 +38,5 @@ include(${rapids-cmake-dir}/cpm/rmm.cmake)
 rapids_cpm_rmm(DOWNLOAD_ONLY ON)
 
 add_custom_target(verify_generated_pins ALL
-  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_SOURCE_DIR}/verify/" -B"${CMAKE_BINARY_DIR}/verify_build" -D"rapids-cmake-dir=${rapids-cmake-dir}" -D"CPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}"
 )

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -89,6 +89,9 @@ function(add_cmake_test mode source_or_dir)
   if(DEFINED CPM_SOURCE_CACHE AND NOT RAPIDS_TEST_NO_CPM_CACHE)
     list(APPEND extra_configure_flags "-DCPM_SOURCE_CACHE=${CPM_SOURCE_CACHE}")
   endif()
+  if(DEFINED CPM_DOWNLOAD_LOCATION)
+    list(APPEND extra_configure_flags "-DCPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}")
+  endif()
 
   foreach(generator gen_name IN ZIP_LISTS supported_generators nice_gen_names)
 

--- a/testing/utils/fill_cache/CMakeLists.txt
+++ b/testing/utils/fill_cache/CMakeLists.txt
@@ -32,8 +32,6 @@ include(${rapids-cmake-dir}/cpm/fmt.cmake)
 
 rapids_cpm_init(GENERATE_PINNED_VERSIONS)
 
-set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
-
 # Download all source packages
 set(CPM_DOWNLOAD_ALL "ON")
 rapids_cpm_cccl(DOWNLOAD_ONLY ON)

--- a/testing/utils/setup_cpm_cache.cmake
+++ b/testing/utils/setup_cpm_cache.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ function(setup_cpm_cache )
   set(CPM_SOURCE_CACHE "${CMAKE_BINARY_DIR}")
   cmake_path(APPEND_STRING CPM_SOURCE_CACHE "/cache")
 
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/CPM.cmake")
+
   set(src_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/fill_cache/")
   set(build_dir "${CPM_SOURCE_CACHE}")
 
@@ -25,8 +27,11 @@ function(setup_cpm_cache )
   execute_process(COMMAND ${CMAKE_COMMAND}
       -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake
       -S ${src_dir} -B ${build_dir}
+      -DCPM_SOURCE_CACHE=${CPM_SOURCE_CACHE}
+      -DCPM_DOWNLOAD_LOCATION=${CPM_DOWNLOAD_LOCATION}
       WORKING_DIRECTORY ${src_dir}
       )
 
   set(CPM_SOURCE_CACHE "${CPM_SOURCE_CACHE}" PARENT_SCOPE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_DOWNLOAD_LOCATION}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Description
To help reduce the amount of network traffic, rapids-cmake now reuses the same CPM.cmake even when running no CPM cache tests. This elimates one source of network errors as we don't need to fetch the same CPM.cmake multiple times per CI run.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
