### PR TITLE
Support `EXCLUDE_FROM_ALL` in all `rapids_cpm_*` functions

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -118,7 +118,10 @@
       },
       "rapids_cpm_bs_thread_pool": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "EXCLUDE_FROM_ALL"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
@@ -129,7 +132,8 @@
         "pargs": {
           "nargs": 0,
           "flags": [
-            "ENABLE_UNSTABLE"
+            "ENABLE_UNSTABLE",
+            "EXCLUDE_FROM_ALL"
           ]
         },
         "kwargs": {
@@ -139,7 +143,10 @@
       },
       "rapids_cpm_cuco": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "EXCLUDE_FROM_ALL"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
@@ -150,7 +157,8 @@
         "pargs": {
           "nargs": 0,
           "flags": [
-            "BUILD_STATIC"
+            "BUILD_STATIC",
+            "EXCLUDE_FROM_ALL"
           ]
         },
         "kwargs": {
@@ -162,7 +170,8 @@
         "pargs": {
           "nargs": 0,
           "flags": [
-            "BUILD_STATIC"
+            "BUILD_STATIC",
+            "EXCLUDE_FROM_ALL"
           ]
         },
         "kwargs": {
@@ -172,14 +181,18 @@
       },
       "rapids_cpm_rapids_logger": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "EXCLUDE_FROM_ALL"
+          ]
         }
       },
       "rapids_cpm_nvbench": {
         "pargs": {
           "nargs": 0,
           "flags": [
-            "BUILD_STATIC"
+            "BUILD_STATIC",
+            "EXCLUDE_FROM_ALL"
           ]
         },
         "kwargs": {
@@ -199,7 +212,10 @@
       },
       "rapids_cpm_nvtx3": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "EXCLUDE_FROM_ALL"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,
@@ -208,7 +224,10 @@
       },
       "rapids_cpm_rmm": {
         "pargs": {
-          "nargs": 0
+          "nargs": 0,
+          "flags": [
+            "EXCLUDE_FROM_ALL"
+          ]
         },
         "kwargs": {
           "BUILD_EXPORT_SET": 1,

--- a/docs/packages/common_package_args.txt
+++ b/docs/packages/common_package_args.txt
@@ -8,5 +8,12 @@
   Installation of |PKG_NAME| will occur if an INSTALL_EXPORT_SET is provided, and |PKG_NAME|
   is added to the project via :cmake:command:`add_subdirectory <cmake:command:add_subdirectory>` by CPM.
 
+``EXCLUDE_FROM_ALL``
+  When provided, marks the package as excluded from the ``install()`` target.
+  This overrides the default value from the versions.json configuration.
+  When ``EXCLUDE_FROM_ALL`` is specified alongside ``INSTALL_EXPORT_SET``,
+  the package will not be installed.
+
+
 ``CPM_ARGS``
   Any arguments after `CPM_ARGS` will be forwarded to the underlying |PKG_NAME| :cmake:command:`CPMFindPackage`()` call

--- a/rapids-cmake/cpm/bs_thread_pool.cmake
+++ b/rapids-cmake/cpm/bs_thread_pool.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_bs_thread_pool( [BUILD_EXPORT_SET <export-name>]
                              [INSTALL_EXPORT_SET <export-name>]
+                             [EXCLUDE_FROM_ALL]
                              [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: bs_thread_pool

--- a/rapids-cmake/cpm/cccl.cmake
+++ b/rapids-cmake/cpm/cccl.cmake
@@ -28,6 +28,7 @@ file will automatically call `thrust_create_target(CCCL::Thrust FROM_OPTIONS)`.
 
   rapids_cpm_cccl( [BUILD_EXPORT_SET <export-name>]
                    [INSTALL_EXPORT_SET <export-name>]
+                   [EXCLUDE_FROM_ALL]
                    [ENABLE_UNSTABLE]
                    [<CPM_ARGS> ...])
 

--- a/rapids-cmake/cpm/cuco.cmake
+++ b/rapids-cmake/cpm/cuco.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_cuco( [BUILD_EXPORT_SET <export-name>]
                    [INSTALL_EXPORT_SET <export-name>]
+                   [EXCLUDE_FROM_ALL]
                    [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: cuco

--- a/rapids-cmake/cpm/detail/package_info.cmake
+++ b/rapids-cmake/cpm/detail/package_info.cmake
@@ -11,6 +11,7 @@ rapids_cpm_package_info
 -----------------------------
 
   rapids_cpm_package_info(<package_name> args....
+                           [EXCLUDE_FROM_ALL]
                            VERSION_VAR <output_var_name>
                            FIND_VAR <output_var_name>
                            CPM_VAR <output_var_name>
@@ -24,13 +25,14 @@ Result Variables
   :cmake:variable:`_RAPIDS_BUILD_EXPORT_SET` will contain the value of the BUILD_EXPORT entry if it exists.
   :cmake:variable:`_RAPIDS_INSTALL_EXPORT_SET` will contain the value of the INSTALL_EXPORT entry if it exists.
 
+  :cmake:variable:`EXCLUDE_FROM_ALL` if set, overrides the JSON-default value to exclude the package from the default build.
 
 #]=======================================================================]
 # cmake-lint: disable=R0912,R0915
 function(rapids_cpm_package_info package_name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.rapids_cpm_package_info")
 
-  set(options FOR_FETCH_CONTENT)
+  set(options FOR_FETCH_CONTENT EXCLUDE_FROM_ALL)
   set(one_value VERSION_VAR FIND_VAR CPM_VAR TO_INSTALL_VAR BUILD_EXPORT_SET INSTALL_EXPORT_SET)
   set(multi_value)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
@@ -39,6 +41,10 @@ function(rapids_cpm_package_info package_name)
   include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
   rapids_cpm_package_details_internal(${package_name} _rapids_version _rapids_url _rapids_tag
                                       _rapids_src_subdir _rapids_shallow _rapids_exclude_from_all)
+
+  if(_RAPIDS_EXCLUDE_FROM_ALL)
+    set(_rapids_exclude_from_all ON)
+  endif()
 
   # Compute all the patch related details
   if(_RAPIDS_CPM_VAR OR _RAPIDS_FIND_VAR)

--- a/rapids-cmake/cpm/gbench.cmake
+++ b/rapids-cmake/cpm/gbench.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_gbench( [BUILD_EXPORT_SET <export-name>]
                      [INSTALL_EXPORT_SET <export-name>]
+                     [EXCLUDE_FROM_ALL]
                      [BUILD_STATIC]
                      [<CPM_ARGS> ...])
 

--- a/rapids-cmake/cpm/gtest.cmake
+++ b/rapids-cmake/cpm/gtest.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_gtest( [BUILD_EXPORT_SET <export-name>]
                     [INSTALL_EXPORT_SET <export-name>]
+                    [EXCLUDE_FROM_ALL]
                     [BUILD_STATIC]
                     [<CPM_ARGS> ...])
 

--- a/rapids-cmake/cpm/nvbench.cmake
+++ b/rapids-cmake/cpm/nvbench.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_nvbench( [BUILD_EXPORT_SET <export-name>]
                       [INSTALL_EXPORT_SET <export-name>]
+                      [EXCLUDE_FROM_ALL]
                       [BUILD_STATIC]
                       [<CPM_ARGS> ...])
 

--- a/rapids-cmake/cpm/nvtx3.cmake
+++ b/rapids-cmake/cpm/nvtx3.cmake
@@ -22,6 +22,7 @@ across all RAPIDS projects.
 
   rapids_cpm_nvtx3( [BUILD_EXPORT_SET <export-name>]
                     [INSTALL_EXPORT_SET <export-name>]
+                    [EXCLUDE_FROM_ALL]
                     [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: nvtx3

--- a/rapids-cmake/cpm/rapids_logger.cmake
+++ b/rapids-cmake/cpm/rapids_logger.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -21,6 +21,7 @@ across all RAPIDS projects.
 
   rapids_cpm_rapids_logger( [BUILD_EXPORT_SET <export-name>]
                             [INSTALL_EXPORT_SET <export-name>]
+                            [EXCLUDE_FROM_ALL]
                             [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: logger

--- a/rapids-cmake/cpm/rmm.cmake
+++ b/rapids-cmake/cpm/rmm.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -22,6 +22,7 @@ for  consistency across all RAPIDS projects.
 
   rapids_cpm_rmm( [BUILD_EXPORT_SET <export-name>]
                   [INSTALL_EXPORT_SET <export-name>]
+                  [EXCLUDE_FROM_ALL]
                   [<CPM_ARGS> ...])
 
 .. |PKG_NAME| replace:: rmm

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -78,6 +78,7 @@ add_cmake_config_test(cpm_package_override-url-to-git.cmake)
 add_cmake_config_test(cpm_package_override-git-to-url.cmake)
 
 add_cmake_config_test(cpm_package_info-url-mode.cmake)
+add_cmake_config_test(cpm_package_info-exclude-from-all.cmake)
 
 add_cmake_config_test(cpm_generate_patch_command-invalid.cmake)
 add_cmake_config_test(cpm_generate_patch_command-override-case-insensitive.cmake)

--- a/testing/cpm/cpm_package_info-exclude-from-all.cmake
+++ b/testing/cpm/cpm_package_info-exclude-from-all.cmake
@@ -18,6 +18,18 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
       "version": "1.0.0",
       "git_url": "https://github.com/NVIDIA/test.git",
       "git_tag": "v1.0.0"
+    },
+    "test_pkg_efa_json": {
+      "version": "2.0.0",
+      "git_url": "https://github.com/NVIDIA/test2.git",
+      "git_tag": "v2.0.0",
+      "exclude_from_all": true
+    },
+    "test_pkg_efa_json_off": {
+      "version": "3.0.0",
+      "git_url": "https://github.com/NVIDIA/test3.git",
+      "git_tag": "v3.0.0",
+      "exclude_from_all": false
     }
   }
 }
@@ -61,4 +73,55 @@ math(EXPR efa_val_idx3 "${efa_idx3} + 1")
 list(GET cpm_args3 ${efa_val_idx3} efa_value3)
 if(NOT efa_value3 STREQUAL "OFF")
   message(FATAL_ERROR "Expected default EXCLUDE_FROM_ALL=OFF in CPM args, got: ${efa_value3}")
+endif()
+
+# Test 4: JSON exclude_from_all=true propagates to CPM args as ON
+rapids_cpm_package_info(test_pkg_efa_json VERSION_VAR version4 CPM_VAR cpm_args4 TO_INSTALL_VAR
+                        to_install4)
+
+list(FIND cpm_args4 "EXCLUDE_FROM_ALL" efa_idx4)
+if(efa_idx4 EQUAL -1)
+  message(FATAL_ERROR "EXCLUDE_FROM_ALL not found in CPM args for JSON-sourced exclude.\nGot: ${cpm_args4}"
+  )
+endif()
+math(EXPR efa_val_idx4 "${efa_idx4} + 1")
+list(GET cpm_args4 ${efa_val_idx4} efa_value4)
+if(NOT efa_value4 STREQUAL "ON")
+  message(FATAL_ERROR "Expected EXCLUDE_FROM_ALL=ON from JSON data, got: ${efa_value4}")
+endif()
+
+# Test 5: JSON exclude_from_all=true with INSTALL_EXPORT_SET suppresses to_install
+rapids_cpm_package_info(test_pkg_efa_json INSTALL_EXPORT_SET test_set VERSION_VAR version5 CPM_VAR
+                        cpm_args5 TO_INSTALL_VAR to_install5)
+if(to_install5)
+  message(FATAL_ERROR "Expected to_install=OFF when JSON sets exclude_from_all=true with INSTALL_EXPORT_SET, got: ${to_install5}"
+  )
+endif()
+
+# Test 6: Function arg EXCLUDE_FROM_ALL overrides JSON exclude_from_all=false
+rapids_cpm_package_info(test_pkg_efa_json_off EXCLUDE_FROM_ALL VERSION_VAR version6 CPM_VAR
+                        cpm_args6 TO_INSTALL_VAR to_install6)
+
+list(FIND cpm_args6 "EXCLUDE_FROM_ALL" efa_idx6)
+if(efa_idx6 EQUAL -1)
+  message(FATAL_ERROR "EXCLUDE_FROM_ALL not found in CPM args.\nGot: ${cpm_args6}")
+endif()
+math(EXPR efa_val_idx6 "${efa_idx6} + 1")
+list(GET cpm_args6 ${efa_val_idx6} efa_value6)
+if(NOT efa_value6 STREQUAL "ON")
+  message(FATAL_ERROR "Expected function arg to override JSON false to ON, got: ${efa_value6}")
+endif()
+
+# Test 7: JSON exclude_from_all=false without function flag stays OFF
+rapids_cpm_package_info(test_pkg_efa_json_off VERSION_VAR version7 CPM_VAR cpm_args7 TO_INSTALL_VAR
+                        to_install7)
+
+list(FIND cpm_args7 "EXCLUDE_FROM_ALL" efa_idx7)
+if(efa_idx7 EQUAL -1)
+  message(FATAL_ERROR "EXCLUDE_FROM_ALL not found in CPM args.\nGot: ${cpm_args7}")
+endif()
+math(EXPR efa_val_idx7 "${efa_idx7} + 1")
+list(GET cpm_args7 ${efa_val_idx7} efa_value7)
+if(NOT efa_value7 STREQUAL "OFF")
+  message(FATAL_ERROR "Expected JSON exclude_from_all=false to stay OFF, got: ${efa_value7}")
 endif()

--- a/testing/cpm/cpm_package_info-exclude-from-all.cmake
+++ b/testing/cpm/cpm_package_info-exclude-from-all.cmake
@@ -1,0 +1,64 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/package_override.cmake)
+
+rapids_cpm_init()
+
+# Define a test package via override so we don't need network access
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/override.json
+     [=[
+{
+  "packages": {
+    "test_pkg": {
+      "version": "1.0.0",
+      "git_url": "https://github.com/NVIDIA/test.git",
+      "git_tag": "v1.0.0"
+    }
+  }
+}
+  ]=])
+
+rapids_cpm_package_override(${CMAKE_CURRENT_BINARY_DIR}/override.json)
+
+include("${rapids-cmake-dir}/cpm/detail/package_info.cmake")
+
+# Test 1: EXCLUDE_FROM_ALL flag sets it to ON in CPM args
+rapids_cpm_package_info(test_pkg EXCLUDE_FROM_ALL VERSION_VAR version CPM_VAR cpm_args
+                        TO_INSTALL_VAR to_install)
+
+list(FIND cpm_args "EXCLUDE_FROM_ALL" efa_idx)
+if(efa_idx EQUAL -1)
+  message(FATAL_ERROR "EXCLUDE_FROM_ALL not found in CPM args when flag was passed.\nGot: ${cpm_args}"
+  )
+endif()
+math(EXPR efa_val_idx "${efa_idx} + 1")
+list(GET cpm_args ${efa_val_idx} efa_value)
+if(NOT efa_value STREQUAL "ON")
+  message(FATAL_ERROR "Expected EXCLUDE_FROM_ALL=ON in CPM args, got: ${efa_value}")
+endif()
+
+# Test 2: EXCLUDE_FROM_ALL with INSTALL_EXPORT_SET should produce to_install=OFF
+rapids_cpm_package_info(test_pkg EXCLUDE_FROM_ALL INSTALL_EXPORT_SET test_set VERSION_VAR version2
+                        CPM_VAR cpm_args2 TO_INSTALL_VAR to_install2)
+if(to_install2)
+  message(FATAL_ERROR "Expected to_install=OFF when EXCLUDE_FROM_ALL is set with INSTALL_EXPORT_SET, got: ${to_install2}"
+  )
+endif()
+
+# Test 3: Without EXCLUDE_FROM_ALL, default behavior preserved (value should be OFF)
+rapids_cpm_package_info(test_pkg VERSION_VAR version3 CPM_VAR cpm_args3 TO_INSTALL_VAR to_install3)
+
+list(FIND cpm_args3 "EXCLUDE_FROM_ALL" efa_idx3)
+if(efa_idx3 EQUAL -1)
+  message(FATAL_ERROR "EXCLUDE_FROM_ALL not found in default CPM args.\nGot: ${cpm_args3}")
+endif()
+math(EXPR efa_val_idx3 "${efa_idx3} + 1")
+list(GET cpm_args3 ${efa_val_idx3} efa_value3)
+if(NOT efa_value3 STREQUAL "OFF")
+  message(FATAL_ERROR "Expected default EXCLUDE_FROM_ALL=OFF in CPM args, got: ${efa_value3}")
+endif()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Closes #764 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
