### PR TITLE
Add offline build example and docs

### DIFF
--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -150,7 +150,7 @@ completely offline as long as all required packages exist locally.
 
       cp -r build/_deps/rapids-cmake-src /path/to/cache/rapids-cmake
 
-3. Transfer the cache directory to the airgapped system.
+3. Transfer the directory specified in step 1 in `-DCPM_SOURCE_CACHE=` to the airgapped system.
 
 4. Build offline using the populated cache. Pass
    :cmake:variable:`FETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE` so that dependencies that use

--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -136,21 +136,46 @@ completely offline as long as all required packages exist locally.
 
 **Workflow for preparing an offline environment:**
 
-1. On a machine with network access, configure with :cmake:variable:`CPM_SOURCE_CACHE`:
+1. On a machine with network access, configure with :cmake:variable:`CPM_SOURCE_CACHE` to
+   populate the dependency cache:
 
    .. code-block:: bash
 
       cmake -B build -DCPM_SOURCE_CACHE=/path/to/cache ...
-      cmake --build build
 
-2. Transfer the cache directory to the airgapped system
-
-3. Build offline using the same cache path:
+2. Copy the rapids-cmake source tree from the build directory into the cache so it is
+   available on the offline system alongside the other dependencies:
 
    .. code-block:: bash
 
-      cmake -B build -DCPM_SOURCE_CACHE=/path/to/cache ...
+      cp -r build/_deps/rapids-cmake-src /path/to/cache/rapids-cmake
+
+3. Transfer the cache directory to the airgapped system.
+
+4. Build offline using the populated cache. Pass
+   :cmake:variable:`FETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE` so that dependencies that use
+   rapids-cmake do not attempt to download it from the network:
+
+   .. code-block:: bash
+
+      cmake -B build \
+            -DCPM_SOURCE_CACHE=/path/to/cache \
+            -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE=/path/to/cache/rapids-cmake \
+            -Drapids-cmake-dir=/path/to/cache/rapids-cmake \
+            ...
       cmake --build build
+
+   Setting :cmake:variable:`FETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE` causes CMake's
+   :cmake:module:`FetchContent <cmake:module:FetchContent>` to treat rapids-cmake as already
+   populated from the given path, bypassing any network fetch for dependencies that use
+   rapids-cmake.
+
+.. note::
+
+   A fully worked example of this workflow is provided in
+   :file:`examples/offline_build`. It contains shell scripts that automate both the
+   cache-population step (``generate_offline_source_cache.sh``) and the offline build step
+   (``use_offline_source_cache.sh``).
 
 Using Local Package Overrides
 ==============================

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,6 +67,18 @@ Demonstrates the cmake/thirdparty/ organization pattern for managing dependencie
 
 Shows how RAPIDS projects organize third-party dependencies. This pattern scales from small projects to large ones (cuDF manages 15+ dependencies this way). Critical for maintainability as projects grow.
 
+### [offline-build](offline_build/)
+Demonstrates the CPM source cache workflow for building in airgapped or offline environments:
+- `CPM_SOURCE_CACHE` - Cache downloaded dependency sources for reuse and offline use
+- `CPM_USE_LOCAL_PACKAGES` - Prefer locally installed packages before falling back to the cache
+- `CPM_LOCAL_PACKAGES_ONLY` - Enforce strictly offline operation; error if any dependency is missing
+- `generate_offline_source_cache.sh` - Populate the CPM source cache on a networked machine
+- `use_offline_source_cache.sh` - Configure and build using only the pre-populated cache
+
+Shows how to prepare a CPM source cache on a machine with network access, then transfer it to an
+airgapped system and perform a fully offline build. The orchestrating `CMakeLists.txt` uses
+`add_custom_command` to drive the generate-then-build workflow as a single CMake build target.
+
 ### [pin-dependencies](pin-dependencies/)
 Demonstrates dependency pinning for reproducible builds:
 - `rapids_cpm_init(GENERATE_PINNED_VERSIONS)` - Generate pinned versions file

--- a/examples/offline_build/CMakeLists.txt
+++ b/examples/offline_build/CMakeLists.txt
@@ -1,0 +1,40 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+
+project(offline_build_orchestration LANGUAGES NONE)
+
+# Directories used by the offline build workflow
+set(offline_cache_dir "${CMAKE_CURRENT_BINARY_DIR}/cpm_cache")
+set(offline_build_dir "${CMAKE_CURRENT_BINARY_DIR}/offline-build")
+
+# Populate the CPM source cache by building the project with network access. All dependency sources
+# are downloaded into offline_cache_dir during this step.
+execute_process(COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/generate_offline_source_cache.sh"
+                        "${offline_cache_dir}" COMMAND_ERROR_IS_FATAL ANY)
+execute_process(COMMAND "${CMAKE_COMMAND}" -E touch "${offline_cache_dir}/.populated")
+
+# Configure and build the project in fully offline mode using the populated cache.
+# CPM_USE_LOCAL_PACKAGES is set by the script to prefer system-installed packages when available.
+add_custom_command(OUTPUT "${offline_build_dir}/.built"
+                   DEPENDS "${offline_cache_dir}/.populated"
+                   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/use_offline_source_cache.sh"
+                           "${offline_cache_dir}" "${offline_build_dir}"
+                   COMMAND "${CMAKE_COMMAND}" -E touch "${offline_build_dir}/.built"
+                   COMMENT "Configuring and building project in offline mode"
+                   VERBATIM)
+
+# Build the offline project using its own build system.
+add_custom_command(OUTPUT "${offline_build_dir}/offline_build_example"
+                   DEPENDS "${offline_build_dir}/.built"
+                   COMMAND "${CMAKE_COMMAND}" --build "${offline_build_dir}"
+                   COMMENT "Building offline_build_example binary"
+                   VERBATIM)
+
+add_custom_target(offline_build_example ALL COMMENT "Building offline_build_example"
+                  DEPENDS "${offline_build_dir}/offline_build_example")

--- a/examples/offline_build/generate_offline_source_cache.sh
+++ b/examples/offline_build/generate_offline_source_cache.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script configures and builds the project with a CPM_SOURCE_CACHE pointing
+# to a directory of your choice. CPM will download all dependencies into that
+# cache during the build. Once complete, the cache directory can be transferred
+# to an airgapped or offline system and used with use_offline_source_cache.sh.
+#
+# Usage:
+#   ./generate_offline_source_cache.sh <cache-dir>
+#
+# Arguments:
+#   cache-dir   Absolute path to the directory where CPM will store downloaded sources.
+#               The directory will be created if it does not exist.
+#
+# Example:
+#   ./generate_offline_source_cache.sh /tmp/my_cpm_cache
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <cache-dir>"
+  exit 1
+fi
+
+CACHE_DIR="$1"
+
+echo "Populating CPM source cache at: ${CACHE_DIR}"
+
+BUILD_DIR="$(mktemp -d)"
+
+cmake -S "${SCRIPT_DIR}/src" \
+      -B "${BUILD_DIR}" \
+      -DCPM_SOURCE_CACHE="${CACHE_DIR}"
+
+cp -r "${BUILD_DIR}/_deps/rapids-cmake-src" "${CACHE_DIR}/rapids-cmake"
+
+rm -rf "${BUILD_DIR}"
+
+echo ""
+echo "Cache populated successfully at: ${CACHE_DIR}"
+echo ""
+echo "To build offline using this cache, run:"
+echo "  ./use_offline_source_cache.sh ${CACHE_DIR} <offline-build-dir>"

--- a/examples/offline_build/generate_offline_source_cache.sh
+++ b/examples/offline_build/generate_offline_source_cache.sh
@@ -17,7 +17,7 @@
 # Example:
 #   ./generate_offline_source_cache.sh /tmp/my_cpm_cache
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/examples/offline_build/src/CMakeLists.txt
+++ b/examples/offline_build/src/CMakeLists.txt
@@ -1,0 +1,55 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+
+cmake_minimum_required(VERSION 3.30.4 FATAL_ERROR)
+
+# When running under rapids-cmake testing infrastructure, rapids-cmake-dir is already set and we
+# should use the local version instead of downloading RAPIDS.cmake
+if(NOT DEFINED rapids-cmake-dir)
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+    file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/main/RAPIDS.cmake
+         ${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+  endif()
+  set(rapids-cmake-branch main)
+  include(${CMAKE_CURRENT_BINARY_DIR}/RAPIDS.cmake)
+else()
+  # Test mode: Set up CMAKE_MODULE_PATH to use local rapids-cmake
+  if(NOT "${rapids-cmake-dir}" IN_LIST CMAKE_MODULE_PATH)
+    list(APPEND CMAKE_MODULE_PATH "${rapids-cmake-dir}")
+  endif()
+endif()
+
+include(rapids-cmake)
+include(rapids-cpm)
+include(rapids-cuda)
+
+rapids_cuda_init_architectures(offline_build_example)
+
+# rapids-pre-commit-hooks: disable-next-line[verify-hardcoded-version]
+project(offline_build_example VERSION 1.0 LANGUAGES CXX CUDA)
+
+rapids_cmake_build_type(Release)
+
+# Initialize CPM. CPM_SOURCE_CACHE and CPM_USE_LOCAL_PACKAGES can be passed on the command line to
+# control offline behavior.
+rapids_cpm_init()
+
+# Fetch CCCL
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
+rapids_cpm_cccl()
+
+# Fetch RMM
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
+rapids_cpm_rmm()
+
+# Create a simple CUDA executable
+add_executable(offline_build_example main.cu)
+
+set_target_properties(offline_build_example PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON
+                                                       CUDA_STANDARD 20 CUDA_STANDARD_REQUIRED ON)
+
+target_link_libraries(offline_build_example PRIVATE Thrust::Thrust rmm::rmm)

--- a/examples/offline_build/src/main.cu
+++ b/examples/offline_build/src/main.cu
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstdio>
+
+void offline_build_example() { printf("offline-build example\n"); }
+
+int main()
+{
+  offline_build_example();
+  return 0;
+}

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -26,7 +26,7 @@
 # Example:
 #   ./use_offline_source_cache.sh /tmp/my_cpm_cache /tmp/offline-build
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -51,7 +51,7 @@ cmake -S "${SCRIPT_DIR}/src" \
       -DCPM_SOURCE_CACHE="${CACHE_DIR}" \
       -DCPM_USE_LOCAL_PACKAGES=ON \
       -Drapids-cmake-dir="${CACHE_DIR}/rapids-cmake/rapids-cmake/" \
-      -Drapids-cmake_POPULATED=ON \
+      -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE="${CACHE_DIR}/rapids-cmake/rapids-cmake/" \
       --trace-expand --trace-redirect="${BUILD_DIR}/trace"
 
 echo "Building..."

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -48,11 +48,11 @@ echo "Configuring offline build using CPM source cache at: ${CACHE_DIR}"
 
 cmake -S "${SCRIPT_DIR}/src" \
       -B "${BUILD_DIR}" \
+      -DRAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS=OFF \
       -DCPM_SOURCE_CACHE="${CACHE_DIR}" \
       -DCPM_USE_LOCAL_PACKAGES=ON \
       -Drapids-cmake-dir="${CACHE_DIR}/rapids-cmake/rapids-cmake/" \
-      -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE="${CACHE_DIR}/rapids-cmake/rapids-cmake/" \
-      --trace-expand --trace-redirect="${BUILD_DIR}/trace"
+      -DFETCHCONTENT_SOURCE_DIR_RAPIDS-CMAKE="${CACHE_DIR}/rapids-cmake/rapids-cmake/"
 
 echo "Building..."
 cmake --build "${BUILD_DIR}"

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script configures and builds the project entirely offline by pointing
+# CPM at a pre-populated source cache. No network access is required as long as
+# the cache directory contains all required dependencies.
+#
+# The following CPM variables are set to enforce offline operation:
+#
+#   CPM_SOURCE_CACHE        - Directs CPM to use the provided cache directory
+#                             for all dependency sources instead of downloading.
+#   CPM_USE_LOCAL_PACKAGES  - Instructs CPM to attempt find_package() first
+#                             before falling back to the source cache, picking up
+#                             any system-installed packages automatically.
+#
+# Usage:
+#   ./use_offline_source_cache.sh <cache-dir> <build-dir>
+#
+# Arguments:
+#   cache-dir   Path (absolute or relative) to the CPM source cache populated by
+#               generate_offline_source_cache.sh.
+#   build-dir   Path (absolute or relative) to the directory where the offline build will
+#               be configured and compiled.
+#
+# Example:
+#   ./use_offline_source_cache.sh /tmp/my_cpm_cache /tmp/offline-build
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <cache-dir> <build-dir>"
+  exit 1
+fi
+
+CACHE_DIR="$(cd "$1" && pwd)"
+BUILD_DIR="$(mkdir -p "$2" && cd "$2" && pwd)"
+
+if [ ! -d "${CACHE_DIR}" ]; then
+  echo "Error: cache directory does not exist: ${CACHE_DIR}"
+  echo "Run generate_offline_source_cache.sh first to populate the cache."
+  exit 1
+fi
+
+echo "Configuring offline build using CPM source cache at: ${CACHE_DIR}"
+
+cmake -S "${SCRIPT_DIR}/src" \
+      -B "${BUILD_DIR}" \
+      -DCPM_SOURCE_CACHE="${CACHE_DIR}" \
+      -DCPM_USE_LOCAL_PACKAGES=ON \
+      -Drapids-cmake-dir="${CACHE_DIR}/rapids-cmake/rapids-cmake/" \
+      -Drapids-cmake_POPULATED=ON \
+      --trace-expand --trace-redirect="${BUILD_DIR}/trace"
+
+echo "Building..."
+cmake --build "${BUILD_DIR}"
+
+echo ""
+echo "Offline build completed successfully."
+echo "Executable: ${BUILD_DIR}/offline_build_example"

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -46,6 +46,7 @@ fi
 
 echo "Configuring offline build using CPM source cache at: ${CACHE_DIR}"
 
+# Turning off `RAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS` is required for CI to not use spdlog from system
 cmake -S "${SCRIPT_DIR}/src" \
       -B "${BUILD_DIR}" \
       -DRAPIDS_LOGGER_HIDE_ALL_SPDLOG_SYMBOLS=OFF \

--- a/testing/examples/CMakeLists.txt
+++ b/testing/examples/CMakeLists.txt
@@ -13,6 +13,8 @@ add_cmake_build_test(export-feature SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/export-feature)
 add_cmake_build_test(find-generate-module SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/find-generate-module)
+add_cmake_build_test(offline-build SOURCE_DIR
+                     ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/offline_build NO_CPM_CACHE)
 add_cmake_build_test(pin-dependencies SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/pin-dependencies NO_CPM_CACHE)
 add_cmake_build_test(project-bootstrap SOURCE_DIR


### PR DESCRIPTION
## Description
Replaces https://github.com/rapidsai/rapids-cmake/pull/943 as documentation and example 

Fixes: https://github.com/rapidsai/rapids-cmake/issues/826

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
