### PR TITLE
Add new global targets for rmm

### DIFF
--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ for  consistency across all RAPIDS projects.
 Result Targets
 ^^^^^^^^^^^^^^
   rmm::rmm target will be created
+  rmm::rmm_logger target will be created
+  rmm::rmm_logger_impl target will be created
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -73,7 +75,7 @@ function(rapids_cpm_rmm)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
   rapids_cpm_find(rmm ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
-                  GLOBAL_TARGETS rmm::rmm
+                  GLOBAL_TARGETS rmm::rmm rmm::rmm_logger rmm::rmm_logger_impl
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}

--- a/testing/cpm/cpm_rmm-simple.cmake
+++ b/testing/cpm/cpm_rmm-simple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2023, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,22 @@ rapids_cpm_init()
 if(TARGET rmm::rmm)
   message(FATAL_ERROR "Expected rmm::rmm not to exist")
 endif()
+if(TARGET rmm::rmm_logger)
+  message(FATAL_ERROR "Expected rmm::rmm_logger not to exist")
+endif()
+if(TARGET rmm::rmm_logger_impl)
+  message(FATAL_ERROR "Expected rmm::rmm_logger_impl not to exist")
+endif()
 
 rapids_cpm_rmm()
 if(NOT TARGET rmm::rmm)
   message(FATAL_ERROR "Expected rmm::rmm target to exist")
+endif()
+if(NOT TARGET rmm::rmm_logger)
+  message(FATAL_ERROR "Expected rmm::rmm_logger target to exist")
+endif()
+if(NOT TARGET rmm::rmm_logger_impl)
+  message(FATAL_ERROR "Expected rmm::rmm_logger_impl target to exist")
 endif()
 
 rapids_cpm_rmm()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
These targets were added in rapidsai/rmm#1722 and must be propagated.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
