### PR TITLE
export_cpm: Better <package>_DIR heuristic in the face of ambiguity

### DIFF
--- a/rapids-cmake/export/cpm.cmake
+++ b/rapids-cmake/export/cpm.cmake
@@ -49,6 +49,7 @@ function(rapids_export_cpm type name export_set)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.export.cpm")
 
   string(TOLOWER ${type} type)
+  string(TOLOWER ${name} lowercase_name)
 
   set(options "")
   set(one_value EXPORT_SET)
@@ -56,12 +57,42 @@ function(rapids_export_cpm type name export_set)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
   if(type STREQUAL build)
-    if(DEFINED ${name}_DIR AND ${name}_DIR)
-      # Export out where we found the existing local config module
-      set(possible_dir "${${name}_DIR}")
+
+    # Check if we have any of the support build directory config files first
+    FetchContent_GetProperties(${name} BINARY_DIR possible_build_dirs)
+    list(APPEND possible_build_dirs "${${name}_BINARY_DIR}")
+
+    set(possible_build_config_files "${lowercase_name}-config.cmake" "/${name}Config.cmake")
+    set(build_dir_config_found FALSE)
+    foreach(bdir IN LISTS possible_build_dirs)
+      foreach(config_file IN LISTS possible_build_config_files)
+        if(EXISTS "${bdir}/${config_file}")
+          set(build_dir_config_found TRUE)
+          set(build_dir_config "${bdir}")
+          break()
+        endif()
+      endforeach()
+      if(build_dir_config_found)
+        break()
+      endif()
+    endforeach()
+
+    if(NOT build_dir_config_found)
+      # Only when we `<package>_DIR` do we want to see if we can use the FetchContent info. This
+      # maintains compatibility with projects where we need to fall-back to the build directory
+      set(possible_src_dir "${${name}_DIR}")
+      if(DEFINED ${name}_DIR AND ${name}_DIR)
+        set(possible_dir "${${name}_DIR}")
+        if(possible_dir STREQUAL CMAKE_FIND_PACKAGE_REDIRECTS_DIR)
+          FetchContent_GetProperties(${name} SOURCE_DIR possible_dir)
+        endif()
+      else()
+        # Currently required to keep the DIR hints consistent when no src or build dir exists
+        # (export_cpm-build-possible-dir)
+        set(possible_dir "${${name}_BINARY_DIR}")
+      endif()
     else()
-      # Export out the build-dir in case it has build directory find-package support
-      set(possible_dir "${${name}_BINARY_DIR}")
+      set(possible_dir "${build_dir_config}")
     endif()
   endif()
 

--- a/rapids-cmake/export/cpm.cmake
+++ b/rapids-cmake/export/cpm.cmake
@@ -62,7 +62,7 @@ function(rapids_export_cpm type name export_set)
     FetchContent_GetProperties(${name} BINARY_DIR possible_build_dirs)
     list(APPEND possible_build_dirs "${${name}_BINARY_DIR}")
 
-    set(possible_build_config_files "${lowercase_name}-config.cmake" "/${name}Config.cmake")
+    set(possible_build_config_files "${lowercase_name}-config.cmake" "${name}Config.cmake")
     set(build_dir_config_found FALSE)
     foreach(bdir IN LISTS possible_build_dirs)
       foreach(config_file IN LISTS possible_build_config_files)
@@ -81,7 +81,7 @@ function(rapids_export_cpm type name export_set)
       # Only when we `<package>_DIR` do we want to see if we can use the FetchContent info. This
       # maintains compatibility with projects where we need to fall-back to the build directory
       set(possible_src_dir "${${name}_DIR}")
-      if(DEFINED ${name}_DIR AND ${name}_DIR)
+      if(${name}_DIR)
         set(possible_dir "${${name}_DIR}")
         if(possible_dir STREQUAL CMAKE_FIND_PACKAGE_REDIRECTS_DIR)
           FetchContent_GetProperties(${name} SOURCE_DIR possible_dir)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -97,6 +97,7 @@ add_cmake_config_test(cpm_cccl-export.cmake)
 add_cmake_build_test(cpm_cccl-version-2-8.cmake NO_CPM_CACHE)
 add_cmake_build_test(cpm_cccl-version-3-0.cmake NO_CPM_CACHE)
 add_cmake_build_test(cpm_cccl-preserve-custom-install-loc)
+add_cmake_config_test(cpm_cccl-package-redirect.cmake)
 
 add_cmake_config_test(cpm_cuco-simple.cmake)
 add_cmake_config_test(cpm_cuco-export.cmake)

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -141,3 +141,4 @@ add_cmake_config_test(cpm_proprietary-url-no-ctk-parsing.cmake)
 
 add_cmake_config_test(cpm_rmm-export.cmake)
 add_cmake_config_test(cpm_rmm-simple.cmake)
+add_cmake_config_test(cpm_rmm-package-redirect.cmake NO_CPM_CACHE)

--- a/testing/cpm/cpm_cccl-package-redirect.cmake
+++ b/testing/cpm/cpm_cccl-package-redirect.cmake
@@ -5,24 +5,26 @@
 # cmake-format: on
 # =============================================================================
 include(${rapids-cmake-dir}/cpm/init.cmake)
-include(${rapids-cmake-dir}/cpm/rmm.cmake)
+include(${rapids-cmake-dir}/cpm/cccl.cmake)
 
 rapids_cpm_init()
 
-rapids_cpm_rmm(INSTALL_EXPORT_SET example-exports)
+# First time without export set so that rapids_export_cpm doesn't record a location
+rapids_cpm_cccl()
 
 # Call find_package which will trigger the FindPackageRedirect logic
-find_package(rmm REQUIRED HINTS "${rmm_BINARY_DIR}")
+find_package(CCCL ${CCCL_VERSION} CONFIG REQUIRED)
 
-rapids_cpm_rmm(BUILD_EXPORT_SET example-exports INSTALL_EXPORT_SET example-exports)
+# Second time with an export set so that rapids_export_cpm now records a location
+rapids_cpm_cccl(BUILD_EXPORT_SET example-exports INSTALL_EXPORT_SET example-exports)
 
-# verify that the expected path exists in cpm_rmm.cmake
-set(path_rmm "${CMAKE_BINARY_DIR}/rapids-cmake/example-exports/build/cpm_rmm.cmake")
-set(to_match_string "${rmm_BINARY_DIR}")
+# verify that the expected path exists in also_fake_cpm_package.cmake
+set(path "${CMAKE_BINARY_DIR}/rapids-cmake/example-exports/build/cpm_CCCL.cmake")
+set(to_match_string "CMakeFiles/pkgRedirects")
 
-file(READ "${path_rmm}" contents)
+file(READ "${path}" contents)
 string(FIND "${contents}" "${to_match_string}" is_found)
-if(is_found EQUAL -1)
+if(NOT is_found EQUAL -1)
   message(FATAL_ERROR "rapids_cpm_cccl(BUILD_EXPORT_SET) failed to write out the proper possible_package_dir"
   )
 endif()

--- a/testing/cpm/cpm_rmm-package-redirect.cmake
+++ b/testing/cpm/cpm_rmm-package-redirect.cmake
@@ -1,0 +1,29 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/rmm.cmake)
+
+rapids_cpm_init()
+
+rapids_cpm_rmm(INSTALL_EXPORT_SET example-exports)
+
+# Call find_package which will trigger the FindPackageRedirect logic
+find_package(rmm REQUIRED HINTS "${rmm_BINARY_DIR}")
+
+rapids_cpm_rmm(BUILD_EXPORT_SET example-exports INSTALL_EXPORT_SET example-exports)
+
+# verify that the expected path exists in cpm_rmm.cmake
+set(path_rmm "${CMAKE_BINARY_DIR}/rapids-cmake/example-exports/build/cpm_rmm.cmake")
+set(to_match_string "${rmm_BINARY_DIR}")
+
+file(READ "${path_rmm}" contents)
+message(FATAL_ERROR "${contents}")
+string(FIND "${contents}" "${to_match_string}" is_found)
+if(is_found EQUAL -1)
+  message(FATAL_ERROR "rapids_cpm_cccl(BUILD_EXPORT_SET) failed to write out the proper possible_package_dir"
+  )
+endif()


### PR DESCRIPTION
## Description

As https://github.com/rapidsai/rapids-cmake/pull/998 and the subsequent revert highlighted the current model for recording the `<package>_DIR` hint for CPM projects was insufficient.

The newly added tests highlight that the proper heursitic is to first see if the build directory has package files ( e.g. <package>-config.cmake ) before falling back to guessing that it could be the source directory.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
