### PR TITLE
Use RMM main (new branching strategy) to fix downstream fetching issues

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -72,7 +72,7 @@
     "rmm": {
       "version": "${rapids-cmake-version}",
       "git_url": "https://github.com/rapidsai/rmm.git",
-      "git_tag": "branch-${version}"
+      "git_tag": "main"
     },
     "spdlog": {
       "version": "1.14.1",


### PR DESCRIPTION
## Description
RMM just switched to a new branching strategy (see https://docs.rapids.ai/notices/rsn0047/).

This changes the branch to `main` to keep RMM fetches working in rapids-cmake.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
