### PR TITLE
Use family arch flags whenever possible

### DIFF
--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -49,7 +49,12 @@ int main(int argc, char** argv)
       char buff[32];
       cudaDeviceProp prop;
       if (cudaGetDeviceProperties(&prop, dev) != cudaSuccess) { continue; }
-      sprintf(buff, \"%d%d\", prop.major, prop.minor);
+      if(prop.major >= 9) {
+        // Enable chip specific optimizations for sm90+
+        sprintf(buff, \"%d%da\", prop.major, prop.minor);
+      } else {
+        sprintf(buff, \"%d%d\", prop.major, prop.minor);
+      }
       archs.insert(buff);
     }
   }

--- a/rapids-cmake/cuda/detail/detect_architectures.cmake
+++ b/rapids-cmake/cuda/detail/detect_architectures.cmake
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
       char buff[32];
       cudaDeviceProp prop;
       if (cudaGetDeviceProperties(&prop, dev) != cudaSuccess) { continue; }
-      if(prop.major >= 9) {
+      if (prop.major >= 9) {
         // Enable chip specific optimizations for sm90+
         sprintf(buff, \"%d%da\", prop.major, prop.minor);
       } else {

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -59,20 +59,23 @@ function(rapids_cuda_set_architectures mode)
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
 
     if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0)
-      set(supported_archs "75" "80" "86" "90a" "100f" "120a" "121f")
+      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100f-real" "120a-real"
+                          "121f-real" "121-virtual")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9.0)
-      set(supported_archs "70" "75" "80" "86" "90a" "100f" "120a" "121f")
+      set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "100f-real"
+                          "120a-real" "121f-real" "121-virtual")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0)
-      set(supported_archs "70" "75" "80" "86" "90a")
+      set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "90-virtual")
       if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)
-        list(APPEND supported_archs "100" "120a" "121")
+        list(REMOVE_ITEM supported_archs "90-virtual")
+        list(APPEND supported_archs "100-real" "120a-real" "121")
       endif()
     else()
       rapids_cmake_policy(DEPRECATED_IN 25.08 REMOVED_IN 25.12
                           MESSAGE "Support for CUDA versions below 12 has been deprecated")
-      set(supported_archs "70" "75" "80" "86")
+      set(supported_archs "70-real" "75-real" "80-real" "86-real")
       if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.8.0)
-        list(APPEND supported_archs "90a")
+        list(APPEND supported_archs "90a-real" "90-virtual")
       endif()
     endif()
 
@@ -85,13 +88,6 @@ function(rapids_cuda_set_architectures mode)
   endif()
 
   if(${mode} STREQUAL "RAPIDS")
-
-    # CMake architecture list entry of "80" means to build compute and sm. What we want is for the
-    # newest arch only to build that way while the rest built only for sm.
-    list(POP_BACK supported_archs latest_arch)
-    list(TRANSFORM supported_archs APPEND "-real")
-    list(APPEND supported_archs ${latest_arch})
-
     set(CMAKE_CUDA_ARCHITECTURES ${supported_archs})
   elseif(${mode} STREQUAL "NATIVE")
     include(${CMAKE_CURRENT_FUNCTION_LIST_DIR}/detail/detect_architectures.cmake)

--- a/testing/cuda/set_arch-rapids.cmake
+++ b/testing/cuda/set_arch-rapids.cmake
@@ -15,6 +15,7 @@
 #=============================================================================
 include(${rapids-cmake-dir}/cuda/set_architectures.cmake)
 
+enable_language(CUDA)
 rapids_cuda_set_architectures(RAPIDS)
 
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)


### PR DESCRIPTION
## Description
Use chip and family conditional flags whenever possible to make sure we have best possible perf flags

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
