### PR TITLE
remove setup.cfg, use pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         exclude: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,11 @@ repos:
         types_or: [c, c++, cuda]
         args: ["-fallback-style=none", "-style=file", "-i"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.3.0
     hooks:
       - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.17.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: codespell
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.8.0
+    rev: v1.17.0
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2024, NVIDIA CORPORATION.
 
-[codespell]
+[tool.codespell]
 # note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
 # this is only to allow you to run codespell interactively
 skip = ./.git,./.github
-# ignore short words, and typename parameters like OffsetT
-ignore-regex = \b(.{1,4}|[A-Z]\w*T)\b
-builtin = clear
+# ignore short words, and typename parameters
+ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
+builtin = "clear"
 quiet-level = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [tool.codespell]
 # note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
 # this is only to allow you to run codespell interactively
-skip = ./.git,./.github
+skip = "./.git"
 # ignore short words, and typename parameters
 ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
 builtin = "clear"

--- a/rapids-cmake/test/gpu_requirements.cmake
+++ b/rapids-cmake/test/gpu_requirements.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ function(rapids_test_gpu_requirements test_name)
     set(percent ${_RAPIDS_TEST_PERCENT})
   endif()
 
-  # verify that gpu and percent are withing the allowed bounds
+  # verify that gpu and percent are within the allowed bounds
   if(NOT gpus GREATER_EQUAL 0)
     message(FATAL_ERROR "rapids_test_gpu_requirements requires a numeric GPUS value [0-N].")
   endif()


### PR DESCRIPTION
## Description

This repo doesn't have a Python package or use `setuptools`, but it has a `setup.cfg`... to hold configuration for tools like `codespell`.

This proposes removing that and using a `pyproject.toml` to store that configuration, matching the conventions used across most of the rest of RAPIDS.

It also updates pre-commit configurations to use the latest version of `rapids-dependency-file-generator` (v1.17.0).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
