### PR TITLE
Sanitize patch inputs so that quotes are properly escaped

### DIFF
--- a/rapids-cmake/cpm/detail/convert_patch_json.cmake
+++ b/rapids-cmake/cpm/detail/convert_patch_json.cmake
@@ -81,6 +81,7 @@ function(rapids_cpm_convert_patch_json)
     # add each line as a json array element
     set(inline_patch [=[ [ ] ]=])
     foreach(line IN LISTS file_content)
+      string(REPLACE "\"" "\\\"" line "${line}")
       string(REPLACE "~&93~" "]" line "${line}")
       string(REPLACE "~&92~" "[" line "${line}")
       string(JSON inline_patch SET "${inline_patch}" ${content_length} "\"${line}\"")

--- a/testing/cpm/cpm_convert_patch_json-special-chars.cmake
+++ b/testing/cpm/cpm_convert_patch_json-special-chars.cmake
@@ -16,18 +16,29 @@
 include(${rapids-cmake-dir}/cpm/detail/convert_patch_json.cmake)
 
 set(bug
-  [=[
+  [=[#include "file.h"
 int function(not_parsed[
 N], properly ) {
 }]=])
-
 set(file_path "${CMAKE_BINARY_DIR}/bug.txt")
 file(WRITE ${file_path} "${bug}" )
 
-rapids_cpm_convert_patch_json(FROM_FILE_TO_JSON json FILE_VAR file_path)
+set(expected_output [==[[
+"#include \"file.h\"",
+"int function(not_parsed[",
+"N], properly ) {",
+"}"
+]]==])
 
-set(expected_output [==[[ "int function(not_parsed[", "N], properly ) {", "}" ]]==])
+rapids_cpm_convert_patch_json(FROM_FILE_TO_JSON json FILE_VAR file_path)
 string(JSON json_content GET "${json}" "content")
-if(NOT (expected_output STREQUAL json_content))
-  message(FATAL_ERROR "exp: `${expected_output}`\ngot: `${json_content}`")
+
+string(JSON content_length LENGTH "${json_content}")
+math(EXPR content_length "${content_length} - 1")
+foreach(index RANGE ${content_length})
+  string(JSON computed_line GET "${json_content}" ${index})
+  string(JSON expected_line GET "${expected_output}" ${index})
+  if(NOT (computed_line STREQUAL expected_line))
+  message(FATAL_ERROR "exp: `${expected_line}`\ngot: `${computed_line}`")
 endif()
+endforeach()


### PR DESCRIPTION
## Description
Previously we failed to escape quotes inside our patches, which would cause lines like `#include "file.h"` to not be properly recorded.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
