### PR TITLE
rapids_find_generate_module: Support a pre-fphsa custom code block

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -352,6 +352,9 @@
           "VERSION": 1,
           "BUILD_EXPORT_SET": 1,
           "INSTALL_EXPORT_SET": 1,
+          "INITIAL_CODE_BLOCK": 1,
+          "PRE_FPHSA_CODE_BLOCK": 1,
+          "FINAL_CODE_BLOCK": 1,
           "HEADER_NAMES": "+",
           "LIBRARY_NAMES": "+",
           "INCLUDE_SUFFIXES": "+"

--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -353,7 +353,7 @@
           "BUILD_EXPORT_SET": 1,
           "INSTALL_EXPORT_SET": 1,
           "INITIAL_CODE_BLOCK": 1,
-          "PRE_FPHSA_CODE_BLOCK": 1,
+          "PRE_PACKAGE_VALIDATED_CODE_BOCK": 1,
           "FINAL_CODE_BLOCK": 1,
           "HEADER_NAMES": "+",
           "LIBRARY_NAMES": "+",

--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -147,7 +147,8 @@ function(rapids_find_generate_module name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.find.generate_module")
 
   set(options NO_CONFIG)
-  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK PRE_FPHSA_CODE_BLOCK FINAL_CODE_BLOCK)
+  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK PRE_FPHSA_CODE_BLOCK
+                FINAL_CODE_BLOCK)
   set(multi_value HEADER_NAMES LIBRARY_NAMES INCLUDE_SUFFIXES)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 

--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -26,7 +26,7 @@ Generate a Find*.cmake module for the requested package
                   [VERSION <version>]
                   [NO_CONFIG]
                   [INITIAL_CODE_BLOCK <code_block_variable>]
-                  [PRE_FPHSA_CODE_BLOCK <code_block_variable>]
+                  [PRE_PACKAGE_VALIDATED_CODE_BOCK <code_block_variable>]
                   [FINAL_CODE_BLOCK <code_block_variable>]
                   [BUILD_EXPORT_SET <name>]
                   [INSTALL_EXPORT_SET <name>]
@@ -85,24 +85,30 @@ when installed.
   Optional value of the variable that holds a string of code that will
   be executed as the first step of this config file.
 
-  Note: This requires the code block variable instead of the contents
-  so that we can properly insert CMake code
+  .. note::
+    This requires the code block variable instead of the contents
+    so that we can properly insert CMake code.
 
-``PRE_FPHSA_CODE_BLOCK``
+``PRE_PACKAGE_VALIDATED_CODE_BOCK``
   Optional value of the variable that holds a string of code that will
   be executed after :cmake:command:`find_path` and :cmake:command:`find_library` calls
-  but before :cmake:command:`find_package_handle_standard_args`. This is particularly
-  useful for inserting code to extract version information from header files.
+  but before :cmake:command:`find_package_handle_standard_args` in `MODULE` mode.
 
-  Note: This requires the code block variable instead of the contents
-  so that we can properly insert CMake code
+  .. note::
+    This argument is particularly useful for inserting CMake code to extract
+    version information from header files.
+
+  .. note::
+    This requires the code block variable instead of the contents
+    so that we can properly insert CMake code.
 
 ``FINAL_CODE_BLOCK``
   Optional value of the variable that holds a string of code that will
   be executed as the last step of this config file.
 
-  Note: This requires the code block variable instead of the contents
-  so that we can properly insert CMake code
+  .. note::
+    This requires the code block variable instead of the contents
+    so that we can properly insert CMake code
 
 ``BUILD_EXPORT_SET``
   Record that this custom FindPackage module needs to be part
@@ -147,8 +153,8 @@ function(rapids_find_generate_module name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.find.generate_module")
 
   set(options NO_CONFIG)
-  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK PRE_FPHSA_CODE_BLOCK
-                FINAL_CODE_BLOCK)
+  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK
+                PRE_PACKAGE_VALIDATED_CODE_BOCK FINAL_CODE_BLOCK)
   set(multi_value HEADER_NAMES LIBRARY_NAMES INCLUDE_SUFFIXES)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
@@ -195,12 +201,13 @@ function(rapids_find_generate_module name)
     set(_RAPIDS_FIND_INITIAL_CODE_BLOCK "${${_RAPIDS_INITIAL_CODE_BLOCK}}")
   endif()
 
-  if(DEFINED _RAPIDS_PRE_FPHSA_CODE_BLOCK)
-    if(NOT DEFINED ${_RAPIDS_PRE_FPHSA_CODE_BLOCK})
-      message(FATAL_ERROR "PRE_FPHSA_CODE_BLOCK variable `${_RAPIDS_PRE_FPHSA_CODE_BLOCK}` doesn't exist"
+  if(DEFINED _RAPIDS_PRE_PACKAGE_VALIDATED_CODE_BOCK)
+    if(NOT DEFINED ${_RAPIDS_PRE_PACKAGE_VALIDATED_CODE_BOCK})
+      message(FATAL_ERROR "PRE_PACKAGE_VALIDATED_CODE_BOCK variable `${_RAPIDS_PRE_PACKAGE_VALIDATED_CODE_BOCK}` doesn't exist"
       )
     endif()
-    set(_RAPIDS_FIND_PRE_FPHSA_CODE_BLOCK "${${_RAPIDS_PRE_FPHSA_CODE_BLOCK}}")
+    set(_RAPIDS_FIND_PRE_PACKAGE_VALIDATED_CODE_BOCK
+        "${${_RAPIDS_PRE_PACKAGE_VALIDATED_CODE_BOCK}}")
   endif()
 
   if(DEFINED _RAPIDS_FINAL_CODE_BLOCK)

--- a/rapids-cmake/find/generate_module.cmake
+++ b/rapids-cmake/find/generate_module.cmake
@@ -26,6 +26,7 @@ Generate a Find*.cmake module for the requested package
                   [VERSION <version>]
                   [NO_CONFIG]
                   [INITIAL_CODE_BLOCK <code_block_variable>]
+                  [PRE_FPHSA_CODE_BLOCK <code_block_variable>]
                   [FINAL_CODE_BLOCK <code_block_variable>]
                   [BUILD_EXPORT_SET <name>]
                   [INSTALL_EXPORT_SET <name>]
@@ -87,6 +88,15 @@ when installed.
   Note: This requires the code block variable instead of the contents
   so that we can properly insert CMake code
 
+``PRE_FPHSA_CODE_BLOCK``
+  Optional value of the variable that holds a string of code that will
+  be executed after :cmake:command:`find_path` and :cmake:command:`find_library` calls
+  but before :cmake:command:`find_package_handle_standard_args`. This is particularly
+  useful for inserting code to extract version information from header files.
+
+  Note: This requires the code block variable instead of the contents
+  so that we can properly insert CMake code
+
 ``FINAL_CODE_BLOCK``
   Optional value of the variable that holds a string of code that will
   be executed as the last step of this config file.
@@ -137,7 +147,7 @@ function(rapids_find_generate_module name)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.find.generate_module")
 
   set(options NO_CONFIG)
-  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK FINAL_CODE_BLOCK)
+  set(one_value VERSION BUILD_EXPORT_SET INSTALL_EXPORT_SET INITIAL_CODE_BLOCK PRE_FPHSA_CODE_BLOCK FINAL_CODE_BLOCK)
   set(multi_value HEADER_NAMES LIBRARY_NAMES INCLUDE_SUFFIXES)
   cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
@@ -182,6 +192,14 @@ function(rapids_find_generate_module name)
       )
     endif()
     set(_RAPIDS_FIND_INITIAL_CODE_BLOCK "${${_RAPIDS_INITIAL_CODE_BLOCK}}")
+  endif()
+
+  if(DEFINED _RAPIDS_PRE_FPHSA_CODE_BLOCK)
+    if(NOT DEFINED ${_RAPIDS_PRE_FPHSA_CODE_BLOCK})
+      message(FATAL_ERROR "PRE_FPHSA_CODE_BLOCK variable `${_RAPIDS_PRE_FPHSA_CODE_BLOCK}` doesn't exist"
+      )
+    endif()
+    set(_RAPIDS_FIND_PRE_FPHSA_CODE_BLOCK "${${_RAPIDS_PRE_FPHSA_CODE_BLOCK}}")
   endif()
 
   if(DEFINED _RAPIDS_FINAL_CODE_BLOCK)

--- a/rapids-cmake/find/template/find_module.cmake.in
+++ b/rapids-cmake/find/template/find_module.cmake.in
@@ -58,7 +58,7 @@ if(NOT @_RAPIDS_PKG_NAME@_LIBRARY AND NOT @_RAPIDS_PKG_NAME@_IS_HEADER_ONLY)
   unset(@_RAPIDS_PKG_NAME@_FOUND) #incorrectly set by select_library_configurations
 endif()
 
-@_RAPIDS_FIND_PRE_FPHSA_CODE_BLOCK@
+@_RAPIDS_FIND_PRE_PACKAGE_VALIDATED_CODE_BOCK@
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 

--- a/rapids-cmake/find/template/find_module.cmake.in
+++ b/rapids-cmake/find/template/find_module.cmake.in
@@ -58,6 +58,8 @@ if(NOT @_RAPIDS_PKG_NAME@_LIBRARY AND NOT @_RAPIDS_PKG_NAME@_IS_HEADER_ONLY)
   unset(@_RAPIDS_PKG_NAME@_FOUND) #incorrectly set by select_library_configurations
 endif()
 
+@_RAPIDS_FIND_PRE_FPHSA_CODE_BLOCK@
+
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 
 if(@_RAPIDS_PKG_NAME@_IS_HEADER_ONLY)

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -34,6 +34,8 @@ add_cmake_config_test(find_generate_module-header-only)
 add_cmake_config_test(find_generate_module-code-blocks)
 add_cmake_config_test(find_generate_module-back-initial-code-block-var.cmake SHOULD_FAIL
                       "INITIAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
+add_cmake_config_test(find_generate_module-back-pre-fphsa-code-block-var.cmake SHOULD_FAIL
+                      "PRE_FPHSA_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test(find_generate_module-back-final-code-block-var.cmake SHOULD_FAIL
                       "FINAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -35,7 +35,7 @@ add_cmake_config_test(find_generate_module-code-blocks)
 add_cmake_config_test(find_generate_module-back-initial-code-block-var.cmake SHOULD_FAIL
                       "INITIAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test(find_generate_module-back-pre-fphsa-code-block-var.cmake SHOULD_FAIL
-                      "PRE_FPHSA_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
+                      "PRE_PACKAGE_VALIDATED_CODE_BOCK variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test(find_generate_module-back-final-code-block-var.cmake SHOULD_FAIL
                       "FINAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 

--- a/testing/find/find_generate_module-back-final-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-final-code-block-var.cmake
@@ -1,11 +1,10 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 include(${rapids-cmake-dir}/find/generate_module.cmake)
 
 rapids_find_generate_module(RapidsTest HEADER_NAMES rapids-cmake-test-header_only.hpp
-                                                    FINAL_CODE_BLOCK var_doesn't_exist
-                            INSTALL_EXPORT_SET test_set)
+                            FINAL_CODE_BLOCK var_doesn't_exist INSTALL_EXPORT_SET test_set)

--- a/testing/find/find_generate_module-back-initial-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-initial-code-block-var.cmake
@@ -1,11 +1,10 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 include(${rapids-cmake-dir}/find/generate_module.cmake)
 
 rapids_find_generate_module(RapidsTest HEADER_NAMES rapids-cmake-test-header_only.hpp
-                                                    INITIAL_CODE_BLOCK var_doesn't_exist
-                            INSTALL_EXPORT_SET test_set)
+                            INITIAL_CODE_BLOCK var_doesn't_exist INSTALL_EXPORT_SET test_set)

--- a/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
@@ -7,4 +7,5 @@
 include(${rapids-cmake-dir}/find/generate_module.cmake)
 
 rapids_find_generate_module(RapidsTest HEADER_NAMES rapids-cmake-test-header_only.hpp
-                            PRE_FPHSA_CODE_BLOCK var_doesn't_exist INSTALL_EXPORT_SET test_set)
+                            PRE_PACKAGE_VALIDATED_CODE_BOCK var_doesn't_exist
+                            INSTALL_EXPORT_SET test_set)

--- a/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
@@ -1,0 +1,12 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/find/generate_module.cmake)
+
+rapids_find_generate_module(RapidsTest
+                            HEADER_NAMES rapids-cmake-test-header_only.hpp
+                            PRE_FPHSA_CODE_BLOCK var_doesn't_exist
+                            INSTALL_EXPORT_SET test_set)

--- a/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
+++ b/testing/find/find_generate_module-back-pre-fphsa-code-block-var.cmake
@@ -1,12 +1,10 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
 include(${rapids-cmake-dir}/find/generate_module.cmake)
 
-rapids_find_generate_module(RapidsTest
-                            HEADER_NAMES rapids-cmake-test-header_only.hpp
-                            PRE_FPHSA_CODE_BLOCK var_doesn't_exist
-                            INSTALL_EXPORT_SET test_set)
+rapids_find_generate_module(RapidsTest HEADER_NAMES rapids-cmake-test-header_only.hpp
+                            PRE_FPHSA_CODE_BLOCK var_doesn't_exist INSTALL_EXPORT_SET test_set)

--- a/testing/find/find_generate_module-code-blocks/CMakeLists.txt
+++ b/testing/find/find_generate_module-code-blocks/CMakeLists.txt
@@ -13,12 +13,12 @@ set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Generate the find module
 set(initial_code_block [[set(RapidsTest_INITIAL_CODE_BLOCK TRUE)]])
-set(middle_code_block [[set(RapidsTest_PRE_FPHSA_CODE_BLOCK TRUE)]])
+set(middle_code_block [[set(RapidsTest_PRE_PACKAGE_VALIDATED_CODE_BOCK TRUE)]])
 set(final_code_block [[set(RapidsTest_FINAL_CODE_BLOCK TRUE)]])
 rapids_find_generate_module(RapidsTest
                             HEADER_NAMES rapids-cmake-test-header_only.hpp
                             INITIAL_CODE_BLOCK initial_code_block
-                            PRE_FPHSA_CODE_BLOCK middle_code_block
+                            PRE_PACKAGE_VALIDATED_CODE_BOCK middle_code_block
                             FINAL_CODE_BLOCK final_code_block
                             INSTALL_EXPORT_SET test_set)
 
@@ -27,8 +27,8 @@ find_package(RapidsTest REQUIRED)
 if(NOT RapidsTest_INITIAL_CODE_BLOCK)
   message(FATAL_ERROR "RapidsTest_INITIAL_CODE_BLOCK should be set to TRUE")
 endif()
-if(NOT RapidsTest_PRE_FPHSA_CODE_BLOCK)
-  message(FATAL_ERROR "RapidsTest_PRE_FPHSA_CODE_BLOCK should be set to TRUE")
+if(NOT RapidsTest_PRE_PACKAGE_VALIDATED_CODE_BOCK)
+  message(FATAL_ERROR "RapidsTest_PRE_PACKAGE_VALIDATED_CODE_BOCK should be set to TRUE")
 endif()
 if(NOT RapidsTest_FINAL_CODE_BLOCK)
   message(FATAL_ERROR "RapidsTest_FINAL_CODE_BLOCK should be set to TRUE")

--- a/testing/find/find_generate_module-code-blocks/CMakeLists.txt
+++ b/testing/find/find_generate_module-code-blocks/CMakeLists.txt
@@ -13,17 +13,23 @@ set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Generate the find module
 set(initial_code_block [[set(RapidsTest_INITIAL_CODE_BLOCK TRUE)]])
+set(middle_code_block [[set(RapidsTest_PRE_FPHSA_CODE_BLOCK TRUE)]])
 set(final_code_block [[set(RapidsTest_FINAL_CODE_BLOCK TRUE)]])
 rapids_find_generate_module(RapidsTest
-                            HEADER_NAMES rapids-cmake-test-header_only.hpp INITIAL_CODE_BLOCK
-                                         initial_code_block FINAL_CODE_BLOCK final_code_block
+                            HEADER_NAMES rapids-cmake-test-header_only.hpp
+                            INITIAL_CODE_BLOCK initial_code_block
+                            PRE_FPHSA_CODE_BLOCK middle_code_block
+                            FINAL_CODE_BLOCK final_code_block
                             INSTALL_EXPORT_SET test_set)
 
 find_package(RapidsTest REQUIRED)
 
 if(NOT RapidsTest_INITIAL_CODE_BLOCK)
-  message(FATAL_ERROR "RapidsTest_FOUND should be set to TRUE")
+  message(FATAL_ERROR "RapidsTest_INITIAL_CODE_BLOCK should be set to TRUE")
+endif()
+if(NOT RapidsTest_PRE_FPHSA_CODE_BLOCK)
+  message(FATAL_ERROR "RapidsTest_PRE_FPHSA_CODE_BLOCK should be set to TRUE")
 endif()
 if(NOT RapidsTest_FINAL_CODE_BLOCK)
-  message(FATAL_ERROR "RAPIDSTEST_FOUND should be set to TRUE")
+  message(FATAL_ERROR "RapidsTest_FINAL_CODE_BLOCK should be set to TRUE")
 endif()

--- a/testing/find/find_generate_module-code-blocks/CMakeLists.txt
+++ b/testing/find/find_generate_module-code-blocks/CMakeLists.txt
@@ -13,12 +13,12 @@ set(CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # Generate the find module
 set(initial_code_block [[set(RapidsTest_INITIAL_CODE_BLOCK TRUE)]])
-set(middle_code_block [[set(RapidsTest_PRE_PACKAGE_VALIDATED_CODE_BOCK TRUE)]])
+set(pre_package_validated_code_block [[set(RapidsTest_PRE_PACKAGE_VALIDATED_CODE_BOCK TRUE)]])
 set(final_code_block [[set(RapidsTest_FINAL_CODE_BLOCK TRUE)]])
 rapids_find_generate_module(RapidsTest
                             HEADER_NAMES rapids-cmake-test-header_only.hpp
                             INITIAL_CODE_BLOCK initial_code_block
-                            PRE_PACKAGE_VALIDATED_CODE_BOCK middle_code_block
+                            PRE_PACKAGE_VALIDATED_CODE_BOCK pre_package_validated_code_block
                             FINAL_CODE_BLOCK final_code_block
                             INSTALL_EXPORT_SET test_set)
 


### PR DESCRIPTION
## Description
`rapids_find_generate_module`: Support a third pre-fphsa custom code block

The existing `INITIAL_CODE_BLOCK` and `FINAL_CODE_BLOCK` arguments are populated before the any `find_path` or `find_library` calls and after target creation respectively. This introduces a new `PRE_PACKAGE_VALIDATED_CODE_BOCK` argument that gets populated after the `find_*` calls but before `find_package_handle_standard_args`. The new argument is particulary useful for providing things like custom code to parse version information from header files for `find_package_handle_standard_args` to consider.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
