### PR TITLE
Search for the normalized package name when patching

### DIFF
--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -40,8 +40,10 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   get_default_json(${package_name} json_data)
   get_override_json(${package_name} override_json_data)
 
-  get_property(json_path GLOBAL PROPERTY rapids_cpm_${package_name}_json_file)
-  get_property(override_json_path GLOBAL PROPERTY rapids_cpm_${package_name}_override_json_file)
+  string(TOLOWER "${package_name}" normalized_pkg_name)
+  get_property(json_path GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_json_file)
+  get_property(override_json_path GLOBAL
+               PROPERTY rapids_cpm_${normalized_pkg_name}_override_json_file)
 
   string(JSON json_data ERROR_VARIABLE no_default_patch GET "${json_data}" patches)
   string(JSON override_json_data ERROR_VARIABLE no_override_patch GET "${override_json_data}"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
#708 broke patches specified via overrides due to the missing case normalization.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
