### PR TITLE
Make git tag and repository optional

### DIFF
--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -36,7 +36,7 @@ Result Variables
 
 #]=======================================================================]
 # cmake-lint: disable=R0913,R0915
-function(rapids_cpm_package_details package_name version_var url_var tag_var shallow_var
+function(rapids_cpm_package_details package_name version_var git_url_var git_tag_var shallow_var
          exclude_from_all_var)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_details")
 
@@ -67,8 +67,14 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   # Only do validation if we have an entry
   if(json_data OR override_json_data)
     # Validate that we have the required fields
-    foreach(var IN ITEMS version git_url git_tag)
+    foreach(var IN ITEMS version)
       if(NOT ${var})
+        message(FATAL_ERROR "rapids_cmake can't parse '${package_name}' json entry, it is missing a `${var}` entry"
+        )
+      endif()
+    endforeach()
+    foreach(var IN ITEMS git_url git_tag)
+      if(NOT ${var} AND ${var}_var)
         message(FATAL_ERROR "rapids_cmake can't parse '${package_name}' json entry, it is missing a `${var}` entry"
         )
       endif()
@@ -111,8 +117,8 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   cmake_language(EVAL CODE "set(git_url ${git_url})")
 
   set(${version_var} ${version} PARENT_SCOPE)
-  set(${url_var} ${git_url} PARENT_SCOPE)
-  set(${tag_var} ${git_tag} PARENT_SCOPE)
+  set(${git_url_var} ${git_url} PARENT_SCOPE)
+  set(${git_tag_var} ${git_tag} PARENT_SCOPE)
   set(${shallow_var} ${git_shallow} PARENT_SCOPE)
   set(${exclude_from_all_var} ${exclude_from_all} PARENT_SCOPE)
   if(DEFINED always_download)

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -86,7 +86,13 @@ function(rapids_cpm_nvcomp)
   set(_RAPIDS_UNPARSED_ARGUMENTS ${_RAPIDS_EXPORT_ARGUMENTS})
 
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
-  rapids_cpm_package_details(nvcomp version repository tag shallow exclude)
+  set(repository_var)
+  set(tag_var)
+  if(NOT _RAPIDS_USE_PROPRIETARY_BINARY)
+    set(repository_var repository)
+    set(tag_var tag)
+  endif()
+  rapids_cpm_package_details(nvcomp version "${repository_var}" "${tag_var}" shallow exclude)
   set(to_exclude OFF)
   if(NOT _RAPIDS_INSTALL_EXPORT_SET OR exclude)
     set(to_exclude ON)
@@ -187,11 +193,13 @@ function(rapids_cpm_nvcomp)
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
+  set(git_args)
+  if(NOT _RAPIDS_USE_PROPRIETARY_BINARY)
+    set(git_args GIT_REPOSITORY ${repository} GIT_TAG ${tag})
+  endif()
   rapids_cpm_find(nvcomp ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
                   GLOBAL_TARGETS nvcomp::nvcomp
-                  CPM_ARGS
-                  GIT_REPOSITORY ${repository}
-                  GIT_TAG ${tag}
+                  CPM_ARGS ${git_args}
                   GIT_SHALLOW ${shallow}
                   EXCLUDE_FROM_ALL ${to_exclude} ${patch_command}
                   OPTIONS "BUILD_STATIC ON" "BUILD_TESTS OFF" "BUILD_BENCHMARKS OFF"

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -47,8 +47,6 @@
     },
     "nvcomp": {
       "version": "4.0.1",
-      "git_url": "https://github.com/NVIDIA/nvcomp.git",
-      "git_tag": "v2.2.0",
       "proprietary_binary_cuda_version_mapping": {
         "11": "11.x",
         "12": "12.x"


### PR DESCRIPTION
## Description
To allow the removal of nvcomp 2.2.0, we make the git tag and repo arguments optional, since all nvcomp versions now use the proprietary binary instead.

Fixes: https://github.com/rapidsai/rapids-cmake/issues/702

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
