### PR TITLE
Unset CUDAARCHS in test

### DIFF
--- a/testing/cuda/init_arch-all-via-undef/CMakeLists.txt
+++ b/testing/cuda/init_arch-all-via-undef/CMakeLists.txt
@@ -18,6 +18,7 @@ include(${rapids-cmake-dir}/cuda/init_architectures.cmake)
 cmake_minimum_required(VERSION 3.30.4)
 
 unset(CMAKE_CUDA_ARCHITECTURES)
+unset(ENV{CUDAARCHS})
 
 rapids_cuda_init_architectures(rapids-project)
 project(rapids-project LANGUAGES CUDA)


### PR DESCRIPTION
## Description
Due to
https://github.com/conda-forge/cuda-nvcc-feedstock/commit/18f55c57bd6e62179dec30beb16cde89c11d0e2f, we can now expect CUDAARCHS to be present in the test environment. Unset it when needed for the test.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
