### PR TITLE
Add `include_guard(GLOBAL)` to download_with_retry.cmake

### DIFF
--- a/rapids-cmake/cmake/download_with_retry.cmake
+++ b/rapids-cmake/cmake/download_with_retry.cmake
@@ -2,6 +2,7 @@
 # Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 #=============================================================================
+include_guard(GLOBAL)
 
 #[=======================================================================[.rst:
 rapids_cmake_download_with_retry

--- a/rapids-cmake/export/write_dependencies.cmake
+++ b/rapids-cmake/export/write_dependencies.cmake
@@ -77,9 +77,12 @@ function(rapids_export_write_dependencies type export_set file_path)
     # Include download_with_retry.cmake in the exported dependencies first
     file(READ "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../cmake/download_with_retry.cmake"
          download_with_retry_logic)
+    string(REPLACE "include_guard(GLOBAL)\n" "" download_with_retry_logic
+                   "${download_with_retry_logic}")
     string(APPEND _RAPIDS_EXPORT_CONTENTS ${download_with_retry_logic})
 
     file(READ "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../cpm/detail/download.cmake" cpm_logic)
+    string(REPLACE "include_guard(GLOBAL)\n" "" cpm_logic "${cpm_logic}")
     string(APPEND _RAPIDS_EXPORT_CONTENTS ${cpm_logic})
     string(APPEND _RAPIDS_EXPORT_CONTENTS "rapids_cpm_download()\n\n")
 


### PR DESCRIPTION
## Description
And strip the include guard from download_with_retry.cmake and download.cmake when writing them to the export file.

Follow-up to https://github.com/rapidsai/rapids-cmake/pull/809

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
