### PR TITLE
Set correct compiler feature for `generate_ctest_json`

### DIFF
--- a/rapids-cmake/test/generate_resource_spec.cmake
+++ b/rapids-cmake/test/generate_resource_spec.cmake
@@ -50,12 +50,14 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
   get_property(rapids_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
   if("CXX" IN_LIST rapids_languages)
     set(rapids_lang CXX)
+    set(rapids_lang_lower cxx)
     # Even when the CUDA language is disabled we want to pass this since it is used by
     # find_package(CUDAToolkit) to find the location
     set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CMAKE_CUDA_COMPILER)
   endif()
   if("CUDA" IN_LIST rapids_languages)
     set(rapids_lang CUDA)
+    set(rapids_lang_lower cuda)
   endif()
 
   if(NOT rapids_lang)
@@ -80,7 +82,7 @@ function(rapids_test_generate_resource_spec DESTINATION filepath)
     set_target_properties(generate_ctest_json
                           PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/rapids-cmake/"
                                      OUTPUT_NAME ${rapids_test_generate_exe_name})
-    target_compile_features(generate_ctest_json PRIVATE cxx_std_17)
+    target_compile_features(generate_ctest_json PRIVATE ${rapids_lang_lower}_std_17)
 
     add_test(NAME generate_resource_spec COMMAND generate_ctest_json "${filepath}")
     set_tests_properties(generate_resource_spec

--- a/testing/test/install_relocatable-complex/tests/CMakeLists.txt
+++ b/testing/test/install_relocatable-complex/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set_tests_properties(
       "STREAM_MODE=new_mode;LD_PRELOAD=$<TARGET_FILE:preload>"
       PASS_REGULAR_EXPRESSION "found a resource file"
   )
+target_compile_features(verify_alloc PRIVATE cuda_std_17)
 
 rapids_test_install_relocatable(INSTALL_COMPONENT_SET testing
                                 DESTINATION bin/testing


### PR DESCRIPTION
## Description
Since https://github.com/rapidsai/shared-workflows/pull/306, we now build and test with CUDA 11.4 and GCC 10, which does not use C++17 by default. To get the CUDA compiler to set C++17, we need to specify `cuda_std_17`. Fix how the compiler feature is set in CMake.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
