### PR TITLE
Update to nvcomp 4.2 which offers full blackwell support

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -60,7 +60,7 @@
       "git_tag": "555d628e9b250868c9da003e4407087ff1982e8e"
     },
     "nvcomp": {
-      "version": "4.1.0.6",
+      "version": "4.2.0.11",
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
       "git_tag": "v2.2.0",
       "proprietary_binary_cuda_version_mapping": {


### PR DESCRIPTION
## Description
Update to nvcomp 4.2.0.11 which offers better blackwell support

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
