### PR TITLE
Temporarily use patched CCCL

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,10 +13,10 @@
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },
     "CCCL": {
-      "version": "3.1.0",
+      "version": "3.0.0",
       "git_shallow": false,
-      "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "549dd45947fac512a808ca8885f2e386b01d25d8"
+      "git_url": "https://github.com/bdice/cccl.git",
+      "git_tag": "ef03faba6d6498b6c08eca6bd16abc96910abb04"
     },
     "cuco": {
       "version": "0.0.1",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,10 +13,10 @@
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },
     "CCCL": {
-      "version": "3.0.0",
+      "version": "3.1.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "e9909935ea1e877822d39a37a340d0e8f4bf0bc5"
+      "git_tag": "549dd45947fac512a808ca8885f2e386b01d25d8"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This pins to a commit of CCCL with a fix for https://github.com/NVIDIA/cccl/pull/4054.

xref: https://github.com/NVIDIA/cccl/pull/4622

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
