### PR TITLE
fix signature in rapids_export() docs

### DIFF
--- a/rapids-cmake/export/export.cmake
+++ b/rapids-cmake/export/export.cmake
@@ -67,7 +67,7 @@ calls to :cmake:command:`find_dependency`, or :cmake:command:`CPMFindPackage`.
     rapids_export(BUILD example
       EXPORT_SET example-targets
       COMPONENTS A B
-      COMPONENTS A-export B-export
+      COMPONENTS_EXPORT_SET A-export B-export
       )
 
   This is needed so that :cmake:command:`rapids_export` can correctly


### PR DESCRIPTION
## Description

Reading through https://docs.rapids.ai/api/rapids-cmake/stable/command/rapids_export/, I noticed what looks like a typo... argument `COMPONENTS` is repeated in the signature of `rapids_export()`. I think that second one was supposed to be `COMPONENTS_EXPORT_SET`.

This fixes that.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
