### PR TITLE
Update to CCCL v3.0.2

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "version": "3.0.2",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "v3.0.2"
+      "git_tag": "9c40ed11560fa8ffd21abe4cdc8dc3ce875e48e3"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
Follow-up to #876. Before merging, ensure that https://github.com/NVIDIA/cccl/pull/5330 is merged and tagged in v3.0.2.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
