### PR TITLE
Get newer CCCL 2.8 with fix for atomics.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "version": "2.8.3",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "8d1f64e72382f10613ffccd04abeae69d73be4a0"
+      "git_tag": "643933a5e4bdb8fa1302da52c8530d4576d92134"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This updates rapids-cmake to get https://github.com/NVIDIA/cccl/pull/4616, which was backported to `branch/2.8.x`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
