### PR TITLE
Set `-Wno-deprecated-gpu-targets` when compiling for RAPIDS architectures

### DIFF
--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -83,13 +83,13 @@ function(rapids_cuda_set_architectures mode)
     rapids_cuda_detect_architectures(supported_archs CMAKE_CUDA_ARCHITECTURES)
 
     list(TRANSFORM CMAKE_CUDA_ARCHITECTURES APPEND "-real")
+  endif()
 
-    # CUDA 12.8.0 and later warns when compiling for arch 70. We ignore this warning when compiling
-    # for RAPIDS architectures.
-    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND CMAKE_CUDA_COMPILER_VERSION
-                                                    VERSION_GREATER_EQUAL 12.8.0)
-      string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
-    endif()
+  # CUDA 12.8.0 and later warns when compiling for arch 70. We ignore this warning when compiling
+  # for RAPIDS architectures.
+  if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL
+                                                  12.8.0)
+    string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
   endif()
 
   # cache the cuda archs.

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -88,7 +88,7 @@ function(rapids_cuda_set_architectures mode)
     # for RAPIDS architectures.
     if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND CMAKE_CUDA_COMPILER_VERSION
                                                     VERSION_GREATER_EQUAL 12.8.0)
-      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+      string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets")
     endif()
   endif()
 
@@ -110,5 +110,6 @@ function(rapids_cuda_set_architectures mode)
 
   # Set as a local variable to maintain comp
   set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} PARENT_SCOPE)
+  set(CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} PARENT_SCOPE)
 
 endfunction()

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -83,6 +83,13 @@ function(rapids_cuda_set_architectures mode)
     rapids_cuda_detect_architectures(supported_archs CMAKE_CUDA_ARCHITECTURES)
 
     list(TRANSFORM CMAKE_CUDA_ARCHITECTURES APPEND "-real")
+
+    # CUDA 12.8.0 and later warns when compiling for arch 70. We ignore this warning when compiling
+    # for RAPIDS architectures.
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND CMAKE_CUDA_COMPILER_VERSION
+                                                    VERSION_GREATER_EQUAL 12.8.0)
+      set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets")
+    endif()
   endif()
 
   # cache the cuda archs.

--- a/testing/cuda/validate-cuda-native.cmake
+++ b/testing/cuda/validate-cuda-native.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,4 +28,10 @@ endforeach()
 
 if(NOT DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES} )
   message(FATAL_ERROR "rapids_cuda_set_architectures didn't make CMAKE_CUDA_ARCHITECTURES a cache variable")
+endif()
+
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0 )
+  if(NOT CMAKE_CUDA_FLAGS MATCHES "Wno-deprecated-gpu-targets")
+    message(FATAL_ERROR "CMAKE_CUDA_FLAGS should have -Wno-deprecated-gpu-targets")
+  endif()
 endif()

--- a/testing/cuda/validate-cuda-rapids.cmake
+++ b/testing/cuda/validate-cuda-rapids.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,4 +47,10 @@ list(APPEND CMAKE_CUDA_ARCHITECTURES ${last_value})
 
 if(NOT DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES} )
   message(FATAL_ERROR "rapids_cuda_set_architectures didn't make CMAKE_CUDA_ARCHITECTURES a cache variable")
+endif()
+
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0 )
+  if(NOT CMAKE_CUDA_FLAGS MATCHES "Wno-deprecated-gpu-targets")
+    message(FATAL_ERROR "CMAKE_CUDA_FLAGS should have -Wno-deprecated-gpu-targets")
+  endif()
 endif()


### PR DESCRIPTION
## Description
Closes #761.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
