### PR TITLE
Update cuCollections to avoid deprecated Thrust features

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -30,7 +30,7 @@
       "git_shallow": false,
       "always_download": true,
       "git_url": "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag": "7b422c00f3541e2472e8d1047b7c3bb4e83c7e2c"
+      "git_tag": "2303a7a2a03e38385dbe1bbc91c55007a94a9192"
     },
     "rapids_logger": {
       "version": "0.1.0",


### PR DESCRIPTION
## Description
Updates cuCollections to get changes from https://github.com/NVIDIA/cuCollections/commit/2303a7a2a03e38385dbe1bbc91c55007a94a9192.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
