### PR TITLE
Fix escaped backticks around `INSTALL_EXPORT_SET` in dependency tracking docs

### DIFF
--- a/docs/dependency_tracking.rst
+++ b/docs/dependency_tracking.rst
@@ -68,7 +68,7 @@ It is common for projects to have dependencies for which CMake doesn't have a ``
 :cmake:command:`rapids_find_generate_module` and :cmake:command:`rapids_export_package`.
 
 The :cmake:command:`rapids_find_generate_module` allows projects to automatically generate a ``Find<Package>`` and encode via the ``BUILD_EXPORT_SET``
-and ```INSTALL_EXPORT_SET``` parameters when the generated module should also be installed and added to ``CMAKE_MODULE_PATH`` so that consumers can use it.
+and ``INSTALL_EXPORT_SET`` parameters when the generated module should also be installed and added to ``CMAKE_MODULE_PATH`` so that consumers can use it.
 
 If you already have an existing ``Find<Package>`` written, :cmake:command:`rapids_export_package` simplifies the process of installing the module and
 making sure it is part of ``CMAKE_MODULE_PATH`` for consumers.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The `INSTALL_EXPORT_SET` reference in `docs/dependency_tracking.rst` was wrapped in triple backticks, and was rendered with literal backticks in the output. Changed to double backticks to render as inline code. Closes #757.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
