### PR TITLE
rapids_cpm_cccl use proper CCCL version value to compute install rules

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -102,8 +102,8 @@ function(rapids_cpm_cccl)
 
     set_property(GLOBAL PROPERTY rapids_cmake_cccl_install_rules ON)
     # CCCL < 2.8 does not currently correctly support installation of cub/thrust/libcudacxx in a
-    # subdirectory
-    if(CCCL_VERSION VERSION_LESS 2.8)
+    # subdirectory CCCL_VERSION doesn't exist when using `add_subdirectory`
+    if(LIBCUDACXX_VERSION VERSION_LESS 2.8)
       set(Thrust_SOURCE_DIR "${CCCL_SOURCE_DIR}/thrust")
       set(CUB_SOURCE_DIR "${CCCL_SOURCE_DIR}/cub")
       set(libcudacxx_SOURCE_DIR "${CCCL_SOURCE_DIR}/libcudacxx")

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ function(rapids_cpm_cccl)
     set_property(GLOBAL PROPERTY rapids_cmake_cccl_install_rules ON)
     # CCCL < 2.8 does not currently correctly support installation of cub/thrust/libcudacxx in a
     # subdirectory
-    if(version VERSION_LESS 2.8)
+    if(CCCL_VERSION VERSION_LESS 2.8)
       set(Thrust_SOURCE_DIR "${CCCL_SOURCE_DIR}/thrust")
       set(CUB_SOURCE_DIR "${CCCL_SOURCE_DIR}/cub")
       set(libcudacxx_SOURCE_DIR "${CCCL_SOURCE_DIR}/libcudacxx")

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -82,9 +82,9 @@ add_cmake_build_test( cpm_bs_thread_pool-install-config-works.cmake )
 
 add_cmake_config_test( cpm_cccl-simple.cmake )
 add_cmake_config_test( cpm_cccl-export.cmake )
-add_cmake_build_test( cpm_cccl-version-2-5.cmake )
-add_cmake_build_test( cpm_cccl-version-2-7.cmake )
-add_cmake_build_test( cpm_cccl-version-2-8.cmake )
+add_cmake_build_test( cpm_cccl-version-2-5.cmake NO_CPM_CACHE )
+add_cmake_build_test( cpm_cccl-version-2-7.cmake NO_CPM_CACHE )
+add_cmake_build_test( cpm_cccl-version-2-8.cmake NO_CPM_CACHE )
 add_cmake_build_test( cpm_cccl-preserve-custom-install-loc )
 
 add_cmake_config_test( cpm_cuco-simple.cmake )


### PR DESCRIPTION
## Description
We can't use the request versions.json version value as it might be 2.7 and we found >= 2.8

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
