### PR TITLE
Fix docs warning about get_html_theme_path.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,13 +12,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
 project = "rapids-cmake"
-copyright = "2021-2023, NVIDIA"
-author = "NVIDIA"
+copyright = f"2021-{datetime.datetime.today().year}, NVIDIA Corporation"
+author = "NVIDIA Corporation"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -87,7 +88,6 @@ todo_include_todos = False
 #
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Description
This fixes a failure in docs builds that comes from a warning.

See https://github.com/rapidsai/rmm/issues/1705 and https://github.com/rapidsai/rmm/pull/1706 for more information.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
