### PR TITLE
Fix how tests are executed

### DIFF
--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -28,9 +28,9 @@ add_cmake_config_test(cpm_find-patch-command-embedded-tarball NO_CPM_CACHE)
 add_cmake_config_test(cpm_find-patch-command-required-git NO_CPM_CACHE)
 add_cmake_config_test(cpm_find-patch-command-required-tarball NO_CPM_CACHE)
 add_cmake_config_test(cpm_find-patch-command-required-fails-git NO_CPM_CACHE SHOULD_FAIL
-                      "rapids-cmake [GTest]: failed to apply patch")
+                      "rapids-cmake \\[GTest\\]: failed to apply patch")
 add_cmake_config_test(cpm_find-patch-command-required-fails-tarball NO_CPM_CACHE SHOULD_FAIL
-                      "rapids-cmake [GTest]: failed to apply patch")
+                      "rapids-cmake \\[GTest\\]: failed to apply patch")
 add_cmake_config_test(cpm_find-restore-cpm-vars)
 add_cmake_config_test(cpm_find-version-explicit-install.cmake)
 
@@ -46,8 +46,8 @@ add_cmake_build_test(cpm_generate_pins-var-and-arg)
 add_cmake_build_test(cpm_generate_pins-url-mode)
 add_cmake_config_test(cpm_convert_patch_json-special-chars.cmake)
 
-add_cmake_config_test(cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm_init can't load")
-add_cmake_config_test(cpm_init-bad-default-cmake-var.cmake SHOULD_FAIL "rapids_cpm_init can't load")
+add_cmake_config_test(cpm_init-bad-default-path.cmake SHOULD_FAIL "rapids_cpm can't load")
+add_cmake_config_test(cpm_init-bad-default-cmake-var.cmake SHOULD_FAIL "rapids_cpm can't load")
 add_cmake_config_test(cpm_init-bad-override-path.cmake SHOULD_FAIL
                       "rapids_cpm_package_override can't load")
 add_cmake_config_test(cpm_init-bad-override-cmake-var.cmake SHOULD_FAIL
@@ -78,9 +78,9 @@ add_cmake_config_test(cpm_package_override-source-subdir.cmake)
 add_cmake_config_test(cpm_package_override-simple.cmake)
 add_cmake_config_test(cpm_package_override-url-mode.cmake)
 add_cmake_config_test(cpm_package_override-url-without-hash.cmake SHOULD_FAIL
-                      "has 'url' but is missing 'url_hash'")
+                      "has 'url' but is\n  missing 'url_hash'")
 add_cmake_config_test(cpm_package_override-hash-without-url.cmake SHOULD_FAIL
-                      "has 'url_hash' but is missing 'url'")
+                      "has 'url_hash' but is\n  missing 'url'")
 add_cmake_config_test(cpm_package_override-url-to-git.cmake)
 add_cmake_config_test(cpm_package_override-git-to-url.cmake)
 

--- a/testing/cython-core/cython-core_create_modules_errors.cmake
+++ b/testing/cython-core/cython-core_create_modules_errors.cmake
@@ -1,10 +1,10 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
-include(${rapids-cmake-dir}/cython/create_modules.cmake)
+include(${rapids-cmake-dir}/cython-core/create_modules.cmake)
 
 # Test that a invocation without calling rapids_cython_init fails.
 rapids_cython_create_modules(SOURCE_FILES test.pyx)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -24,9 +24,9 @@ add_cmake_build_test(export-verify-no-namespace)
 add_cmake_config_test(export-verify-bad-code-block-var.cmake SHOULD_FAIL
                       "FINAL_CODE_BLOCK variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test(export-verify-missing-components.cmake SHOULD_FAIL
-                      "is missing COMPONENTS as COMPONENTS_EXPORT_SET was provided")
+                      "is missing COMPONENTS as\n  COMPONENTS_EXPORT_SET was provided")
 add_cmake_config_test(export-verify-missing-components-export.cmake SHOULD_FAIL
-                      "is missing COMPONENTS_EXPOR22T_SET as COMPONENTS was provided")
+                      "is missing COMPONENTS_EXPORT_SET as\n  COMPONENTS was provided")
 add_cmake_config_test(export-verify-bad-doc-var.cmake SHOULD_FAIL
                       "DOCUMENTATION variable `var_doesn't_exist` doesn't exist")
 add_cmake_config_test(export-verify-calendar-version-matching.cmake)

--- a/testing/find/CMakeLists.txt
+++ b/testing/find/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -25,7 +25,7 @@ add_cmake_config_test(find_package-version-explicit-failed.cmake)
 add_cmake_config_test(find_package-version-explicit.cmake)
 add_cmake_config_test(find_package-version-none.cmake)
 add_cmake_config_test(find_package-version-required-explicit-failed.cmake SHOULD_FAIL
-                      "but required is exact version \"99999999999\"")
+                      "but required is\n  exact version \"99999999999\"")
 
 add_cmake_config_test(find_generate_module-build)
 add_cmake_config_test(find_generate_module-install)

--- a/testing/test/CMakeLists.txt
+++ b/testing/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -9,8 +9,9 @@ add_cmake_config_test(rapids-test.cmake)
 add_cmake_build_test(generate_resource_spec-no-gpus)
 add_cmake_config_test(generate_resource_spec-simple.cmake)
 
-set(percent_error_message "rapids_test_gpu_requirements requires a numeric PERCENT value [1-100].")
-set(gpu_error_message "rapids_test_gpu_requirements GPUS requires a numeric value")
+set(percent_error_message
+    "rapids_test_gpu_requirements requires a numeric PERCENT value \\[1-100\\].")
+set(gpu_error_message "rapids_test_gpu_requirements requires a numeric GPUS value")
 set(gpu_missing_message "rapids_test_gpu_requirements requires the GPUS option to be provided")
 add_cmake_config_test(gpu_requirements-char-percent.cmake SHOULD_FAIL "${percent_error_message}")
 add_cmake_config_test(gpu_requirements-char-gpu.cmake SHOULD_FAIL "${gpu_error_message}")
@@ -31,7 +32,7 @@ add_cmake_config_test(gpu_requirements-zero-percent.cmake SHOULD_FAIL "${percent
 add_cmake_config_test(init-existing-specfile.cmake)
 add_cmake_config_test(init-simple.cmake)
 
-set(wrong_component_message "No install component set [wrong_component] can be found")
+set(wrong_component_message "No install component set \\[wrong_component\\] can be found")
 add_cmake_build_test(install_relocatable-include-in-all.cmake)
 add_cmake_build_test(install_relocatable-labels.cmake)
 add_cmake_build_test(install_relocatable-complex)

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -107,6 +107,14 @@ function(add_cmake_test mode source_or_dir)
     endforeach()
   endif()
 
+  if(RAPIDS_TEST_SHOULD_FAIL)
+    set(will_fail TRUE)
+    set(expected_regular_expression "${RAPIDS_TEST_SHOULD_FAIL}")
+  else()
+    set(will_fail FALSE)
+    set(expected_regular_expression)
+  endif()
+
   foreach(generator gen_name IN ZIP_LISTS supported_generators nice_gen_names)
 
     set(test_name "${test_name_stem}-${gen_name}")
@@ -114,9 +122,11 @@ function(add_cmake_test mode source_or_dir)
 
     if(mode STREQUAL "config")
       add_test(NAME ${test_name}
-               COMMAND ${CMAKE_COMMAND} -S ${src_dir} -B ${build_dir} -G "${generator}"
-                       ${extra_configure_flags} -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
-                       -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
+               COMMAND ${CMAKE_COMMAND}
+                       "-DTEST_COMMAND=${CMAKE_COMMAND};-S;${src_dir};-B;${build_dir};-G;${generator};${extra_configure_flags};-Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR};-Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake"
+                       "-DWILL_FAIL=${will_fail}"
+                       "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
+                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake")
 
     elseif(mode STREQUAL "build")
       add_test(NAME ${test_name}_configure
@@ -124,7 +134,12 @@ function(add_cmake_test mode source_or_dir)
                        ${extra_configure_flags} -Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR}
                        -Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake)
 
-      add_test(NAME ${test_name} COMMAND ${CMAKE_COMMAND} --build ${build_dir} -j3000)
+      add_test(NAME ${test_name}
+               COMMAND ${CMAKE_COMMAND}
+                       "-DTEST_COMMAND=${CMAKE_COMMAND};--build;${build_dir};-j3000"
+                       "-DWILL_FAIL=${will_fail}"
+                       "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
+                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake")
 
       set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})
       set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED ${test_name})
@@ -137,7 +152,11 @@ function(add_cmake_test mode source_or_dir)
       add_test(NAME ${test_name}_build COMMAND ${CMAKE_COMMAND} --build ${build_dir} -j3)
       set_tests_properties(${test_name}_build PROPERTIES DEPENDS ${test_name}_configure)
 
-      add_test(NAME ${test_name} COMMAND ${CMAKE_CTEST_COMMAND} -C Debug -j400 -VV
+      add_test(NAME ${test_name}
+               COMMAND ${CMAKE_COMMAND} "-DTEST_COMMAND=${CMAKE_CTEST_COMMAND};-C;Debug;-j400;-VV"
+                       "-DWILL_FAIL=${will_fail}"
+                       "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
+                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake"
                WORKING_DIRECTORY ${build_dir})
 
       set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})
@@ -159,16 +178,6 @@ function(add_cmake_test mode source_or_dir)
       if(TEST ${test_name}_build)
         set_tests_properties(${test_name}_build PROPERTIES RUN_SERIAL ON)
       endif()
-    endif()
-
-    if(RAPIDS_TEST_SHOULD_FAIL)
-      # Make sure we have a match
-      set_tests_properties(${test_name} PROPERTIES WILL_FAIL ON)
-      set_tests_properties(${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION
-                                                   "${RAPIDS_TEST_SHOULD_FAIL}")
-    else()
-      # Error out if we detect any CMake syntax warnings
-      set_tests_properties(${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION "Syntax Warning")
     endif()
 
     # Apply a label to the test based on the folder it is in and the generator used

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -126,7 +126,7 @@ function(add_cmake_test mode source_or_dir)
                        "-DTEST_COMMAND=${CMAKE_COMMAND};-S;${src_dir};-B;${build_dir};-G;${generator};${extra_configure_flags};-Drapids-cmake-testing-dir=${PROJECT_SOURCE_DIR};-Drapids-cmake-dir=${PROJECT_SOURCE_DIR}/../rapids-cmake"
                        "-DWILL_FAIL=${will_fail}"
                        "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
-                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake")
+                       "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/execute_cmake_test.cmake")
 
     elseif(mode STREQUAL "build")
       add_test(NAME ${test_name}_configure
@@ -139,7 +139,7 @@ function(add_cmake_test mode source_or_dir)
                        "-DTEST_COMMAND=${CMAKE_COMMAND};--build;${build_dir};-j3000"
                        "-DWILL_FAIL=${will_fail}"
                        "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
-                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake")
+                       "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/execute_cmake_test.cmake")
 
       set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})
       set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED ${test_name})
@@ -156,7 +156,7 @@ function(add_cmake_test mode source_or_dir)
                COMMAND ${CMAKE_COMMAND} "-DTEST_COMMAND=${CMAKE_CTEST_COMMAND};-C;Debug;-j400;-VV"
                        "-DWILL_FAIL=${will_fail}"
                        "-DEXPECTED_REGULAR_EXPRESSION=${expected_regular_expression}" -P
-                       "${CMAKE_CURRENT_LIST_DIR}/execute_cmake_test.cmake"
+                       "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/execute_cmake_test.cmake"
                WORKING_DIRECTORY ${build_dir})
 
       set_tests_properties(${test_name}_configure PROPERTIES FIXTURES_SETUP ${test_name})

--- a/testing/utils/execute_cmake_test.cmake
+++ b/testing/utils/execute_cmake_test.cmake
@@ -1,0 +1,24 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+
+execute_process(COMMAND ${TEST_COMMAND} RESULT_VARIABLE result OUTPUT_VARIABLE stdout
+                ERROR_VARIABLE stderr)
+
+if(WILL_FAIL AND result EQUAL 0)
+  message(SEND_ERROR "Expected exit code other than 0, got 0")
+elseif(NOT WILL_FAIL AND NOT result EQUAL 0)
+  message(SEND_ERROR "Expected exit code 0, got ${result}")
+endif()
+
+if(EXPECTED_REGULAR_EXPRESSION AND NOT stdout MATCHES "${EXPECTED_REGULAR_EXPRESSION}"
+   AND NOT stderr MATCHES "${EXPECTED_REGULAR_EXPRESSION}")
+  message(SEND_ERROR "stdout and stderr did not match expected regular expression")
+endif()
+
+if(NOT WILL_FAIL AND (stdout MATCHES "Syntax Warning" OR stderr MATCHES "Syntax Warning"))
+  message(SEND_ERROR "Got a syntax warning")
+endif()

--- a/testing/utils/execute_cmake_test.cmake
+++ b/testing/utils/execute_cmake_test.cmake
@@ -14,7 +14,11 @@ endif()
 
 if(EXPECTED_REGULAR_EXPRESSION AND NOT stdout MATCHES "${EXPECTED_REGULAR_EXPRESSION}"
    AND NOT stderr MATCHES "${EXPECTED_REGULAR_EXPRESSION}")
-  message(SEND_ERROR "stdout and stderr did not match expected regular expression")
+  string(REPLACE "\n" "\n  " formatted_expected_regular_expression "${EXPECTED_REGULAR_EXPRESSION}")
+  string(REPLACE "\n" "\n  " formatted_stdout "${stdout}")
+  string(REPLACE "\n" "\n  " formatted_stderr "${stderr}")
+  message(SEND_ERROR "Expected regular expression:\n  ${formatted_expected_regular_expression}\nActual stdout:\n  ${formatted_stdout}\nActual stderr:\n  ${formatted_stderr}"
+  )
 endif()
 
 if(NOT WILL_FAIL AND (stdout MATCHES "Syntax Warning" OR stderr MATCHES "Syntax Warning"))

--- a/testing/utils/execute_cmake_test.cmake
+++ b/testing/utils/execute_cmake_test.cmake
@@ -8,9 +8,7 @@
 execute_process(COMMAND ${TEST_COMMAND} RESULT_VARIABLE result OUTPUT_VARIABLE stdout
                 ERROR_VARIABLE stderr)
 
-if(WILL_FAIL AND result EQUAL 0)
-  message(SEND_ERROR "Expected exit code other than 0, got 0")
-elseif(NOT WILL_FAIL AND NOT result EQUAL 0)
+if(NOT WILL_FAIL AND NOT result EQUAL 0)
   message(SEND_ERROR "Expected exit code 0, got ${result}")
 endif()
 


### PR DESCRIPTION
## Description
Before this change, it was possible for a test to "pass" without actually meeting the required conditions. If a `SHOULD_FAIL` argument was passed with a regular expression, and the test was supposed to have stdout or stderr that matches the regular expression, but in reality it had an exit code of 1 without matching the regular expression, it would pass. Change test execution so that the conditions are checked more carefully. Use a test script to do these checks.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
