### PR TITLE
Update to CCCL 2.8.4.

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,10 +13,10 @@
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },
     "CCCL": {
-      "version": "2.8.3",
+      "version": "2.8.4",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "643933a5e4bdb8fa1302da52c8530d4576d92134"
+      "git_tag": "e80fa6c8c53c1d868b46571f3335c3964a63e816"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This updates to CCCL 2.8.4. No downstream testing is needed, as this is identical to the previously pinned commit hash aside from the version number. The 2.8.4 tag was made specifically for RAPIDS, so we should use it.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
