### PR TITLE
Upgrade to nvcomp 5.2.0.10

### DIFF
--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -191,6 +191,10 @@ function(rapids_cpm_nvcomp)
     install(DIRECTORY "${nvcomp_ROOT}/${lib_dir}/" DESTINATION "${lib_dir}")
     install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}/"
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    if(EXISTS "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}")
+      install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}/"
+              DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    endif()
     # place the license information in the location that conda uses
     install(FILES "${nvcomp_ROOT}/NOTICE" DESTINATION info/ RENAME NVCOMP_NOTICE)
     install(FILES "${nvcomp_ROOT}/LICENSE" DESTINATION info/ RENAME NVCOMP_LICENSE)

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -41,7 +41,7 @@
       "git_tag": "b88a45f4170af4e907e69af22a55af67859d3b49"
     },
     "nvcomp": {
-      "version": "5.1.0.21",
+      "version": "5.2.0.10",
       "git_shallow": false,
       "git_url": "https://github.com/NVIDIA/nvcomp.git",
       "git_tag": "a6e4e64a177e07cd2e5c8c5e07bb66ffefceae84",


### PR DESCRIPTION
## Description
Upgrades nvcomp to version 5.2.0.10.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
