### PR TITLE
Fix tests broken by rapids-logger changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@
 # Enforce the minimum required CMake version for all users
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
+
 set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
 if(NOT DEFINED CACHE{rapids-cmake-dir})
   set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE INTERNAL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@
 # Enforce the minimum required CMake version for all users
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
-set(rapids-cmake-dir "test")
 set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
 if(NOT DEFINED CACHE{rapids-cmake-dir})
   set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE INTERNAL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 # Enforce the minimum required CMake version for all users
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 
-
+set(rapids-cmake-dir "test")
 set(rapids-cmake-dir "${CMAKE_CURRENT_LIST_DIR}/rapids-cmake")
 if(NOT DEFINED CACHE{rapids-cmake-dir})
   set(rapids-cmake-dir "${rapids-cmake-dir}" CACHE INTERNAL "" FORCE)

--- a/testing/cpm/cpm_generate_pins-nested/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-nested/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_generate_pins-nested/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-nested/CMakeLists.txt
@@ -25,4 +25,4 @@ include(${rapids-cmake-dir}/cpm/init.cmake)
 rapids_cpm_init(GENERATE_PINNED_VERSIONS)
 
 include("${rapids-cmake-testing-dir}/cpm/verify_generated_pins.cmake")
-verify_generated_pins(verify_pins PROJECTS rmm fmt spdlog)
+verify_generated_pins(verify_pins PROJECTS rmm spdlog)

--- a/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
@@ -27,5 +27,5 @@ rapids_cpm_rmm()
 
 include("${rapids-cmake-testing-dir}/cpm/verify_generated_pins.cmake")
 verify_generated_pins(verify_pins
-    PROJECTS rmm fmt spdlog
+    PROJECTS rmm spdlog
     PIN_FILE "${RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE}")

--- a/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-simple-via-variable/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
@@ -26,9 +26,9 @@ rapids_cpm_rmm()
 
 include("${rapids-cmake-testing-dir}/cpm/verify_generated_pins.cmake")
 verify_generated_pins(verify_pins_A
-    PROJECTS rmm fmt spdlog
+    PROJECTS rmm spdlog
     PIN_FILE "${RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE}")
 
 verify_generated_pins(verify_pins_B
-    PROJECTS rmm fmt spdlog
+    PROJECTS rmm spdlog
     PIN_FILE "${CMAKE_BINARY_DIR}/rapids-cmake/pinned_versions.json")

--- a/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
+++ b/testing/cpm/cpm_generate_pins-var-and-arg/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
#765 required an admin merge on this repository to break a circular dependency between this repository and rmm because rapids-cmake provides a centralized `rapids_cpm_rmm` function. Unfortunately, because of how certain tests in this repo were set up, they could not be tested against a fork (like #765 did) without manually copying over branches to the fork, so that was not done. Now that the rmm PR is merged, we can see that there are a few issues to be ironed out with the tests here. In particular, since rmm no longer clones fmt, the pin testing needs to be updated to not look for it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
