### PR TITLE
Disable git_shallow for nvtx3 and bs_thread_pool

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -67,6 +67,7 @@
     },
     "nvtx3": {
       "version": "3.1.0",
+      "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/NVTX.git",
       "git_tag": "4808eeda29bb6dcfd38291d1a8ea280b48562c57"
     },

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -7,6 +7,7 @@
     },
     "bs_thread_pool": {
       "version": "4.1.0",
+      "git_shallow": false,
       "git_url": "https://github.com/bshoshany/thread-pool.git",
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
We are specifying a hash rather than a branch or tag, [which requires a non-shallow clone in CMake](https://cmake.org/cmake/help/latest/module/ExternalProject.html#git).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
