### PR TITLE
Upgrade cuco version to include murmurhash performance fix

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -23,7 +23,7 @@
       "git_shallow": false,
       "always_download": true,
       "git_url": "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag": "2303a7a2a03e38385dbe1bbc91c55007a94a9192"
+      "git_tag": "65ca4875faaf42707a499d767388c154da68411a"
     },
     "rapids_logger": {
       "version": "0.1.0",


### PR DESCRIPTION
## Description
This PR upgrades the cuco version to incorporate a performance improvement related to MurmurHash: https://github.com/NVIDIA/cuCollections/pull/701. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
