### PR TITLE
Update to clang 20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: pretty-format-json
         args: ["--autofix", "--no-sort-keys"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v20.1.4
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]

--- a/rapids-cmake/test/detail/generate_resource_spec.cpp
+++ b/rapids-cmake/test/detail/generate_resource_spec.cpp
@@ -31,7 +31,7 @@ struct version {
 };
 
 struct gpu {
-  gpu(int i) : id(i), memory(0), slots(0){};
+  gpu(int i) : id(i), memory(0), slots(0) {};
   gpu(int i, size_t mem) : id(i), memory(mem), slots(100) {}
   int id;
   size_t memory;


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/177

This PR updates the clang version to 20.
