### PR TITLE
Update CCCL version

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,8 +13,8 @@
     },
     "CCCL": {
       "version": "3.4.0",
-      "url": "https://github.com/NVIDIA/cccl/archive/a4fd97855d629244eedff0fa9ec6af9bcdb24348.tar.gz",
-      "url_hash": "SHA256=783916b2c72a7f2a2509a84a4944b4866f5709075c268aa3befc37b8c23c0a98"
+      "url": "https://github.com/NVIDIA/cccl/archive/2b7188d2b5e4f2671f68078abc7d842e6b1e3d22.tar.gz",
+      "url_hash": "SHA256=76905e6564507911f2c845156ae6c0c16a4b011227c80fbe4e42c41dbe2093ac"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This PR updates CCCL to the latest 3.4.0 pre-release commit.

Comparison of CCCL commits: https://github.com/NVIDIA/cccl/compare/a4fd97855d629244eedff0fa9ec6af9bcdb24348...2b7188d2b5e4f2671f68078abc7d842e6b1e3d22

We specifically need these features/fixes for RAPIDS projects:
- https://github.com/NVIDIA/cccl/pull/8728

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
