### PR TITLE
Update docs for proprietary_binary-only packages and nvCOMP

### DIFF
--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -279,8 +279,10 @@ Project Object Fields
 
 Each ``project`` object must contain the following fields so that
 rapids-cmake can properly use CPM to find or download the project
-as needed. Each project must define ``version`` and either
-(``git_url`` + ``git_tag``) or (``url`` + ``url_hash``).
+as needed. Each project must define ``version`` and one of the following:
+(``git_url`` + ``git_tag``), (``url`` + ``url_hash``), or ``proprietary_binary``.
+When only ``proprietary_binary`` is provided, ``git_url``/``git_tag`` and
+``url``/``url_hash`` may be omitted entirely.
 
 ``version``
 
@@ -294,10 +296,12 @@ as needed. Each project must define ``version`` and either
 
 ``git_url``
 
-    A required string representing the git url to be used when cloning the
+    A string representing the git url to be used when cloning the
     project locally by the :cmake:command:`rapids_cpm_find` when a locally
-    installed copy of the project can't be found. When ``git_url`` is provided,
-    ``git_tag`` must also be supplied and ``url``/``url_hash`` must not be present.
+    installed copy of the project can't be found. Required unless
+    ``proprietary_binary`` or ``url``/``url_hash`` is provided. When ``git_url``
+    is provided, ``git_tag`` must also be supplied and ``url``/``url_hash``
+    must not be present.
 
     Supports the following placeholders:
         - ``${rapids-cmake-version}`` will be evaluated to 'major.minor' of the current rapids-cmake cal-ver value.
@@ -306,9 +310,10 @@ as needed. Each project must define ``version`` and either
 
 ``git_tag``
 
-    A required string representing the git tag to be used when cloning the
+    A string representing the git tag to be used when cloning the
     project locally by the :cmake:command:`rapids_cpm_find` when a locally
-    installed copy of the project can't be found.
+    installed copy of the project can't be found. Required when ``git_url``
+    is provided.
 
     Supports the following placeholders:
         - ``${rapids-cmake-checkout-tag}`` will be evaluated to ``main`` when using rapids-cmake ``main`` branch, or ``release/<major>.<minor>`` when not on the 'main' branch, using the rapids-cmake CalVer values.
@@ -318,9 +323,10 @@ as needed. Each project must define ``version`` and either
 
 ``url``
 
-    A required string representing a URL to a source tarball.
-    When ``url`` is provided, ``url_hash`` must also be supplied and
-    ``git_url``/``git_tag`` must not be present.
+    A string representing a URL to a source tarball. Required unless
+    ``proprietary_binary`` or ``git_url``/``git_tag`` is provided. When ``url``
+    is provided, ``url_hash`` must also be supplied and ``git_url``/``git_tag``
+    must not be present.
 
     Supports the following placeholders:
         - ``${rapids-cmake-version}`` will be evaluated to 'major.minor' of the current rapids-cmake cal-ver value.
@@ -431,14 +437,15 @@ as needed. Each project must define ``version`` and either
 
 ``proprietary_binary``
 
-    An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library. This creates a new entry in the search
-    logic for a project:
+    An optional dictionary of cpu architecture and operating system keys to url values that represents a download for a pre-built proprietary version of the library. When ``proprietary_binary`` is
+    present, ``git_url``/``git_tag`` and ``url``/``url_hash`` may be omitted, making the proprietary
+    binary the sole fetch mechanism. This creates a new entry in the search logic for a project:
 
         - Search for a local version matching the ``version`` key
             - disabled by ``always_download``
         - Download proprietary version if a valid OS + CPU Arch exists
             - disabled by ``USE_PROPRIETARY_BLOB`` being off
-        - Fallback to using git url and tag
+        - Fallback to using ``git_url``/``git_tag`` or ``url``/``url_hash`` if provided
 
     To determine the correct key, CMake will query for a key that matches the lower case value of `<arch>-<os>` where `arch` maps to
     :cmake:variable:`CMAKE_SYSTEM_PROCESSOR <cmake:variable:CMAKE_SYSTEM_PROCESSOR>` and `os` maps to :cmake:variable:`CMAKE_SYSTEM_NAME <cmake:variable:CMAKE_SYSTEM_NAME>`.

--- a/rapids-cmake/cpm/nvcomp.cmake
+++ b/rapids-cmake/cpm/nvcomp.cmake
@@ -11,30 +11,28 @@ rapids_cpm_nvcomp
 -----------------
 .. versionadded:: v22.06.00
 
-Allow projects to find or build `nvComp` via `CPM` with built-in
+Allow projects to find or build `nvCOMP` via `CPM` with built-in
 tracking of these dependencies for correct export support.
 
-Uses the version of nvComp :ref:`specified in the version file <cpm_versions>` for consistency
+Uses the version of nvCOMP :ref:`specified in the version file <cpm_versions>` for consistency
 across all RAPIDS projects.
 
 .. code-block:: cmake
 
-  rapids_cpm_nvcomp( [USE_PROPRIETARY_BINARY <ON|OFF>]
+  rapids_cpm_nvcomp( USE_PROPRIETARY_BINARY <ON|OFF>
                      [BUILD_EXPORT_SET <export-name>]
                      [INSTALL_EXPORT_SET <export-name>]
                      [<CPM_ARGS> ...])
 
 ``USE_PROPRIETARY_BINARY``
   By enabling this flag and using the software, you agree to fully comply with the terms and conditions of
-  nvcomp's NVIDIA Software License Agreement. Found at https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt
+  nvCOMP's NVIDIA Software License Agreement, found at https://developer.download.nvidia.com/compute/nvcomp/2.3/LICENSE.txt.
 
-  NVComp offers pre-built proprietary version of the library ( for x86_64 only ) that offer more features compared to the
-  open source version. Since NVComp currently doesn't offer pre-built versions for all platforms, callers should verify
-  the the request for a proprietary binary was fulfilled by checking the :cmake:variable:`nvcomp_proprietary_binary`
-  variable after calling :cmake:command:`rapids_cpm_nvcomp`.
+  nvCOMP is distributed as a pre-built proprietary binary. This flag is required for rapids-cmake to
+  download nvCOMP; without it, nvCOMP can only be found if already installed on the system.
 
 .. note::
-  If an override entry exists for the nvcomp package it MUST have a proprietary_binary entry for this to
+  If an override entry exists for the nvCOMP package it MUST have a ``proprietary_binary`` entry for this
   flag to do anything. Any override without this entry is considered to invalidate the existing proprietary
   binary entry.
 
@@ -45,16 +43,15 @@ Result Targets
 ^^^^^^^^^^^^^^
   nvcomp::nvcomp target will be created
   nvcomp::nvcomp_cpu target will be created
-  nvcomp::nvcomp_device_static target will be created
   nvcomp::nvcomp_static target might be created
   nvcomp::nvcomp_cpu_static target might be created
 
 Result Variables
 ^^^^^^^^^^^^^^^^
-  :cmake:variable:`nvcomp_SOURCE_DIR` is set to the path to the source directory of nvcomp.
-  :cmake:variable:`nvcomp_BINARY_DIR` is set to the path to the build directory of nvcomp.
-  :cmake:variable:`nvcomp_ADDED`      is set to a true value if nvcomp has not been added before.
-  :cmake:variable:`nvcomp_VERSION`    is set to the version of nvcomp specified by the versions.json.
+  :cmake:variable:`nvcomp_SOURCE_DIR` is set to the path to the source directory of nvCOMP.
+  :cmake:variable:`nvcomp_BINARY_DIR` is set to the path to the build directory of nvCOMP.
+  :cmake:variable:`nvcomp_ADDED`      is set to a true value if nvCOMP has not been added before.
+  :cmake:variable:`nvcomp_VERSION`    is set to the version of nvCOMP specified by the versions.json.
   :cmake:variable:`nvcomp_proprietary_binary` is set to ON if the proprietary binary is being used
 
 #]=======================================================================]
@@ -76,23 +73,23 @@ function(rapids_cpm_nvcomp)
   rapids_cpm_package_info(nvcomp ${_RAPIDS_UNPARSED_ARGUMENTS} VERSION_VAR version FIND_VAR
                           find_args CPM_VAR cpm_find_info TO_INSTALL_VAR to_install)
 
-  # first search locally if `rapids_cmake_always_download` is false
+  # First search locally if `rapids_cmake_always_download` is false
   if(NOT rapids_cmake_always_download)
     include("${rapids-cmake-dir}/find/package.cmake")
     rapids_find_package(nvcomp ${version} GLOBAL_TARGETS nvcomp::nvcomp ${_RAPIDS_EXPORT_ARGUMENTS}
                         FIND_ARGS QUIET)
     if(nvcomp_FOUND)
-      # report where nvcomp was found
+      # Report where nvcomp was found
       message(STATUS "Found nvcomp: ${nvcomp_DIR} (found version ${nvcomp_VERSION})")
     endif()
   endif()
 
-  # Set up the version of nvcomp we have downloaded to match the OS layout. that means ensuring we
+  # Set up the version of nvcomp we have downloaded to match the OS layout. That means ensuring we
   # have a `lib64` directory on Fedora based machines
   include("${rapids-cmake-dir}/cmake/install_lib_dir.cmake")
   rapids_cmake_install_lib_dir(lib_dir)
 
-  # second see if we have a proprietary pre-built binary listed in versions.json and download it if
+  # Second see if we have a proprietary pre-built binary listed in versions.json and download it if
   # requested.
   set(nvcomp_proprietary_binary OFF) # will be set to true by rapids_cpm_get_proprietary_binary
   if(_RAPIDS_USE_PROPRIETARY_BINARY AND NOT nvcomp_FOUND)
@@ -170,9 +167,8 @@ function(rapids_cpm_nvcomp)
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(nvcomp)
 
-  # provide consistent targets between a found nvcomp and one building from source
-  set(nvcomp_possible_target_names nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_device_static
-                                   nvcomp_static)
+  # Provide consistent targets between a found nvcomp and one building from source
+  set(nvcomp_possible_target_names nvcomp nvcomp_cpu nvcomp_cpu_static nvcomp_static)
   foreach(name IN LISTS nvcomp_possible_target_names)
     if(NOT TARGET nvcomp::${name} AND TARGET ${name})
       add_library(nvcomp::${name} ALIAS ${name})
@@ -200,12 +196,12 @@ function(rapids_cpm_nvcomp)
       install(DIRECTORY "${nvcomp_ROOT}/${CMAKE_INSTALL_BINDIR}/"
               DESTINATION "${CMAKE_INSTALL_BINDIR}")
     endif()
-    # place the license information in the location that conda uses
+    # Place the license information in the location that conda uses
     install(FILES "${nvcomp_ROOT}/NOTICE" DESTINATION info/ RENAME NVCOMP_NOTICE)
     install(FILES "${nvcomp_ROOT}/LICENSE" DESTINATION info/ RENAME NVCOMP_LICENSE)
   endif()
 
-  # point our consumers to where they can find the pre-built version
+  # Point our consumers to where they can find the pre-built version
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(BUILD nvcomp "${nvcomp_ROOT}"
                                   EXPORT_SET ${_RAPIDS_BUILD_EXPORT_SET}


### PR DESCRIPTION
## Description

Update documentation to reflect the changes from #1004, which allowed `proprietary_binary`-only packages without `git_url`/`git_tag`.

### `docs/cpm.rst`
- Document `proprietary_binary` as a third valid fetch mode alongside `git_url`/`git_tag` and `url`/`url_hash`
- Update `git_url`, `git_tag`, and `url` field descriptions to note they are not required when `proprietary_binary` is present
- Clarify the `proprietary_binary` fallback behavior for git vs URL mode

### `rapids-cmake/cpm/nvcomp.cmake`
- Rewrite `USE_PROPRIETARY_BINARY` description: nvCOMP is distributed as a proprietary binary, flag is required for rapids-cmake to download it
- Remove stale "x86_64 only" references
- Remove `nvcomp::nvcomp_device_static` (target has been removed from nvCOMP)
- Mark `USE_PROPRIETARY_BINARY` as a required argument in the signature

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst