### PR TITLE
Update cuco version to fetch signed comparison warning fix

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -23,7 +23,7 @@
       "git_shallow": false,
       "always_download": true,
       "git_url": "https://github.com/NVIDIA/cuCollections.git",
-      "git_tag": "8a28cb049249c59ff1c029aee2579a2c4c28e794"
+      "git_tag": "6d59add35767afaf8dbc03ee52f916b00cd0fb11"
     },
     "rapids_logger": {
       "version": "0.1.0",


### PR DESCRIPTION
## Description
This PR updates the cuco version to include a fix for the signed comparison warning. The update is only 4 commits ahead of the previous version, with the intermediate changes limited to documentation and CI updates. Therefore, no downstream project tests are required.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
