### PR TITLE
Update nvcomp to 4.1.1.1.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -46,7 +46,7 @@
       "git_tag": "555d628e9b250868c9da003e4407087ff1982e8e"
     },
     "nvcomp": {
-      "version": "4.1.0.6",
+      "version": "4.1.1.1",
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
       "git_tag": "v2.2.0",
       "proprietary_binary_cuda_version_mapping": {


### PR DESCRIPTION
## Description
Updates to nvcomp 4.1.1.1 to get some bug fixes needed for Spark-RAPIDS.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
