### PR TITLE
Use CCCL v2.7.0 final tag.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -14,7 +14,7 @@
       "version": "2.7.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "83028fcdcfa8de51ab359e61ce07198a6003a65e"
+      "git_tag": "v${version}"
     },
     "cuco": {
       "version": "0.0.1",

--- a/testing/cpm/cpm_cccl-version-2-7.cmake
+++ b/testing/cpm/cpm_cccl-version-2-7.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "version": "2.7.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "v2.7.0-rc2"
+      "git_tag": "v2.7.0"
     }
   }
 }


### PR DESCRIPTION
## Description
CCCL is currently pinned to `v2.7.0-rc2`. Now that a final tag for `v2.7.0` is available, we should use that instead.

See diff: https://github.com/NVIDIA/cccl/compare/v2.7.0-rc2...v2.7.0

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
