### PR TITLE
Fix rapids_cpm_nvtx3 unconditional NVTX3_INSTALL and undefined exclude variable

### DIFF
--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -46,12 +46,17 @@ function(rapids_cpm_nvtx3)
   rapids_cpm_package_info(nvtx3 ${ARGN} VERSION_VAR version FIND_VAR find_args CPM_VAR
                           cpm_find_info TO_INSTALL_VAR to_install)
 
+  # nvtx3's NVTX3_INSTALL option gates both install rules AND build-tree config generation (export
+  # sets, config files). We need it ON whenever either BUILD_EXPORT_SET or INSTALL_EXPORT_SET is
+  # provided.
+  set(nvtx3_install OFF)
+  if(_RAPIDS_BUILD_EXPORT_SET OR to_install)
+    set(nvtx3_install ON)
+  endif()
+
   include("${rapids-cmake-dir}/cpm/find.cmake")
-  rapids_cpm_find(nvtx3 ${version} ${find_args}
-                  GLOBAL_TARGETS nvtx3-c nvtx3-cpp
-                  CPM_ARGS ${cpm_find_info}
-                  EXCLUDE_FROM_ALL ${exclude}
-                  OPTIONS "NVTX3_INSTALL ON")
+  rapids_cpm_find(nvtx3 ${version} ${find_args} GLOBAL_TARGETS nvtx3-c nvtx3-cpp
+                  CPM_ARGS ${cpm_find_info} OPTIONS "NVTX3_INSTALL ${nvtx3_install}")
 
   include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
   rapids_cpm_display_patch_status(nvtx3)


### PR DESCRIPTION
## Description

Fix two bugs in `rapids_cpm_nvtx3`:

1. **Remove undefined `${exclude}` variable reference**: The `EXCLUDE_FROM_ALL ${exclude}` argument on the `rapids_cpm_find()` call referenced a variable that is never defined in this function. It was a leftover from the old `rapids_cpm_package_details()` API — the refactoring to `rapids_cpm_package_info()` (commit ce51fca) embedded `EXCLUDE_FROM_ALL` inside `${cpm_find_info}`, but the orphaned reference was never cleaned up. Since `rapids_cpm_find()` does not parse `EXCLUDE_FROM_ALL` as a named parameter, the empty expansion was passed as garbage into `_RAPIDS_UNPARSED_ARGUMENTS`.

2. **Make `NVTX3_INSTALL` conditional on `${to_install}`**: `NVTX3_INSTALL` was unconditionally hardcoded to `ON`, ignoring the `to_install` variable that `rapids_cpm_package_info()` correctly computes as `INSTALL_EXPORT_SET AND NOT exclude_from_all`. This now uses `"NVTX3_INSTALL ${to_install}"` to match the pattern used by `cuco`, `gbench`, `gtest`, `nvbench`, and other `rapids_cpm_*` wrappers.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.