### PR TITLE
Bump cuco by one commit to include `cuco::arrow_filter_policy` updates

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -21,7 +21,7 @@
       "git_shallow": false,
       "always_download": true,
       "git_url": "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag": "95f338d233e1365fb3841439e39235ae0ca7ca7e"
+      "git_tag": "096346b739da3fb1d9c3b402190c0a3a7e554440"
     },
     "fmt": {
       "version": "11.0.2",


### PR DESCRIPTION
## Description
Simply bump cuco by one commit which contains updates to unblock https://github.com/rapidsai/cudf/pull/17289

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
