### PR TITLE
CCCL: disable PDL

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -116,9 +116,17 @@ function(rapids_cpm_cccl)
   endif()
 
   if(TARGET CCCL::CCCL)
+    target_compile_definitions(CCCL::CCCL INTERFACE CUB_DISABLE_NAMESPACE_MAGIC)
+    target_compile_definitions(CCCL::CCCL INTERFACE CUB_IGNORE_NAMESPACE_MAGIC_ERROR)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
     target_compile_definitions(CCCL::CCCL INTERFACE CCCL_DISABLE_PDL)
     set(post_find_code
         [=[
+    target_compile_definitions(CCCL::CCCL INTERFACE CUB_DISABLE_NAMESPACE_MAGIC)
+    target_compile_definitions(CCCL::CCCL INTERFACE CUB_IGNORE_NAMESPACE_MAGIC_ERROR)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
+    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
     target_compile_definitions(CCCL::CCCL INTERFACE CCCL_DISABLE_PDL)
     ]=])
     include("${rapids-cmake-dir}/export/detail/post_find_package_code.cmake")

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -116,18 +116,10 @@ function(rapids_cpm_cccl)
   endif()
 
   if(TARGET CCCL::CCCL)
-    # Can be removed once we move to CCCL 2.3
-    #
-    target_compile_definitions(CCCL::CCCL INTERFACE CUB_DISABLE_NAMESPACE_MAGIC)
-    target_compile_definitions(CCCL::CCCL INTERFACE CUB_IGNORE_NAMESPACE_MAGIC_ERROR)
-    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
-    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
+    target_compile_definitions(CCCL::CCCL INTERFACE CCCL_DISABLE_PDL)
     set(post_find_code
         [=[
-    target_compile_definitions(CCCL::CCCL INTERFACE CUB_DISABLE_NAMESPACE_MAGIC)
-    target_compile_definitions(CCCL::CCCL INTERFACE CUB_IGNORE_NAMESPACE_MAGIC_ERROR)
-    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_DISABLE_ABI_NAMESPACE)
-    target_compile_definitions(CCCL::CCCL INTERFACE THRUST_IGNORE_ABI_NAMESPACE_ERROR)
+    target_compile_definitions(CCCL::CCCL INTERFACE CCCL_DISABLE_PDL)
     ]=])
     include("${rapids-cmake-dir}/export/detail/post_find_package_code.cmake")
     rapids_export_post_find_package_code(BUILD CCCL "${post_find_code}" EXPORT_SET

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "version": "3.0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "dc1db8aefcfe52c66c26c6038fef58da37a46ae9"
+      "git_tag": "c444d5240d58c8ec0a85099055908068da55f52b"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This disables CCCL features using PDL. Spark-RAPIDS has reported some errors with PDL enabled.

This should use a tag once https://github.com/NVIDIA/cccl/pull/5330 is merged and released.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
