### PR TITLE
Bump CCCL to v3.0.3

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,10 +13,10 @@
       "git_tag": "097aa718f25d44315cadb80b407144ad455ee4f9"
     },
     "CCCL": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/cccl.git",
-      "git_tag": "9c40ed11560fa8ffd21abe4cdc8dc3ce875e48e3"
+      "git_tag": "8c04b6539859932f5602e86d38314e4d87f96420"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->

Backport bump of CCCL to 3.0.3 to include https://github.com/NVIDIA/cccl/pull/4796 and https://github.com/NVIDIA/cccl/pull/6102

<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst


cc @manopapad 