### PR TITLE
Fetch the atomic fix in CCCL 3.0

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "version": "3.0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "54925a37f8bec3a83ea60a4a834b96c30918711f"
+      "git_tag": "dc1db8aefcfe52c66c26c6038fef58da37a46ae9"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This follow-up PR to #854 includes the bug fixes for device atomics.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
