### PR TITLE
chore: update docker version tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       arch: "amd64"
       branch: ${{ inputs.branch }}
       build_type: ${{ inputs.build_type || 'branch' }}
-      container_image: "rapidsai/ci-conda:25.08-latest"
+      container_image: "rapidsai/ci-conda:25.10-latest"
       date: ${{ inputs.date }}
       node_type: "cpu4"
       script: "ci/build_docs.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,7 +48,7 @@ jobs:
       build_type: pull-request
       node_type: "cpu4"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:25.08-latest"
+      container_image: "rapidsai/ci-conda:25.10-latest"
       script: "ci/build_docs.sh"
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.


### PR DESCRIPTION
## Description

The 25.10 branch was created just before my docker tag update PR landed. So the
`update-version.sh` script was updated, but the newly forward-merged docker
tags are incorrect.  Fixing them up here.
