### PR TITLE
Revert "Use RMM main (new branching strategy)"

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -72,7 +72,7 @@
     "rmm": {
       "version": "${rapids-cmake-version}",
       "git_url": "https://github.com/rapidsai/rmm.git",
-      "git_tag": "main"
+      "git_tag": "branch-${version}"
     },
     "spdlog": {
       "version": "1.14.1",


### PR DESCRIPTION
## Description
This reverts commit fde70e1a40ceb8e32088dae75c7e131ffa48c695.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
