### PR TITLE
Use GCC 13 in CUDA 12 conda builds.

### DIFF
--- a/conda/recipes/rapids_core_dependencies/conda_build_config.yaml
+++ b/conda/recipes/rapids_core_dependencies/conda_build_config.yaml
@@ -1,11 +1,10 @@
 cxx_compiler_version:
-  - 11
+  - 13  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - 11  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cuda_compiler:
-  - cuda-nvcc
-
-cuda11_compiler:
-  - nvcc
+  - cuda-nvcc  # [not os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
+  - nvcc  # [os.environ.get("RAPIDS_CUDA_VERSION", "").startswith("11")]
 
 cmake_version:
   - ">=3.26.4"
@@ -14,4 +13,4 @@ c_stdlib:
   - sysroot
 
 c_stdlib_version:
-  - "2.17"
+  - "2.28"

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -16,11 +16,7 @@ build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   ignore_run_exports_from:
-    {% if cuda_major == "11" %}
     - {{ compiler('cuda') }}
-    {% else %}
-    - {{ compiler('cuda') }}
-    {% endif %}
 
 requirements:
   build:

--- a/conda/recipes/rapids_core_dependencies/meta.yaml
+++ b/conda/recipes/rapids_core_dependencies/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set cuda_version = '.'.join(environ['RAPIDS_CUDA_VERSION'].split('.')[:2]) %}
@@ -17,7 +17,7 @@ build:
   string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   ignore_run_exports_from:
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }}
+    - {{ compiler('cuda') }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}
@@ -27,7 +27,7 @@ requirements:
     - cmake {{ cmake_version }}
     - {{ compiler('cxx') }}
     {% if cuda_major == "11" %}
-    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    - {{ compiler('cuda') }} ={{ cuda_version }}
     {% else %}
     - {{ compiler('cuda') }}
     {% endif %}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,17 +49,17 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - gcc<13.0.0
+              - gcc<14.0.0
       - output_types: conda
         matrices:
           - matrix:
               arch: x86_64
             packages:
-              - sysroot_linux-64==2.17
+              - sysroot_linux-64==2.28
           - matrix:
               arch: aarch64
             packages:
-              - sysroot_linux-aarch64==2.17
+              - sysroot_linux-aarch64==2.28
       - output_types: conda
         matrices:
           - matrix:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,6 +47,10 @@ dependencies:
             packages:
               - gcc<12.0.0
           - matrix:
+              cuda: "12.[0123]"
+            packages:
+              - gcc<13.0.0
+          - matrix:
               cuda: "12.*"
             packages:
               - gcc<14.0.0


### PR DESCRIPTION
## Description
conda-forge is using GCC 13 for CUDA 12 builds. This PR updates CUDA 12 conda builds to use GCC 13, for alignment.

These PRs should be merged in a specific order, see https://github.com/rapidsai/build-planning/issues/129 for details.
