### PR TITLE
Adds `versions.json` and user-provided `versions.json` to `CMAKE_CONFIGURE_DEPENDS`.

### DIFF
--- a/rapids-cmake/cpm/detail/load_preset_versions.cmake
+++ b/rapids-cmake/cpm/detail/load_preset_versions.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -38,11 +38,15 @@ function(rapids_cpm_load_preset_versions)
   if(DEFINED RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE)
     set(_rapids_preset_version_file "${RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE}")
   endif()
+  cmake_path(ABSOLUTE_PATH _rapids_preset_version_file NORMALIZE)
 
   if(NOT EXISTS "${_rapids_preset_version_file}")
     message(FATAL_ERROR "rapids_cpm can't load '${_rapids_preset_version_file}' to find package version information, verify it exists"
     )
   endif()
+
+  # Add json file as a configure dependency
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_rapids_preset_version_file}")
 
   # Check if we have been loaded before, if so early terminate
   get_property(already_loaded GLOBAL PROPERTY rapids_cpm_load_presets_${_rapids_preset_version_file}

--- a/rapids-cmake/cpm/detail/load_preset_versions.cmake
+++ b/rapids-cmake/cpm/detail/load_preset_versions.cmake
@@ -38,7 +38,6 @@ function(rapids_cpm_load_preset_versions)
   if(DEFINED RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE)
     set(_rapids_preset_version_file "${RAPIDS_CMAKE_CPM_DEFAULT_VERSION_FILE}")
   endif()
-  cmake_path(ABSOLUTE_PATH _rapids_preset_version_file NORMALIZE)
 
   if(NOT EXISTS "${_rapids_preset_version_file}")
     message(FATAL_ERROR "rapids_cpm can't load '${_rapids_preset_version_file}' to find package version information, verify it exists"
@@ -46,6 +45,7 @@ function(rapids_cpm_load_preset_versions)
   endif()
 
   # Add json file as a configure dependency
+  cmake_path(ABSOLUTE_PATH _rapids_preset_version_file NORMALIZE)
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_rapids_preset_version_file}")
 
   # Check if we have been loaded before, if so early terminate

--- a/rapids-cmake/cpm/package_override.cmake
+++ b/rapids-cmake/cpm/package_override.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -71,6 +71,7 @@ function(rapids_cpm_package_override _rapids_override_filepath)
     message(FATAL_ERROR "rapids_cpm_package_override can't load '${_rapids_override_filepath}', verify it exists"
     )
   endif()
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_rapids_override_filepath}")
   file(READ "${_rapids_override_filepath}" json_data)
 
   # Determine all the projects that exist in the json file

--- a/testing/cpm/cpm_init-custom-default-multiple.cmake
+++ b/testing/cpm/cpm_init-custom-default-multiple.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -74,4 +74,15 @@ foreach(proj IN ITEMS rmm nvbench GTest)
     )
   endif()
   unset(CPM_DOWNLOAD_ALL)
+endforeach()
+
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+foreach(path IN
+        ITEMS "${CMAKE_CURRENT_BINARY_DIR}/defaultsA.json"
+              "${CMAKE_CURRENT_BINARY_DIR}/defaultsB.json"
+              "${CMAKE_CURRENT_BINARY_DIR}/defaultsC.json")
+  # Verify that each default file is registered as a configure dependency
+  if(NOT "${path}" IN_LIST configure_depends)
+    message(FATAL_ERROR "${path} was not registered as a configure dependency")
+  endif()
 endforeach()

--- a/testing/cpm/cpm_init-custom-default-simple.cmake
+++ b/testing/cpm/cpm_init-custom-default-simple.cmake
@@ -22,6 +22,18 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/defaults.json
 
 rapids_cpm_init(CUSTOM_DEFAULT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/defaults.json")
 
+# Verify that the custom default file is a configure dependency but rapids-cmake versions.json is
+# not
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/defaults.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "custom default versions.json was not registered as a configure dependency")
+endif()
+set(default_version_file "${rapids-cmake-dir}/cpm/versions.json")
+cmake_path(ABSOLUTE_PATH default_version_file NORMALIZE)
+if("${default_version_file}" IN_LIST configure_depends)
+  message(FATAL_ERROR "default versions.json should not be registered when using a custom default")
+endif()
+
 # Verify that the custom defaults works
 include("${rapids-cmake-dir}/cpm/detail/package_details.cmake")
 rapids_cpm_package_details_internal(nvbench version repository tag src_subdir shallow exclude)
@@ -39,16 +51,4 @@ if(NOT tag STREQUAL "my_tag")
 endif()
 if(CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL shouldn't be set to true when using a custom default")
-endif()
-
-# Verify that the custom default file is a configure dependency but rapids-cmake versions.json is
-# not
-get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
-if(NOT "${CMAKE_CURRENT_BINARY_DIR}/defaults.json" IN_LIST configure_depends)
-  message(FATAL_ERROR "custom default versions.json was not registered as a configure dependency")
-endif()
-set(default_version_file "${rapids-cmake-dir}/cpm/versions.json")
-cmake_path(ABSOLUTE_PATH default_version_file NORMALIZE)
-if("${default_version_file}" IN_LIST configure_depends)
-  message(FATAL_ERROR "default versions.json should not be registered when using a custom default")
 endif()

--- a/testing/cpm/cpm_init-custom-default-simple.cmake
+++ b/testing/cpm/cpm_init-custom-default-simple.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -39,4 +39,16 @@ if(NOT tag STREQUAL "my_tag")
 endif()
 if(CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL shouldn't be set to true when using a custom default")
+endif()
+
+# Verify that the custom default file is a configure dependency but rapids-cmake versions.json is
+# not
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/defaults.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "custom default versions.json was not registered as a configure dependency")
+endif()
+set(default_version_file "${rapids-cmake-dir}/cpm/versions.json")
+cmake_path(ABSOLUTE_PATH default_version_file NORMALIZE)
+if("${default_version_file}" IN_LIST configure_depends)
+  message(FATAL_ERROR "default versions.json should not be registered when using a custom default")
 endif()

--- a/testing/cpm/cpm_init-override-multiple.cmake
+++ b/testing/cpm/cpm_init-override-multiple.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -120,4 +120,13 @@ endif()
 if(CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be false by default when an override exists that doesn't modify url or tag"
   )
+endif()
+
+# Verify that the default and override files are registered as configure dependencies
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/default.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "custom default versions.json was not registered as a configure dependency")
+endif()
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/override.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "override versions.json was not registered as a configure dependency")
 endif()

--- a/testing/cpm/cpm_init-override-simple.cmake
+++ b/testing/cpm/cpm_init-override-simple.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -41,4 +41,15 @@ if(NOT DEFINED CPM_DOWNLOAD_ALL)
 endif()
 if(NOT CPM_DOWNLOAD_ALL)
   message(FATAL_ERROR "CPM_DOWNLOAD_ALL should be set to true when an override exists")
+endif()
+
+# Verify that the override file and default file are registered as a configure dependency
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+set(default_version_file "${rapids-cmake-dir}/cpm/versions.json")
+cmake_path(ABSOLUTE_PATH default_version_file NORMALIZE)
+if(NOT "${default_version_file}" IN_LIST configure_depends)
+  message(FATAL_ERROR "default versions.json was not registered as a configure dependency")
+endif()
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/override.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "override versions.json was not registered as a configure dependency")
 endif()

--- a/testing/cpm/cpm_package_override-before-init.cmake
+++ b/testing/cpm/cpm_package_override-before-init.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -37,4 +37,15 @@ if(NOT repository STREQUAL "my_url2")
 endif()
 if(NOT tag STREQUAL "my_tag")
   message(FATAL_ERROR "custom git_tag field was ignored. ${tag} found instead of my_tag")
+endif()
+
+# Verify override files loaded before `rapids_cpm_init` are configure dependencies.
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}/simple_override.json" IN_LIST configure_depends)
+  message(FATAL_ERROR "override file was not registered as a configure dependency")
+endif()
+set(default_version_file "${rapids-cmake-dir}/cpm/versions.json")
+cmake_path(ABSOLUTE_PATH default_version_file NORMALIZE)
+if(NOT "${default_version_file}" IN_LIST configure_depends)
+  message(FATAL_ERROR "default versions.json was not registered as a configure dependency")
 endif()

--- a/testing/cpm/cpm_package_override-multiple.cmake
+++ b/testing/cpm/cpm_package_override-multiple.cmake
@@ -82,3 +82,12 @@ if(NOT tag MATCHES "new_rmm_tag")
   message(FATAL_ERROR "custom version field not used when computing git_tag value. ${tag} was found instead"
   )
 endif()
+
+# Verify each directly loaded override file is registered as a configure dependency.
+get_property(configure_depends DIRECTORY PROPERTY CMAKE_CONFIGURE_DEPENDS)
+foreach(path IN ITEMS "${CMAKE_CURRENT_BINARY_DIR}/override1.json"
+                      "${CMAKE_CURRENT_BINARY_DIR}/override2.json")
+  if(NOT "${path}" IN_LIST configure_depends)
+    message(FATAL_ERROR "${path} was not registered as a configure dependency")
+  endif()
+endforeach()


### PR DESCRIPTION
## Description
Updating the default `versions.json` or the override files for `versions.json` should trigger a reconfigure from CMake. These changes add these files to `CMAKE_CONFIGURE_DEPENDS` to ensure this behavior.

This closes #926. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
