### PR TITLE
Deprecate fmt and spdlog

### DIFF
--- a/rapids-cmake/cpm/fmt.cmake
+++ b/rapids-cmake/cpm/fmt.cmake
@@ -50,6 +50,10 @@ Result Variables
 #]=======================================================================]
 function(rapids_cpm_fmt)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.fmt")
+  rapids_cmake_policy(DEPRECATED_IN 25.08
+                      REMOVED_IN 26.04
+                      MESSAGE [=[`rapids_cpm_fmt` is deprecated. If you need to fetch fmt, please use rapids_cpm_find directly.]=]
+  )
 
   set(to_install OFF)
   if(INSTALL_EXPORT_SET IN_LIST ARGN)

--- a/rapids-cmake/cpm/spdlog.cmake
+++ b/rapids-cmake/cpm/spdlog.cmake
@@ -67,6 +67,10 @@ Result Variables
 #]=======================================================================]
 function(rapids_cpm_spdlog)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.spdlog")
+  rapids_cmake_policy(DEPRECATED_IN 25.08
+                      REMOVED_IN 26.04
+                      MESSAGE [=[`rapids_cpm_spdlog` is deprecated. If you need to fetch spdlog, please use rapids_cpm_find directly.]=]
+  )
 
   set(options)
   set(one_value FMT_OPTION BUILD_EXPORT_SET INSTALL_EXPORT_SET)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Resolves #813 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
