### PR TITLE
Add rapids_cpm_libcoro

### DIFF
--- a/docs/packages/packages.rst
+++ b/docs/packages/packages.rst
@@ -6,6 +6,7 @@
    /packages/rapids_cpm_cuco
    /packages/rapids_cpm_gbench
    /packages/rapids_cpm_gtest
+   /packages/rapids_cpm_libcoro
    /packages/rapids_cpm_rapids_logger
    /packages/rapids_cpm_nvbench
    /packages/rapids_cpm_nvtx3

--- a/docs/packages/rapids_cpm_libcoro.rst
+++ b/docs/packages/rapids_cpm_libcoro.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cpm/libcoro.cmake

--- a/rapids-cmake/cpm/libcoro.cmake
+++ b/rapids-cmake/cpm/libcoro.cmake
@@ -1,0 +1,101 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include_guard(GLOBAL)
+
+# rapids-pre-commit-hooks: disable[verify-hardcoded-version]
+#[=======================================================================[.rst:
+rapids_cpm_libcoro
+------------------
+
+.. versionadded:: v26.08.00
+
+Allow projects to find or build `libcoro` via `CPM` with built-in
+tracking of these dependencies for correct export support.
+
+libcoro is a C++20 coroutine library.
+
+Uses the version of libcoro :ref:`specified in the version file <cpm_versions>` for consistency
+across all RAPIDS projects.
+
+.. code-block:: cmake
+
+  rapids_cpm_libcoro( [BUILD_EXPORT_SET <export-name>]
+                      [INSTALL_EXPORT_SET <export-name>]
+                      [EXCLUDE_FROM_ALL]
+                      [BUILD_STATIC]
+                      [<CPM_ARGS> ...])
+
+.. |PKG_NAME| replace:: libcoro
+.. include:: common_package_args.txt
+
+.. versionadded:: v26.08.00
+
+``BUILD_STATIC``
+  Will build `libcoro` statically. No local searching for a previously
+  built version will occur.
+
+Result Targets
+^^^^^^^^^^^^^^
+  libcoro::libcoro target will be created
+
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`libcoro_SOURCE_DIR` is set to the path to the source directory of libcoro.
+  :cmake:variable:`libcoro_BINARY_DIR` is set to the path to the build directory of libcoro.
+  :cmake:variable:`libcoro_ADDED`      is set to a true value if libcoro has not been added before.
+  :cmake:variable:`libcoro_VERSION`    is set to the version of libcoro specified by the versions.json.
+
+#]=======================================================================]
+# rapids-pre-commit-hooks: enable[verify-hardcoded-version]
+function(rapids_cpm_libcoro)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cpm.libcoro")
+
+  set(build_shared ON)
+  if(BUILD_STATIC IN_LIST ARGN)
+    set(build_shared OFF)
+    set(CPM_DOWNLOAD_libcoro ON)
+  endif()
+
+  include("${rapids-cmake-dir}/cpm/detail/package_info.cmake")
+  rapids_cpm_package_info(libcoro ${ARGN} VERSION_VAR version FIND_VAR find_args CPM_VAR
+                          cpm_find_info TO_INSTALL_VAR to_install)
+
+  set(_rapids_libcoro_orig_build_shared_libs ${BUILD_SHARED_LIBS})
+
+  include("${rapids-cmake-dir}/cpm/find.cmake")
+  rapids_cpm_find(libcoro ${version} ${find_args}
+                  GLOBAL_TARGETS libcoro::libcoro
+                  CPM_ARGS ${cpm_find_info}
+                  OPTIONS "LIBCORO_BUILD_SHARED_LIBS ${build_shared}"
+                          "LIBCORO_EXTERNAL_DEPENDENCIES OFF"
+                          "LIBCORO_FEATURE_NETWORKING OFF"
+                          "LIBCORO_FEATURE_TLS OFF"
+                          "LIBCORO_BUILD_TESTS OFF"
+                          "LIBCORO_BUILD_EXAMPLES OFF"
+                          "CMAKE_POSITION_INDEPENDENT_CODE ON")
+
+  # cmake-lint: disable=C0103
+  set(BUILD_SHARED_LIBS ${_rapids_libcoro_orig_build_shared_libs} CACHE INTERNAL "" FORCE)
+
+  include("${rapids-cmake-dir}/cpm/detail/display_patch_status.cmake")
+  rapids_cpm_display_patch_status(libcoro)
+
+  if(libcoro_ADDED AND TARGET libcoro)
+    set_property(TARGET libcoro PROPERTY SYSTEM TRUE)
+  endif()
+
+  if(NOT TARGET libcoro::libcoro AND TARGET libcoro)
+    add_library(libcoro::libcoro ALIAS libcoro)
+  endif()
+
+  # Propagate up variables that CPMFindPackage provide
+  set(libcoro_SOURCE_DIR "${libcoro_SOURCE_DIR}" PARENT_SCOPE)
+  set(libcoro_BINARY_DIR "${libcoro_BINARY_DIR}" PARENT_SCOPE)
+  set(libcoro_ADDED "${libcoro_ADDED}" PARENT_SCOPE)
+  set(libcoro_VERSION ${version} PARENT_SCOPE)
+
+endfunction()

--- a/rapids-cmake/cpm/libcoro.cmake
+++ b/rapids-cmake/cpm/libcoro.cmake
@@ -32,8 +32,6 @@ across all RAPIDS projects.
 .. |PKG_NAME| replace:: libcoro
 .. include:: common_package_args.txt
 
-.. versionadded:: v26.08.00
-
 ``BUILD_STATIC``
   Will build `libcoro` statically. No local searching for a previously
   built version will occur.

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -31,6 +31,11 @@
       "url": "https://github.com/google/googletest/archive/6910c9d9165801d8827d628cb72eb7ea9dd538c5.tar.gz",
       "url_hash": "SHA256=bde221be7f3841fcbc3971665d77d717116394a42155d988ee6407dfc39f1f09"
     },
+    "libcoro": {
+      "version": "0.15.0",
+      "url": "https://github.com/jbaldwin/libcoro/archive/f8dd9f744c7e5e00fa8df6aa79f8dfbd573717fd.tar.gz",
+      "url_hash": "SHA256=02f18b0488d3f3ba6c89deb74d72d1480c43bca352c030d2b00f16ae0be2d3ac"
+    },
     "nvbench": {
       "version": "0.0",
       "url": "https://github.com/NVIDIA/nvbench/archive/b88a45f4170af4e907e69af22a55af67859d3b49.tar.gz",

--- a/testing/cpm/CMakeLists.txt
+++ b/testing/cpm/CMakeLists.txt
@@ -118,6 +118,7 @@ add_cmake_config_test(cpm_gtest-export.cmake)
 add_cmake_config_test(cpm_gtest-simple.cmake)
 add_cmake_config_test(cpm_gtest-static.cmake)
 add_cmake_config_test(cpm_gtest-explicit-static.cmake)
+add_cmake_config_test(cpm_libcoro-simple.cmake)
 
 add_cmake_config_test(cpm_logger-simple.cmake)
 

--- a/testing/cpm/cpm_libcoro-simple.cmake
+++ b/testing/cpm/cpm_libcoro-simple.cmake
@@ -1,0 +1,29 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/cpm/init.cmake)
+include(${rapids-cmake-dir}/cpm/libcoro.cmake)
+
+rapids_cpm_init()
+
+if(TARGET libcoro::libcoro)
+  message(FATAL_ERROR "Expected libcoro::libcoro not to exist")
+endif()
+
+set(BUILD_SHARED_LIBS ON)
+
+rapids_cpm_libcoro()
+
+if(NOT TARGET libcoro::libcoro)
+  message(FATAL_ERROR "Expected libcoro::libcoro to exist")
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "BUILD_SHARED_LIBS was corrupted by rapids_cpm_libcoro")
+endif()
+
+# Idempotency: second call must not error
+rapids_cpm_libcoro()


### PR DESCRIPTION
Closes #1034

Adds a `rapids_cpm_libcoro()` function that provides consistent libcoro versioning across RAPIDS projects via `versions.json`.

## Summary

- Pins libcoro v0.15.0 at commit `f8dd9f744c7e5e00fa8df6aa79f8dfbd573717fd` (post [PR #366](https://github.com/jbaldwin/libcoro/commit/0416de54cf98) which removed the `-fconcepts`/`-fcoroutines` flags; the old rapidsmpf fetch of libcoro was explicitly removing these flags)
- Creates `libcoro::libcoro` alias target for namespace consistency
- Exposes `BUILD_STATIC` option (like gtest/nvbench)
- Saves/restores `BUILD_SHARED_LIBS` around CPM call (libcoro overwrites it as `CACHE INTERNAL`)
- Hardcodes networking, TLS, tests, and examples OFF
- Sets `CMAKE_POSITION_INDEPENDENT_CODE ON` and `SYSTEM TRUE` on the target