### PR TITLE
Update gtest version

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -42,7 +42,7 @@
       "git_tag": "${version}"
     },
     "GTest": {
-      "version": "1.13.0",
+      "version": "1.15.2",
       "git_url": "https://github.com/google/googletest.git",
       "git_tag": "v${version}"
     },

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -42,7 +42,7 @@
       "git_tag": "${version}"
     },
     "GTest": {
-      "version": "1.15.2",
+      "version": "1.16.0",
       "git_url": "https://github.com/google/googletest.git",
       "git_tag": "v${version}"
     },


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The version of gtest that we are using (1.13) is no longer compatible with the version of gtest that is default in conda-forge (1.15.2). The issue is in "private APIs" changing: gtest is intended to be used via its macros, so directly calling some of the functions whose APIs have changed is not supported, but the problem is that the macros produce code using those functions. The second problem is that gtest and gmock mark their includes as isystem when they are built from source, which means that when building inside any environment where gtest is installed to system locations, if that version of gtest has incompatible versions of these APIs we wind up using the headers from the system installation (e.g. conda's) but then we link to our local build, resulting in linker errors. That is the issue that is currently arising. Due to the number of warnings that would surface if we tried to change the `-isystem` to `-I` for gtest, our best option is to just update gtest rather than muck with any of that. Since all of RAPIDS builds a static copy of gtest and avoids bundling it now, it should be safe to upgrade the version now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
