### PR TITLE
Update rapids-logger to 0.2.2

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -26,9 +26,9 @@
       "git_tag": "d36905c69ce02d74abdd31dc864ce3e1ffc5a7db"
     },
     "rapids_logger": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "git_url": "https://github.com/rapidsai/rapids-logger.git",
-      "git_tag": "aab9882574e75cc3d7cd1809888b0e5380ebe85d"
+      "git_tag": "963ba3575f3916226fa617fb530160acbe6a351a"
     },
     "GTest": {
       "version": "1.16.0",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
0.2.1 had a typo in the fmt tag, see https://github.com/rapidsai/rapids-logger/pull/58

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
