### PR TITLE
Allow sysroot 2.28 in CUDA 11 jobs.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,16 +58,6 @@ dependencies:
         matrices:
           - matrix:
               arch: x86_64
-              cuda: "11.[2456]"
-            packages:
-              - sysroot_linux-64==2.17
-          - matrix:
-              arch: aarch64
-              cuda: "11.[2456]"
-            packages:
-              - sysroot_linux-aarch64==2.17
-          - matrix:
-              arch: x86_64
             packages:
               - sysroot_linux-64==2.28
           - matrix:


### PR DESCRIPTION
## Description
This removes some special cases added in #745 around sysroot pinnings. Those were needed for CUDA 11.4 until a recent repodata patch. Thanks @jakirkham!

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
