### PR TITLE
Update CCCL version tag for PDL disable

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -16,7 +16,7 @@
       "version": "3.0.0",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "c444d5240d58c8ec0a85099055908068da55f52b"
+      "git_tag": "a1c47643a941eb3b13128f96afd4a050e824acf2"
     },
     "cuco": {
       "version": "0.0.1",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,7 +13,7 @@
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },
     "CCCL": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
       "git_tag": "a1c47643a941eb3b13128f96afd4a050e824acf2"


### PR DESCRIPTION
## Description
Update to new CCCL tag for PDL disable
Correction to #876 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
