### PR TITLE
Update CCCL version

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,8 +13,8 @@
     },
     "CCCL": {
       "version": "3.4.0",
-      "url": "https://github.com/NVIDIA/cccl/archive/69d3293e1ebbd4aff44a9453491965633937591c.tar.gz",
-      "url_hash": "SHA256=30865f5ccfd367badb36c4ea390bf11ef9962b7db778c8e16b5f9cb9661c77b0"
+      "url": "https://github.com/NVIDIA/cccl/archive/bc6be123688ed496ce068a9799b910c69ed0b509.tar.gz",
+      "url_hash": "SHA256=186a0b7cb2b61f8274c0889aaec2486475abda71c483386091602317d32db26c"
     },
     "cuco": {
       "version": "0.0.1",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -13,8 +13,8 @@
     },
     "CCCL": {
       "version": "3.4.0",
-      "url": "https://github.com/NVIDIA/cccl/archive/2b7188d2b5e4f2671f68078abc7d842e6b1e3d22.tar.gz",
-      "url_hash": "SHA256=76905e6564507911f2c845156ae6c0c16a4b011227c80fbe4e42c41dbe2093ac"
+      "url": "https://github.com/NVIDIA/cccl/archive/69d3293e1ebbd4aff44a9453491965633937591c.tar.gz",
+      "url_hash": "SHA256=30865f5ccfd367badb36c4ea390bf11ef9962b7db778c8e16b5f9cb9661c77b0"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This PR updates CCCL to the latest 3.4.0 pre-release commit.

Comparison of CCCL commits: https://github.com/NVIDIA/cccl/compare/2b7188d2b5e4f2671f68078abc7d842e6b1e3d22...bc6be123688ed496ce068a9799b910c69ed0b509

We specifically need these features/fixes for RAPIDS projects:
- https://github.com/NVIDIA/cccl/pull/8839
- https://github.com/NVIDIA/cccl/pull/8845
- https://github.com/NVIDIA/cccl/pull/8882

Changes to revert once this lands:
- `sort_merge_joins.cu` workaround from https://github.com/rapidsai/cudf/pull/22349
- Disabled warpspeed scan in cuVS from https://github.com/rapidsai/cuvs/pull/2062
- Refactor `sample_and_compute_local_nbr_indices.cuh` to avoid transform iterators from https://github.com/rapidsai/cugraph/pull/5502/commits/913da05abb21e70e013c3e12df39cfecb18156b1

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst