### PR TITLE
change Architectures to avoid compute_100/120 code gen bug

### DIFF
--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -59,7 +59,7 @@ function(rapids_cuda_set_architectures mode)
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
 
     if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0)
-      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100fg-real" "120a-real" "120")
+      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100f-real" "120a-real" "120")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9.0)
       set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "100f-real"
                           "120a-real" "120")

--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -59,11 +59,10 @@ function(rapids_cuda_set_architectures mode)
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
 
     if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0)
-      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100f-real" "120a-real"
-                          "121f-real" "121-virtual")
+      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100fg-real" "120a-real" "120")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9.0)
       set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "100f-real"
-                          "120a-real" "121f-real" "121-virtual")
+                          "120a-real" "120")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0.0)
       set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "90-virtual")
       if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)


### PR DESCRIPTION
## Description
CUDA 12.9+ has a bug where generating for only compute_100 or compute_120 can fail.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
