### PR TITLE
Demonstrate issue with NVTX3 export

### DIFF
--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -130,6 +130,7 @@ add_cmake_build_test( cpm_nvtx-build-config-works.cmake )
 add_cmake_build_test( cpm_nvtx-install-config-works.cmake )
 add_cmake_config_test( cpm_nvtx-export.cmake )
 add_cmake_config_test( cpm_nvtx-simple.cmake )
+add_cmake_build_test( cpm_nvtx-build-config-subdir )
 
 add_cmake_config_test( cpm_proprietary-url-ctk-version-find-ctk.cmake )
 add_cmake_config_test( cpm_proprietary-url-ctk-version.cmake )

--- a/testing/cpm/cpm_nvtx-build-config-subdir/CMakeLists.txt
+++ b/testing/cpm/cpm_nvtx-build-config-subdir/CMakeLists.txt
@@ -1,0 +1,43 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+cmake_minimum_required(VERSION 3.30.4)
+project(cpm_nvtx-build-config-subdir)
+
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/nvtx3.cmake)
+
+rapids_cpm_init()
+
+add_subdirectory(subdir1)
+add_subdirectory(subdir2)
+
+# Add a custom command that verifies that we can use targets that link to nvtx3
+file(WRITE "${CMAKE_BINARY_DIR}/check_uses_nvtx_dir/CMakeLists.txt" "
+cmake_minimum_required(VERSION 3.30.4)
+project(verify_nvtx LANGUAGES CXX)
+
+set(CMAKE_PREFIX_PATH \"${CMAKE_BINARY_DIR}/\")
+find_package(uses-nvtx3 REQUIRED)
+
+file(WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/stub.cpp\" \" \")
+add_library(uses_nvtx SHARED stub.cpp)
+target_link_libraries(uses_nvtx PRIVATE uses-nvtx3::uses-nvtx3-cpp)
+")
+
+add_custom_target(verify_build_config ALL
+  COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/check_uses_nvtx_dir/build"
+  COMMAND ${CMAKE_COMMAND} -S="${CMAKE_BINARY_DIR}/check_uses_nvtx_dir" -B="${CMAKE_BINARY_DIR}/check_uses_nvtx_dir/build"
+)

--- a/testing/cpm/cpm_nvtx-build-config-subdir/CMakeLists.txt
+++ b/testing/cpm/cpm_nvtx-build-config-subdir/CMakeLists.txt
@@ -21,7 +21,9 @@ include(${rapids-cmake-dir}/cpm/nvtx3.cmake)
 
 rapids_cpm_init()
 
+# Commenting out this add_subdirectory() causes the test to pass
 add_subdirectory(subdir1)
+
 add_subdirectory(subdir2)
 
 # Add a custom command that verifies that we can use targets that link to nvtx3

--- a/testing/cpm/cpm_nvtx-build-config-subdir/subdir1/CMakeLists.txt
+++ b/testing/cpm/cpm_nvtx-build-config-subdir/subdir1/CMakeLists.txt
@@ -1,0 +1,19 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+project(subdir1)
+
+rapids_cpm_nvtx3(BUILD_EXPORT_SET other-exports)

--- a/testing/cpm/cpm_nvtx-build-config-subdir/subdir2/CMakeLists.txt
+++ b/testing/cpm/cpm_nvtx-build-config-subdir/subdir2/CMakeLists.txt
@@ -1,0 +1,28 @@
+#=============================================================================
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+rapids_cpm_nvtx3(BUILD_EXPORT_SET uses-nvtx3-exports)
+
+add_library(uses-nvtx3-cpp INTERFACE)
+target_link_libraries(uses-nvtx3-cpp INTERFACE nvtx3::nvtx3-cpp)
+install(TARGETS uses-nvtx3-cpp EXPORT uses-nvtx3-exports)
+
+rapids_export(
+  BUILD uses-nvtx3
+  EXPORT_SET uses-nvtx3-exports
+  GLOBAL_TARGETS uses-nvtx3-cpp
+  NAMESPACE uses-nvtx3::
+)


### PR DESCRIPTION
## Description
When NVTX3 is added from a subproject (usually from CPM), it causes issues for other parts of the project that rely on it. Demonstrate with a minimum reproducer.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
