### PR TITLE
Sanitize patch input to protect against CMake Language limitations

### DIFF
--- a/rapids-cmake/cpm/detail/convert_patch_json.cmake
+++ b/rapids-cmake/cpm/detail/convert_patch_json.cmake
@@ -69,6 +69,9 @@ function(rapids_cpm_convert_patch_json)
   elseif(_RAPIDS_FROM_FILE_TO_JSON)
     # extract contents from `file`
     file(STRINGS "${${_RAPIDS_FILE_VAR}}" file_content)
+    # Work around https://github.com/rapidsai/rapids-cmake/issues/769
+    string(REPLACE "]" "~&93~" file_content "${file_content}")
+    string(REPLACE "[" "~&92~" file_content "${file_content}")
     list(LENGTH file_content content_length)
 
     # Get the file extension
@@ -78,6 +81,8 @@ function(rapids_cpm_convert_patch_json)
     # add each line as a json array element
     set(inline_patch [=[ [ ] ]=])
     foreach(line IN LISTS file_content)
+      string(REPLACE "~&93~" "]" line "${line}")
+      string(REPLACE "~&92~" "[" line "${line}")
       string(JSON inline_patch SET "${inline_patch}" ${content_length} "\"${line}\"")
     endforeach()
 

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -42,6 +42,7 @@ add_cmake_build_test( cpm_generate_pins-pure-cpm )
 add_cmake_build_test( cpm_generate_pins-simple )
 add_cmake_build_test( cpm_generate_pins-simple-via-variable )
 add_cmake_build_test( cpm_generate_pins-var-and-arg )
+add_cmake_config_test( cpm_convert_patch_json-special-chars.cmake )
 
 add_cmake_config_test( cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm_init can't load")
 add_cmake_config_test( cpm_init-bad-default-cmake-var.cmake SHOULD_FAIL "rapids_cpm_init can't load")

--- a/testing/cpm/cpm_convert_patch_json-special-chars.cmake
+++ b/testing/cpm/cpm_convert_patch_json-special-chars.cmake
@@ -1,0 +1,33 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+include(${rapids-cmake-dir}/cpm/detail/convert_patch_json.cmake)
+
+set(bug
+  [=[
+int function(not_parsed[
+N], properly ) {
+}]=])
+
+set(file_path "${CMAKE_BINARY_DIR}/bug.txt")
+file(WRITE ${file_path} "${bug}" )
+
+rapids_cpm_convert_patch_json(FROM_FILE_TO_JSON json FILE_VAR file_path)
+
+set(expected_output [==[[ "int function(not_parsed[", "N], properly ) {", "}" ]]==])
+string(JSON json_content GET "${json}" "content")
+if(NOT (expected_output STREQUAL json_content))
+  message(FATAL_ERROR "exp: `${expected_output}`\ngot: `${json_content}`")
+endif()


### PR DESCRIPTION
## Description
The CMake language outlines a couple of limitations of the language ( https://cmake.org/cmake/help/v3.14/manual/cmake-language.7.html#lists ) which makes parsing abitrary files in CMake problematic.

We work around unbalanced `[`, `]` when parsing git patch files by transforming those characters into unique placeholders.

Fixes #769

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
