### PR TITLE
Disallow nvcomp git checkout

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -47,8 +47,8 @@
     },
     "nvcomp": {
       "version": "4.0.1",
-      "git_url": "https://github.com/NVIDIA/nvcomp.git",
-      "git_tag": "v2.2.0",
+      "git_url": "no_git_checkout_allowed",
+      "git_tag": "no_git_checkout_allowed",
       "proprietary_binary_cuda_version_mapping": {
         "11": "11.x",
         "12": "12.x"

--- a/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
+++ b/testing/cpm/cpm_nvcomp-always-download-proprietary_binary.cmake
@@ -32,8 +32,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
     "nvcomp": {
       "always_download" : true,
       "version": "3.0.6",
-      "git_url": "https://github.com/NVIDIA/nvcomp.git",
-      "git_tag": "v2.2.0",
+      "git_url": "no_git_checkout_allowed",
+      "git_tag": "no_git_checkout_allowed",
       "proprietary_binary": {
         "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_x86_64_${cuda-toolkit-version-major}.x.tgz",
         "aarch64-linux": "https://developer.download.nvidia.com/compute/nvcomp/${version}/local_installers/nvcomp_${version}_SBSA_${cuda-toolkit-version-major}.x.tgz"


### PR DESCRIPTION
## Description
Closes #702.

This adopts a minimal approach that does not affect parsing logic, it only disables git checkout of the nvcomp dependency.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
