### PR TITLE
Backport build patch functionality

### DIFF
--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -239,6 +239,15 @@ as needed.
 
             The default value for this field is ``false``.
 
+        ``build``
+            An optional boolean value that specifies whether or not this patch is a
+            build patch. Build patches only affect the build process, not the runtime
+            functionality or exported headers. If all patches are build patches, the
+            project is not required to be downloaded and can be found with
+            ``find_package()``.
+
+            The default value for this field is ``false``.
+
 ``proprietary_binary``
 
     An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library. This creates a new entry in the search

--- a/rapids-cmake/cpm/bs_thread_pool.cmake
+++ b/rapids-cmake/cpm/bs_thread_pool.cmake
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -68,10 +68,10 @@ function(rapids_cpm_bs_thread_pool)
   rapids_cpm_package_details(bs_thread_pool version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(bs_thread_pool ${version} patch_command)
+  rapids_cpm_generate_patch_command(bs_thread_pool ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(bs_thread_pool ${version} ${ARGN}
+  rapids_cpm_find(bs_thread_pool ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS rapids_bs_thread_pool
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -75,10 +75,10 @@ function(rapids_cpm_cccl)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(CCCL ${version} patch_command)
+  rapids_cpm_generate_patch_command(CCCL ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(CCCL ${version} ${ARGN}
+  rapids_cpm_find(CCCL ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/cuco.cmake
+++ b/rapids-cmake/cpm/cuco.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,10 +72,10 @@ function(rapids_cpm_cuco)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(cuco ${version} patch_command)
+  rapids_cpm_generate_patch_command(cuco ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(cuco ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(cuco ${version} ${_RAPIDS_UNPARSED_ARGUMENTS} ${build_patch_only}
                   GLOBAL_TARGETS cuco::cuco
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/detail/generate_patch_command.cmake
+++ b/rapids-cmake/cpm/detail/generate_patch_command.cmake
@@ -25,11 +25,11 @@ Applies any relevant patches to the provided CPM package
 
 .. code-block:: cmake
 
-  rapids_cpm_generate_patch_command(<pkg> <version> patch_command)
+  rapids_cpm_generate_patch_command(<pkg> <version> patch_command build_patch_only)
 
 #]=======================================================================]
 # cmake-lint: disable=R0915,E1120
-function(rapids_cpm_generate_patch_command package_name version patch_command)
+function(rapids_cpm_generate_patch_command package_name version patch_command build_patch_only)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.generate_patch_command")
 
   include("${rapids-cmake-dir}/cpm/detail/load_preset_versions.cmake")
@@ -78,6 +78,7 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
   set(patch_files_to_run)
   set(patch_issues_to_ref)
   set(patch_required_to_apply)
+  set(${build_patch_only} BUILD_PATCH_ONLY PARENT_SCOPE)
 
   # Gather number of patches
   string(JSON patch_count LENGTH "${json_data}")
@@ -87,15 +88,22 @@ function(rapids_cpm_generate_patch_command package_name version patch_command)
       string(JSON patch_data GET "${json_data}" ${index})
       rapids_cpm_json_get_value(${patch_data} fixed_in)
       if(NOT fixed_in OR version VERSION_LESS fixed_in)
+        set(build)
+
         rapids_cpm_json_get_value(${patch_data} file)
         rapids_cpm_json_get_value(${patch_data} inline_patch)
         rapids_cpm_json_get_value(${patch_data} issue)
+        rapids_cpm_json_get_value(${patch_data} build)
 
         # Convert any embedded patch to a file.
         if(inline_patch)
           include("${rapids-cmake-dir}/cpm/detail/convert_patch_json.cmake")
           rapids_cpm_convert_patch_json(FROM_JSON_TO_FILE inline_patch FILE_VAR file PACKAGE_NAME
                                         ${package_name} INDEX ${index})
+        endif()
+
+        if(NOT build)
+          set(${build_patch_only} PARENT_SCOPE)
         endif()
 
         if(file AND issue)

--- a/rapids-cmake/cpm/fmt.cmake
+++ b/rapids-cmake/cpm/fmt.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@ function(rapids_cpm_fmt)
   rapids_cpm_package_details(fmt version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(fmt ${version} patch_command)
+  rapids_cpm_generate_patch_command(fmt ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(fmt ${version} ${ARGN}
+  rapids_cpm_find(fmt ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS fmt::fmt fmt::fmt-header-only
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,13 +66,13 @@ function(rapids_cpm_gbench)
   rapids_cpm_package_details(benchmark version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(benchmark ${version} patch_command)
+  rapids_cpm_generate_patch_command(benchmark ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(benchmark ${version} ${ARGN}
+  rapids_cpm_find(benchmark ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS benchmark::benchmark benchmark::benchmark_main
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,10 +73,10 @@ function(rapids_cpm_gtest)
   rapids_cpm_package_details(GTest version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(GTest ${version} patch_command)
+  rapids_cpm_generate_patch_command(GTest ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(GTest ${version} ${ARGN}
+  rapids_cpm_find(GTest ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS GTest::gtest GTest::gmock GTest::gtest_main GTest::gmock_main
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS "EXACT"
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -87,10 +87,10 @@ function(rapids_cpm_nvbench)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(nvbench ${version} patch_command)
+  rapids_cpm_generate_patch_command(nvbench ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(nvbench ${version} ${ARGN}
+  rapids_cpm_find(nvbench ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS nvbench::nvbench nvbench::main
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ function(rapids_cpm_nvcomp)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(nvcomp ${version} patch_command)
+  rapids_cpm_generate_patch_command(nvcomp ${version} patch_command build_patch_only)
 
   # Apply any patch commands to the proprietary binary
   if(nvcomp_proprietary_binary AND patch_command)
@@ -187,7 +187,7 @@ function(rapids_cpm_nvcomp)
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(nvcomp ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(nvcomp ${version} ${_RAPIDS_UNPARSED_ARGUMENTS} ${build_patch_only}
                   GLOBAL_TARGETS nvcomp::nvcomp
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,10 +69,10 @@ function(rapids_cpm_nvtx3)
   rapids_cpm_package_details(nvtx3 version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(nvtx3 ${version} patch_command)
+  rapids_cpm_generate_patch_command(nvtx3 ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(nvtx3 ${version} ${ARGN}
+  rapids_cpm_find(nvtx3 ${version} ${ARGN} ${build_patch_only}
                   GLOBAL_TARGETS nvtx3-c nvtx3-cpp
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -135,7 +135,7 @@ function(rapids_cpm_package_override _rapids_override_filepath)
       rapids_cpm_package_details(${package_name} version repository tag shallow exclude)
 
       include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-      rapids_cpm_generate_patch_command(${package_name} ${version} patch_command)
+      rapids_cpm_generate_patch_command(${package_name} ${version} patch_command build_patch_only)
 
       unset(exclude_from_all)
       if(exclude)

--- a/rapids-cmake/cpm/rapids_logger.cmake
+++ b/rapids-cmake/cpm/rapids_logger.cmake
@@ -47,10 +47,10 @@ function(rapids_cpm_rapids_logger)
   rapids_cpm_package_details(rapids_logger version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(rapids_logger ${version} patch_command)
+  rapids_cpm_generate_patch_command(rapids_logger ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(rapids_logger ${version} ${ARGN}
+  rapids_cpm_find(rapids_logger ${version} ${ARGN} ${build_patch_only}
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}
                   GIT_TAG ${tag}

--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -71,10 +71,10 @@ function(rapids_cpm_rmm)
   endif()
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(rmm ${version} patch_command)
+  rapids_cpm_generate_patch_command(rmm ${version} patch_command build_patch_only)
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(rmm ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(rmm ${version} ${ARGN} ${_RAPIDS_UNPARSED_ARGUMENTS} ${build_patch_only}
                   GLOBAL_TARGETS rmm::rmm rmm::rmm_logger rmm::rmm_logger_impl
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ function(rapids_cpm_spdlog)
   rapids_cpm_package_details(spdlog version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(spdlog ${version} patch_command)
+  rapids_cpm_generate_patch_command(spdlog ${version} patch_command build_patch_only)
 
   # If the option wasn't passed to the command, default to header only fmt
   if(NOT _RAPIDS_FMT_OPTION)
@@ -124,7 +124,7 @@ function(rapids_cpm_spdlog)
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(spdlog ${version} ${_RAPIDS_UNPARSED_ARGUMENTS}
+  rapids_cpm_find(spdlog ${version} ${_RAPIDS_UNPARSED_ARGUMENTS} ${build_patch_only}
                   GLOBAL_TARGETS spdlog::spdlog spdlog::spdlog_header_only
                   CPM_ARGS
                   GIT_REPOSITORY ${repository}

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -21,6 +21,7 @@ set(RAPIDS_TEST_DISABLE_DEV_ERRORS ON)
 
 add_cmake_config_test( cpm_find-add-pkg-source )
 add_cmake_config_test( cpm_find-and-find_package )
+add_cmake_config_test( cpm_find-build-patch )
 add_cmake_config_test( cpm_find-components )
 add_cmake_config_test( cpm_find-existing-build-dir )
 add_cmake_config_test( cpm_find-existing-target )
@@ -76,6 +77,7 @@ add_cmake_config_test( cpm_generate_patch_command-override-case-insensitive.cmak
 add_cmake_config_test( cpm_generate_patch_command-override.cmake )
 add_cmake_config_test( cpm_generate_patch_command-current_json_dir.cmake )
 add_cmake_config_test( cpm_generate_patch_command-verify-copyright-header.cmake )
+add_cmake_config_test( cpm_generate_patch_command-build.cmake )
 
 add_cmake_config_test( cpm_bs_thread_pool-simple.cmake )
 add_cmake_config_test( cpm_bs_thread_pool-export.cmake )

--- a/testing/cpm/cpm_find-build-patch/CMakeLists.txt
+++ b/testing/cpm/cpm_find-build-patch/CMakeLists.txt
@@ -1,0 +1,41 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.30.4)
+project(rapids-cpm_find-build-patch-project LANGUAGES CXX)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/modules)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+rapids_cpm_init()
+
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+rapids_cpm_package_override(${CMAKE_CURRENT_SOURCE_DIR}/override.json)
+
+include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
+rapids_cpm_generate_patch_command(test_pkg 1.0 patch_command build_patch_only)
+if(NOT patch_command)
+  message(FATAL_ERROR "rapids_cpm_generate_patch_command() did not return a patch command")
+endif()
+if(NOT build_patch_only STREQUAL "BUILD_PATCH_ONLY")
+  message(FATAL_ERROR "rapids_cpm_generate_patch_command() did not return BUILD_PATCH_ONLY")
+endif()
+
+include(${rapids-cmake-dir}/cpm/find.cmake)
+rapids_cpm_find(test_pkg 1.0 ${build_patch_only} CPM_ARGS ${patch_command})
+
+if(NOT TARGET test_pkg::lib)
+  message(FATAL_ERROR "test_pkg was not found by our find-module")
+endif()

--- a/testing/cpm/cpm_find-build-patch/modules/Findtest_pkg.cmake
+++ b/testing/cpm/cpm_find-build-patch/modules/Findtest_pkg.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-include(${rapids-cmake-dir}/cpm/init.cmake)
-include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
-
-rapids_cpm_generate_patch_command(not_a_project 1 patch_command build_patch_only)
-if(patch_command)
-  message(FATAL_ERROR "not_a_project should not have a patch command")
-endif()
-
-rapids_cpm_init()
-rapids_cpm_generate_patch_command(not_a_project 1 patch_command build_patch_only)
-if(patch_command)
-  message(FATAL_ERROR "not_a_project should not have a patch command")
-endif()
+add_library(test_pkg::lib IMPORTED INTERFACE)
+set(test_pkg_FOUND TRUE)

--- a/testing/cpm/cpm_find-build-patch/override.json
+++ b/testing/cpm/cpm_find-build-patch/override.json
@@ -1,0 +1,17 @@
+{
+  "packages": {
+    "test_pkg": {
+      "version": "1.0",
+      "git_url": "a_url",
+      "git_tag": "a_tag",
+      "patches": [
+        {
+          "file": "${current_json_dir}/example.diff",
+          "issue": "explain",
+          "fixed_in": "",
+          "build": true
+        }
+      ]
+    }
+  }
+}

--- a/testing/cpm/cpm_generate_patch_command-build.cmake
+++ b/testing/cpm/cpm_generate_patch_command-build.cmake
@@ -1,0 +1,79 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.30.4)
+project(rapids-cpm_find-patch-command-project LANGUAGES CXX)
+
+
+# Need to write out an override file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+  [=[
+{
+  "packages": {
+    "pkg_with_non_build_patch": {
+      "version": "10.2",
+      "git_url": "a_url",
+      "git_tag": "a_tag",
+      "patches": [
+        {
+          "file": "${current_json_dir}/example.diff",
+          "issue": "explain",
+          "fixed_in": "",
+          "build": true
+        },
+        {
+          "file": "${current_json_dir}/example2.diff",
+          "issue": "explain",
+          "fixed_in": ""
+        }
+      ]
+    },
+    "pkg_with_only_build_patches": {
+      "version": "10.2",
+      "git_url": "a_url",
+      "git_tag": "a_tag",
+      "patches": [
+        {
+          "file": "${current_json_dir}/example.diff",
+          "issue": "explain",
+          "fixed_in": "",
+          "build": true
+        },
+        {
+          "file": "${current_json_dir}/example2.diff",
+          "issue": "explain",
+          "fixed_in": "",
+          "build": true
+        }
+      ]
+    }
+  }
+}
+  ]=])
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+rapids_cpm_init(OVERRIDE ${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
+
+rapids_cpm_generate_patch_command(pkg_with_only_build_patches 10.2 patch_command build_patch_only)
+if(NOT build_patch_only STREQUAL "BUILD_PATCH_ONLY")
+  message(FATAL_ERROR "rapids_cpm_generate_patch_command generated wrong arguments for pkg_with_only_build_patches")
+endif()
+
+rapids_cpm_generate_patch_command(pkg_with_non_build_patch 10.2 patch_command build_patch_only)
+if(DEFINED build_patch_only)
+  message(FATAL_ERROR "rapids_cpm_generate_patch_command generated wrong arguments for pkg_with_non_build_patch")
+endif()

--- a/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
+++ b/testing/cpm/cpm_generate_patch_command-current_json_dir.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ include(${rapids-cmake-dir}/cpm/package_override.cmake)
 include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
 
 rapids_cpm_init()
-rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command build_patch_only)
 if(patch_command)
   message(FATAL_ERROR "pkg_with_patch doesn't have override yet, patch_command should be empty")
 endif()
@@ -52,7 +52,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   ]=])
 rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 
-rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command build_patch_only)
 if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
 endif()

--- a/testing/cpm/cpm_generate_patch_command-override-case-insensitive.cmake
+++ b/testing/cpm/cpm_generate_patch_command-override-case-insensitive.cmake
@@ -42,7 +42,7 @@ include(${rapids-cmake-dir}/cpm/init.cmake)
 rapids_cpm_init(OVERRIDE ${CMAKE_CURRENT_BINARY_DIR}/override.json)
 
 include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-rapids_cpm_generate_patch_command(GTest ${version} patch_command)
+rapids_cpm_generate_patch_command(GTest ${version} patch_command build_patch_only)
 message(STATUS "patch_command: ${patch_command}")
 if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override failed to load patch step for `GTest` from package `gtest`")

--- a/testing/cpm/cpm_generate_patch_command-override.cmake
+++ b/testing/cpm/cpm_generate_patch_command-override.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ include(${rapids-cmake-dir}/cpm/package_override.cmake)
 include(${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake)
 
 rapids_cpm_init()
-rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command build_patch_only)
 if(patch_command)
   message(FATAL_ERROR "pkg_with_patch doesn't have override yet, patch_command should be empty")
 endif()
@@ -61,13 +61,13 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   ]=])
 rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 
-rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command build_patch_only)
 if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
 endif()
 
 unset(patch_command)
-rapids_cpm_generate_patch_command(pkg_patch_not_applied 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_patch_not_applied 10.2 patch_command build_patch_only)
 if(patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override patch step for `pkg_patch_not_applied` shouldn't apply due to version values")
 endif()

--- a/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
+++ b/testing/cpm/cpm_generate_patch_command-verify-copyright-header.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
   ]=])
 rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
 
-rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command)
+rapids_cpm_generate_patch_command(pkg_with_patch 10.2 patch_command build_patch_only)
 if(NOT patch_command)
   message(FATAL_ERROR "rapids_cpm_package_override specified a patch step for `pkg_with_patch`")
 endif()

--- a/testing/cpm/cpm_package_override-empty-patches.cmake
+++ b/testing/cpm/cpm_package_override-empty-patches.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,13 +43,13 @@ include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
 include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
 
 rapids_cpm_package_details(rmm version repository tag shallow exclude)
-rapids_cpm_generate_patch_command(rmm ${version} patch_command)
+rapids_cpm_generate_patch_command(rmm ${version} patch_command build_patch_only)
 if(patch_command)
   message(FATAL_ERROR "no patch command expected for rmm")
 endif()
 
 rapids_cpm_package_details(CCCL version repository tag shallow exclude)
-rapids_cpm_generate_patch_command(CCCL ${version} patch_command)
+rapids_cpm_generate_patch_command(CCCL ${version} patch_command build_patch_only)
 if(patch_command)
   message(FATAL_ERROR "no patch command expected for cccl")
 endif()


### PR DESCRIPTION
## Description
This will allow us to easily deal with patching issues in cuspatial.

Backport of #801

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
