### PR TITLE
Use hashes instead of tags

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -2,8 +2,9 @@
   "packages": {
     "benchmark": {
       "version": "1.8.0",
+      "git_shallow": false,
       "git_url": "https://github.com/google/benchmark.git",
-      "git_tag": "v${version}"
+      "git_tag": "2dd015dfef425c866d9a43f2c67d8b52d709acb6"
     },
     "bs_thread_pool": {
       "version": "4.1.0",
@@ -14,7 +15,7 @@
       "version": "2.7.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "v${version}",
+      "git_tag": "b5fe509fd11a925f90d6495176707cc1184eed9d",
       "patches": [
         {
           "file": "cccl/backport-suppress-execution-checks.patch",
@@ -38,13 +39,15 @@
     },
     "fmt": {
       "version": "11.0.2",
+      "git_shallow": false,
       "git_url": "https://github.com/fmtlib/fmt.git",
-      "git_tag": "${version}"
+      "git_tag": "0c9fce2ffefecfdce794e1859584e25877b7b592"
     },
     "GTest": {
       "version": "1.16.0",
+      "git_shallow": false,
       "git_url": "https://github.com/google/googletest.git",
-      "git_tag": "v${version}"
+      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5"
     },
     "nvbench": {
       "version": "0.0",
@@ -54,8 +57,9 @@
     },
     "nvcomp": {
       "version": "4.2.0.11",
+      "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
-      "git_tag": "v2.2.0",
+      "git_tag": "a6e4e64a177e07cd2e5c8c5e07bb66ffefceae84",
       "proprietary_binary_cuda_version_mapping": {
         "11": "11",
         "12": "12"
@@ -77,8 +81,9 @@
     },
     "spdlog": {
       "version": "1.14.1",
+      "git_shallow": false,
       "git_url": "https://github.com/gabime/spdlog.git",
-      "git_tag": "v${version}"
+      "git_tag": "27cb4c76708608465c413f6d0e6b8d99a4d84302"
     }
   }
 }

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "git_tag": "my_tag"
     },
     "GTest": {
-      "version": "2.99"
+      "version": "2.99",
+      "git_tag": "v${version}"
     }
   }
 }

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -26,7 +26,32 @@ function(expect_fetch_content_details project expected)
   endif()
 endfunction()
 
-rapids_cpm_init()
+# Need to write out a default file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/default.json
+  [=[
+{
+  "packages": {
+    "nvbench": {
+      "version": "0.0",
+      "git_shallow": false,
+      "git_url": "https://github.com/NVIDIA/nvbench.git",
+      "git_tag": "555d628e9b250868c9da003e4407087ff1982e8e"
+    },
+    "rmm": {
+      "version": "${rapids-cmake-version}",
+      "git_url": "https://github.com/rapidsai/rmm.git",
+      "git_tag": "branch-${version}"
+    },
+    "GTest": {
+      "version": "1.16.0",
+      "git_url": "https://github.com/google/googletest.git",
+      "git_tag": "v${version}"
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/default.json")
 
 # Load the default values for nvbench and GTest projects
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
@@ -51,14 +76,13 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "git_tag": "my_tag"
     },
     "GTest": {
-      "version": "2.99",
-      "git_tag": "v${version}"
+      "version": "2.99"
     }
   }
 }
   ]=])
 
-rapids_cpm_init(OVERRIDE "${CMAKE_CURRENT_BINARY_DIR}/override.json")
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/default.json" OVERRIDE "${CMAKE_CURRENT_BINARY_DIR}/override.json")
 expect_fetch_content_details(nvbench YES)
 expect_fetch_content_details(rmm YES)
 expect_fetch_content_details(GTest YES)

--- a/testing/cpm/cpm_package_override-defaults-with-different-casing.cmake
+++ b/testing/cpm/cpm_package_override-defaults-with-different-casing.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "exclude_from_all": "ON"
     },
     "gtest": {
-      "version": "3.00.A1"
+      "version": "3.00.A1",
+      "git_tag": "v${version}"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-defaults-with-different-casing.cmake
+++ b/testing/cpm/cpm_package_override-defaults-with-different-casing.cmake
@@ -17,7 +17,26 @@
 include(${rapids-cmake-dir}/cpm/init.cmake)
 include(${rapids-cmake-dir}/cpm/package_override.cmake)
 
-rapids_cpm_init()
+# Need to write out a default file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/default.json
+  [=[
+{
+  "packages": {
+    "rmm": {
+      "version": "${rapids-cmake-version}",
+      "git_url": "https://github.com/rapidsai/rmm.git",
+      "git_tag": "branch-${version}"
+    },
+    "GTest": {
+      "version": "1.16.0",
+      "git_url": "https://github.com/google/googletest.git",
+      "git_tag": "v${version}"
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/default.json")
 
 # Need to write out an override file
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
@@ -30,8 +49,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "exclude_from_all": "ON"
     },
     "gtest": {
-      "version": "3.00.A1",
-      "git_tag": "v${version}"
+      "version": "3.00.A1"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-multiple-cmake-var.cmake
+++ b/testing/cpm/cpm_package_override-multiple-cmake-var.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override1.json
       "git_tag": "my_tag"
     },
     "gtest": {
-      "version": "2.99"
+      "version": "2.99",
+      "git_tag": "v${version}"
     }
   }
 }
@@ -39,7 +40,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override2.json
       "git_tag": "new_rmm_tag"
     },
     "GTest": {
-      "version": "3.99"
+      "version": "3.99",
+      "git_tag": "v${version}"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-multiple.cmake
+++ b/testing/cpm/cpm_package_override-multiple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override1.json
       "git_tag": "my_tag"
     },
     "GTest": {
-      "version": "2.99"
+      "version": "2.99",
+      "git_tag": "v${version}"
     }
   }
 }
@@ -47,7 +48,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override2.json
       "git_tag": "new_rmm_tag"
     },
     "GTest": {
-      "version": "3.99"
+      "version": "3.99",
+      "git_tag": "v${version}"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-simple.cmake
+++ b/testing/cpm/cpm_package_override-simple.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "exclude_from_all": "ON"
     },
     "GTest": {
-      "version": "3.00.A1"
+      "version": "3.00.A1",
+      "git_tag": "v${version}"
     }
   }
 }

--- a/testing/cpm/cpm_package_override-simple.cmake
+++ b/testing/cpm/cpm_package_override-simple.cmake
@@ -16,7 +16,26 @@
 include(${rapids-cmake-dir}/cpm/init.cmake)
 include(${rapids-cmake-dir}/cpm/package_override.cmake)
 
-rapids_cpm_init()
+# Need to write out a default file
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/default.json
+  [=[
+{
+  "packages": {
+    "rmm": {
+      "version": "${rapids-cmake-version}",
+      "git_url": "https://github.com/rapidsai/rmm.git",
+      "git_tag": "branch-${version}"
+    },
+    "GTest": {
+      "version": "1.16.0",
+      "git_url": "https://github.com/google/googletest.git",
+      "git_tag": "v${version}"
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/default.json")
 
 # Need to write out an override file
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
@@ -29,8 +48,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "exclude_from_all": "ON"
     },
     "GTest": {
-      "version": "3.00.A1",
-      "git_tag": "v${version}"
+      "version": "3.00.A1"
     }
   }
 }

--- a/testing/cpm/verify_generated_pins/CMakeLists.txt
+++ b/testing/cpm/verify_generated_pins/CMakeLists.txt
@@ -45,7 +45,9 @@ endmacro()
 foreach(proj IN LISTS projects-to-verify)
   # Verify that each git_tag is now different.
   rapids_cpm_package_details(${proj} ${proj}_version ${proj}_repository pin_${proj}_tag pin_${proj}_shallow ${proj}_exclude)
-  if(pin_${proj}_tag STREQUAL ${proj}_tag)
+  # 160 bits for SHA-1, 256 bits for SHA-256
+  string(LENGTH "${${proj}_tag}" tag_length)
+  if(pin_${proj}_tag STREQUAL ${proj}_tag AND NOT (${proj}_tag MATCHES "^[0-9a-f]+$" AND (tag_length EQUAL 40 OR tag_length EQUAL 64)))
     _get_json_data()
     message(FATAL_ERROR "pinned ${proj} tag (${pin_${proj}_tag}) should differ compared to baseline ${${proj}_tag}\npinned_versions.json:\n${pinned_versions}\nversions.json:\n${default_versions}")
   endif()


### PR DESCRIPTION
## Description
Tags are mutable and can be replaced with malicious code. Replace them with the hash that the tag points to at the time of this PR.

Each hash was found by doing:

```
curl https://api.github.com/repos/$OWNER/$REPO/tags | jq -r '.[] | select(.name == "$TAG") | .commit.sha'
```

nvtx and bs_thread_pool are separately covered by https://github.com/rapidsai/rapids-cmake/pull/811.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
