### PR TITLE
Update RAPIDS.cmake to match new logic in other projects

### DIFF
--- a/RAPIDS.cmake
+++ b/RAPIDS.cmake
@@ -20,8 +20,8 @@
 cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
 
 # Allow users to control which version is used
-if(NOT rapids-cmake-version OR NOT rapids-cmake-version MATCHES [[^([0-9][0-9])\.([0-9][0-9])$]])
-  message(FATAL_ERROR "The CMake variable rapids-cmake-version must be defined in the format MAJOR.MINOR."
+if(NOT rapids-cmake-branch OR NOT rapids-cmake-version)
+  message(FATAL_ERROR "The CMake variable `rapids-cmake-branch` or `rapids-cmake-version` must be defined"
   )
 endif()
 


### PR DESCRIPTION
## Description
This loosens the checks in the rapids-cmake RAPIDS.cmake to match other projects. 

This only matters so that unknown projects still fetching `RAPIDS.cmake` from rapids-cmake get the correct logic.
To that end I haven't changed the `rapids-cmake-branch` logic yet since the branching strategy hasn't been rolled out.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
