### PR TITLE
Update RAPIDS_BRANCH to 25.10

### DIFF
--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-branch-25.08
+branch-25.10


### PR DESCRIPTION
## Description
Since 25.10 was opened before the introduction of RAPIDS_BRANCH it had the incorrect value.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
