### PR TITLE
rapids_cpm_package_override: Always load overrides

### DIFF
--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -95,13 +95,14 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   # Ensure that always_download is not set by default so that the if(DEFINED always_download) check
   # below works as expected in the default case.
   unset(always_download)
+  unset(override_ignored)
   if(override_json_data AND json_data AND git_details_overridden)
     # `always_download` default value requires the package to exist in both the default and override
     # and that the git url / git tag have been modified. We also need to make sure that when using
     # an override that it isn't disabled due to `CPM_<pkg>_SOURCE`
     string(TOLOWER "${package_name}" normalized_pkg_name)
-    get_property(override_ignored GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored
-                 SET)
+    get_property(override_ignored GLOBAL
+                 PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored)
     if(NOT (override_ignored OR DEFINED CPM_${package_name}_SOURCE))
       set(always_download ON)
     endif()

--- a/rapids-cmake/cpm/detail/package_details.cmake
+++ b/rapids-cmake/cpm/detail/package_details.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,8 +97,14 @@ function(rapids_cpm_package_details package_name version_var url_var tag_var sha
   unset(always_download)
   if(override_json_data AND json_data AND git_details_overridden)
     # `always_download` default value requires the package to exist in both the default and override
-    # and that the git url / git tag have been modified.
-    set(always_download ON)
+    # and that the git url / git tag have been modified. We also need to make sure that when using
+    # an override that it isn't disabled due to `CPM_<pkg>_SOURCE`
+    string(TOLOWER "${package_name}" normalized_pkg_name)
+    get_property(override_ignored GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored
+                 SET)
+    if(NOT (override_ignored OR DEFINED CPM_${package_name}_SOURCE))
+      set(always_download ON)
+    endif()
   endif()
   rapids_cpm_json_get_value(always_download)
 

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -56,7 +56,7 @@ as the override.
 
 .. note::
 
-  .. versionadded:: v24.04.00
+  .. versionadded:: v25.04.00
 
     When the variable `CPM_<package_name>_SOURCE` exists, any override entries
     for `package_name` will be parsed but ignored.

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -126,9 +126,8 @@ function(rapids_cpm_package_override _rapids_override_filepath)
       if(DEFINED CPM_${package_name}_SOURCE)
         set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored "ON")
         continue()
-      else()
-        set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored "OFF")
       endif()
+      set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored "OFF")
 
       # establish the fetch content
       include(FetchContent)

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -61,7 +61,7 @@ as the override.
     When the variable `CPM_<package_name>_SOURCE` exists, any override entries
     for `package_name` will be parsed but ignored.
 
-    For versions v24.02 and v23.10 ( inclusive ) the variable `CPM_<package_name>_SOURCE`
+    For versions between v25.02 and v23.10 ( inclusive ) the variable `CPM_<package_name>_SOURCE`
     will cause any override entries for `package_name` to be ignored and not parsed.
 
 

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -61,8 +61,9 @@ as the override.
     When the variable `CPM_<package_name>_SOURCE` exists, any override entries
     for `package_name` will be parsed but ignored.
 
-    For versions between v25.02 and v23.10 ( inclusive ) the variable `CPM_<package_name>_SOURCE`
-    will cause any override entries for `package_name` to be ignored and not parsed.
+    For versions between v23.10 and v25.02 ( inclusive both sides ) the variable
+    `CPM_<package_name>_SOURCE` will cause any override entries for `package_name`
+    to be ignored and not parsed.
 
 
 .. note::

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,10 +56,13 @@ as the override.
 
 .. note::
 
-  .. versionadded:: v23.10.00
+  .. versionadded:: v24.04.00
 
     When the variable `CPM_<package_name>_SOURCE` exists, any override entries
-    for `package_name` will be ignored.
+    for `package_name` will be parsed but ignored.
+
+    For versions v24.02 and v23.10 ( inclusive ) the variable `CPM_<package_name>_SOURCE`
+    will cause any override entries for `package_name` to be ignored and not parsed.
 
 
 .. note::
@@ -91,7 +94,8 @@ function(rapids_cpm_package_override _rapids_override_filepath)
       string(TOLOWER "${package_name}" normalized_pkg_name)
       get_property(override_exists GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_json
                    SET)
-      if(override_exists OR DEFINED CPM_${package_name}_SOURCE)
+      if(override_exists)
+        # Early terminate if this project already has an override
         continue()
       endif()
 
@@ -107,11 +111,23 @@ function(rapids_cpm_package_override _rapids_override_filepath)
         set(package_proper_name ${package_name}) # Required for FetchContent_Declare
       endif()
 
-      # only add the first override for a project we encounter
+      # Always load overrides into our internal properties even when CPM_${package_name}_SOURCE is
+      # set. We add the override_ignored so that `package_details` can maintain behavior around
+      # `CPM_DOWNLOAD_ALL` when an override is loaded but not used
+      #
+      # We are using this behavior so that advanced users can retrieve the contents of an override
+      # even when not in use
       string(JSON data GET "${json_data}" packages "${package_name}")
       set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_json "${data}")
       set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_json_file
                                    "${_rapids_override_filepath}")
+
+      if(DEFINED CPM_${package_name}_SOURCE)
+        set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored "ON")
+        continue()
+      else()
+        set_property(GLOBAL PROPERTY rapids_cpm_${normalized_pkg_name}_override_ignored "OFF")
+      endif()
 
       # establish the fetch content
       include(FetchContent)

--- a/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
+++ b/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
@@ -65,14 +65,12 @@ if(NOT (version AND repository AND tag))
   message(FATAL_ERROR "rapids_cpm_package_details should still have details for package that doesn't exist")
 endif()
 
-get_property(override_ignored GLOBAL PROPERTY rapids_cpm_rmm_override_ignored
-             SET)
+get_property(override_ignored GLOBAL PROPERTY rapids_cpm_rmm_override_ignored)
 if(NOT override_ignored)
   message(FATAL_ERROR "rapids_cpm_package override for `not_in_base` isn't being ignored")
 endif()
 
-get_property(override_ignored GLOBAL PROPERTY rapids_cpm_not_in_base_override_ignored
-             SET)
+get_property(override_ignored GLOBAL PROPERTY rapids_cpm_not_in_base_override_ignored)
 if(NOT override_ignored)
   message(FATAL_ERROR "rapids_cpm_package override for `not_in_base` isn't being ignored")
 endif()

--- a/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
+++ b/testing/cpm/cpm_package_override-obey-cpm-source-var.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,10 +47,10 @@ rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
 
 rapids_cpm_package_details(rmm version repository tag shallow exclude)
-if(repository MATCHES "new_rmm_url")
+if(NOT repository MATCHES "new_rmm_url")
   message(FATAL_ERROR "custom url field should not be set, due to CPM_rmm_SOURCE")
 endif()
-if(shallow MATCHES "OFF")
+if(NOT shallow MATCHES "OFF")
   message(FATAL_ERROR "shallow field should not be set, due to CPM_rmm_SOURCE")
 endif()
 if(CPM_DOWNLOAD_ALL)
@@ -61,6 +61,18 @@ unset(version)
 unset(repository)
 unset(tag)
 rapids_cpm_package_details(not_in_base version repository tag shallow exclude)
-if(version OR repository OR tag)
-  message(FATAL_ERROR "rapids_cpm_package_details should not return anything for package that doesn't exist")
+if(NOT (version AND repository AND tag))
+  message(FATAL_ERROR "rapids_cpm_package_details should still have details for package that doesn't exist")
+endif()
+
+get_property(override_ignored GLOBAL PROPERTY rapids_cpm_rmm_override_ignored
+             SET)
+if(NOT override_ignored)
+  message(FATAL_ERROR "rapids_cpm_package override for `not_in_base` isn't being ignored")
+endif()
+
+get_property(override_ignored GLOBAL PROPERTY rapids_cpm_not_in_base_override_ignored
+             SET)
+if(NOT override_ignored)
+  message(FATAL_ERROR "rapids_cpm_package override for `not_in_base` isn't being ignored")
 endif()


### PR DESCRIPTION
## Description
rapids-cmake will now always load override entries from disk and populate the internal json state. In the case of `CPM_<pkg>_SOURCE` this information will still be ignored. This gives advanced users a consistent behavior when calling `
rapids_cpm_package_details`


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
