### PR TITLE
Revert CMP0169 before CPM usage to support CMake 3.30

### DIFF
--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2020-2024, NVIDIA CORPORATION.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ function(rapids_cpm_find name version)
 
   if(POLICY CMP0169)
     cmake_policy(PUSH)
-    cmake_policy(SET CMP0169 NEW)
+    cmake_policy(SET CMP0169 OLD)
   endif()
 
   set(options CPM_ARGS)

--- a/rapids-cmake/cpm/find.cmake
+++ b/rapids-cmake/cpm/find.cmake
@@ -147,6 +147,12 @@ modified version is used.
 # cmake-lint: disable=R0912,R0915
 function(rapids_cpm_find name version)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.find")
+
+  if(POLICY CMP0169)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0169 NEW)
+  endif()
+
   set(options CPM_ARGS)
   set(one_value BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(multi_value COMPONENTS GLOBAL_TARGETS)
@@ -225,5 +231,9 @@ function(rapids_cpm_find name version)
   set(${name}_SOURCE_DIR "${${name}_SOURCE_DIR}" PARENT_SCOPE)
   set(${name}_BINARY_DIR "${${name}_BINARY_DIR}" PARENT_SCOPE)
   set(${name}_ADDED "${${name}_ADDED}" PARENT_SCOPE)
+
+if(POLICY CMP0169)
+  cmake_policy(POP)
+endif()
 
 endfunction()


### PR DESCRIPTION

## Description
When a project has specified CMake 3.30 as the minimum required value it forces `CMP0169` to be a hard error.

So when need to mark it as OLD for now while we bump the minimum required CMake version in each RAPIDS project, before removing this when we update our CPM dependency version.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
