### PR TITLE
Use sysroot 2.17 on CUDA < 11.8.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,6 +58,16 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
+              cuda: "11.[2456]"
+            packages:
+              - sysroot_linux-64==2.17
+          - matrix:
+              arch: aarch64
+              cuda: "11.[2456]"
+            packages:
+              - sysroot_linux-aarch64==2.17
+          - matrix:
+              arch: x86_64
             packages:
               - sysroot_linux-64==2.28
           - matrix:


### PR DESCRIPTION
## Description
Nightly CI was failing on CUDA 11.4 due to #741. This fixes it.
Old versions of `nvcc` for CUDA 11 do not support sysroot 2.28 until CUDA 11.8.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
