### PR TITLE
Update rapids-cmake to support cccl 2.8 new install rules

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -101,9 +101,9 @@ function(rapids_cpm_cccl)
   if(CCCL_SOURCE_DIR AND to_install AND NOT rapids_cccl_install_rules_already_called)
 
     set_property(GLOBAL PROPERTY rapids_cmake_cccl_install_rules ON)
-    # CCCL < 2.7 does not currently correctly support installation of cub/thrust/libcudacxx in a
+    # CCCL < 2.8 does not currently correctly support installation of cub/thrust/libcudacxx in a
     # subdirectory
-    if(version VERSION_LESS 2.7)
+    if(version VERSION_LESS 2.8)
       set(Thrust_SOURCE_DIR "${CCCL_SOURCE_DIR}/thrust")
       set(CUB_SOURCE_DIR "${CCCL_SOURCE_DIR}/cub")
       set(libcudacxx_SOURCE_DIR "${CCCL_SOURCE_DIR}/libcudacxx")

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -76,6 +76,7 @@ add_cmake_config_test( cpm_cccl-simple.cmake )
 add_cmake_config_test( cpm_cccl-export.cmake )
 add_cmake_build_test( cpm_cccl-version-2-5.cmake )
 add_cmake_build_test( cpm_cccl-version-2-7.cmake )
+add_cmake_build_test( cpm_cccl-version-2-8.cmake )
 add_cmake_build_test( cpm_cccl-preserve-custom-install-loc )
 
 add_cmake_config_test( cpm_cuco-simple.cmake )

--- a/testing/cpm/cpm_cccl-version-2-5.cmake
+++ b/testing/cpm/cpm_cccl-version-2-5.cmake
@@ -33,7 +33,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
       "git_tag": "e21d607157218540cd7c45461213fb96adf720b7"
-    },
+    }
   }
 }
   ]=])

--- a/testing/cpm/cpm_cccl-version-2-7.cmake
+++ b/testing/cpm/cpm_cccl-version-2-7.cmake
@@ -33,7 +33,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
       "git_tag": "v2.7.0-rc2"
-    },
+    }
   }
 }
   ]=])

--- a/testing/cpm/cpm_cccl-version-2-8.cmake
+++ b/testing/cpm/cpm_cccl-version-2-8.cmake
@@ -29,11 +29,11 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
 {
   "packages": {
     "CCCL": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "v2.7.0-rc2"
-    },
+      "git_tag": "fb4453dd632194dd2736772a9a0c19d200855ad7"
+    }
   }
 }
   ]=])
@@ -73,6 +73,7 @@ foreach(to_verify IN LISTS include_dirs_to_verify cmake_dirs_to_verify)
   endif()
 endforeach()
 ]=])
+
 
 add_custom_target(verify_thrust_header_search ALL
   COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/check_cccl/build"


### PR DESCRIPTION
## Description
Previous logic had the CCCL rules updated for 2.7 but that was due to incorrect information. 

Updated tests to confirm the install logic against 2.7 and 2.8

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
