### PR TITLE
Correct nvbench + conda test to explicitly pull spdlog

### DIFF
--- a/testing/cpm/cpm_nvbench-conda-fmt.cmake
+++ b/testing/cpm/cpm_nvbench-conda-fmt.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #=============================================================================
 include(${rapids-cmake-dir}/cpm/init.cmake)
 include(${rapids-cmake-dir}/cpm/rmm.cmake)
+include(${rapids-cmake-dir}/cpm/spdlog.cmake)
 include(${rapids-cmake-dir}/cpm/nvbench.cmake)
 
 enable_language(CUDA)
@@ -27,6 +28,7 @@ rapids_cuda_set_architectures(RAPIDS)
 set(BUILD_SHARED_LIBS ON)
 rapids_cpm_init()
 rapids_cpm_rmm()
+rapids_cpm_spdlog()
 rapids_cpm_nvbench()
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/use_fmt.cpp" [=[
@@ -50,5 +52,5 @@ int main() { return 0; }
 
 
 add_library(uses_fmt SHARED "${CMAKE_CURRENT_BINARY_DIR}/use_fmt.cpp")
-target_link_libraries(uses_fmt PRIVATE rmm::rmm nvbench::nvbench)
+target_link_libraries(uses_fmt PRIVATE rmm::rmm nvbench::nvbench spdlog::spdlog_header_only)
 target_compile_features(uses_fmt PRIVATE cxx_std_17)


### PR DESCRIPTION
## Description
As of https://github.com/rapidsai/rmm/pull/1722, rmm no longer depends on spdlog. However, some tests were depending on spdlog transitively through rmm. This PR adds spdlog as an explicit dependency to correct those failures.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
