### PR TITLE
Fix generation of `RAPIDS_BRANCH`

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -28,7 +28,7 @@ function sed_runner() {
 }
 
 echo "${NEXT_FULL_TAG}" > VERSION
-echo "${NEXT_SHORT_TAG}" > RAPIDS_BRANCH
+echo "branch-${NEXT_SHORT_TAG}" > RAPIDS_BRANCH
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"


### PR DESCRIPTION
## Description
Put the correct branch name in `RAPIDS_BRANCH` from `update-version.sh`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
