### PR TITLE
Can't use Genex in `GLOBAL_TARGETS`

### DIFF
--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -100,9 +100,8 @@ function(rapids_cpm_cccl)
   endif()
 
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(CCCL ${version} ${find_args}
-                  GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB CCCL::libcudacxx
-                                 $<IF:$<BOOL:${_RAPIDS_ENABLE_UNSTABLE}>,CCCL::cudax,>
+  rapids_cpm_find(CCCL ${version} ${find_args} GLOBAL_TARGETS CCCL CCCL::CCCL CCCL::CUB
+                                                              CCCL::libcudacxx CCCL::cudax
                   CPM_ARGS FIND_PACKAGE_ARGUMENTS EXACT ${cpm_find_info})
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")


### PR DESCRIPTION
## Description
You can't use generator expression in the arguments to `GLOBAL_TARGET`, as it will get converted to something like:

```cmake

if(TARGET $<IF:$<BOOL:${_RAPIDS_ENABLE_UNSTABLE}>,CCCL::cudax,>)
   .... 
endif()

```

Which is invalid as generator expression can't be used in an `if` statement. Instead just always pass optional targets in `GLOBAL_TARGETS` as the function already does an existince check.




## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
