### PR TITLE
CUDA 13 builds will properly pull nvcomp  4.2.0.11

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -56,7 +56,8 @@
       "git_tag": "a6e4e64a177e07cd2e5c8c5e07bb66ffefceae84",
       "proprietary_binary_cuda_version_mapping": {
         "11": "11",
-        "12": "12"
+        "12": "12",
+        "13": "12"
       },
       "proprietary_binary": {
         "x86_64-linux": "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-x86_64/nvcomp-linux-x86_64-${version}_cuda${cuda-toolkit-version-mapping}-archive.tar.xz",


### PR DESCRIPTION
## Description
Since nvcomp uses a static CUDA runtime we can safely mix a CUDA 12 version of nvcomp with a CUDA 13 build

This is needed so that developers on 25.10 can start to build using CUDA 13

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
