### PR TITLE
Add Jetson Thor (sm_110) to architecture preset

### DIFF
--- a/rapids-cmake/cuda/set_architectures.cmake
+++ b/rapids-cmake/cuda/set_architectures.cmake
@@ -50,10 +50,9 @@ function(rapids_cuda_set_architectures mode)
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
 
     if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0.0)
-      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100f-real" "120a-real" "120")
+      set(supported_archs "75-real" "80-real" "86-real" "90a-real" "100f-real" "110-real"  "120a-real" "120")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9.0)
-      set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "100f-real"
-                          "120a-real" "120")
+      set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "100f-real" "110-real" "120a-real" "120")
     else()
       set(supported_archs "70-real" "75-real" "80-real" "86-real" "90a-real" "90-virtual")
       if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)


### PR DESCRIPTION
This pull request adds the Jetson Thor (`sm_110`) to the architecture preset in `rapids_cuda_set_architectures`. 

Before this change, projects consuming the previous preset emitted no SASS for Thor and failed at runtime on Jetson Thor with `cudaErrorInvalidDevice` on the first kernel launch.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [x] I have added new files under rapids-cmake/
   - [x] I have added include guards (`include_guard(GLOBAL)`)
   - [x] I have added the associated docs/ rst file and update the api.rst
