### PR TITLE
Add `rapids_cmake_check_conda_env()` function

### DIFF
--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -6,6 +6,11 @@
           "nargs": 1
         }
       },
+      "rapids_cmake_check_conda_env": {
+        "pargs": {
+          "nargs": 1
+        }
+      },
       "rapids_cmake_default_install_component": {
         "pargs": {
           "nargs": "*",

--- a/cmake-format-rapids-cmake.json
+++ b/cmake-format-rapids-cmake.json
@@ -8,7 +8,10 @@
       },
       "rapids_cmake_check_conda_env": {
         "pargs": {
-          "nargs": 1
+          "nargs": "0"
+        },
+        "kwargs": {
+          "REBUILD_INSTRUCTION": 1
         }
       },
       "rapids_cmake_default_install_component": {

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,7 @@ require.
    :titlesonly:
 
    /command/rapids_cmake_build_type
+   /command/rapids_cmake_check_conda_env
    /command/rapids_cmake_default_install_component
    /command/rapids_cmake_download_with_retry
    /command/rapids_cmake_install_lib_dir

--- a/docs/command/rapids_cmake_check_conda_env.rst
+++ b/docs/command/rapids_cmake_check_conda_env.rst
@@ -1,0 +1,1 @@
+.. cmake-module:: ../../rapids-cmake/cmake/check_conda_env.cmake

--- a/rapids-cmake/cmake/check_conda_env.cmake
+++ b/rapids-cmake/cmake/check_conda_env.cmake
@@ -28,11 +28,6 @@ differs from the recorded value, configure terminates with a fatal error that in
   Instructions shown to the user on how to delete the build directory and reconfigure. If not provided, a
   default instruction ``rm -rf <build directory>`` is used.
 
-Result Variables
-^^^^^^^^^^^^^^^^
-  :cmake:variable:`rapids_conda_prefix` will be set to ``CONDA_PREFIX`` when
-  initially configured.
-
 #]=======================================================================]
 # rapids-pre-commit-hooks: enable[verify-hardcoded-version]
 function(rapids_cmake_check_conda_env)

--- a/rapids-cmake/cmake/check_conda_env.cmake
+++ b/rapids-cmake/cmake/check_conda_env.cmake
@@ -1,0 +1,53 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include_guard(GLOBAL)
+
+# rapids-pre-commit-hooks: disable[verify-hardcoded-version]
+#[=======================================================================[.rst:
+rapids_cmake_check_conda_env
+----------------------------
+
+.. versionadded:: v26.08.00
+
+Detect when the active Conda environment has changed since the build directory was initially configured.
+
+  .. code-block:: cmake
+
+    rapids_cmake_check_conda_env(rebuild_instruction)
+
+When called from within a Conda environment, records the current ``CONDA_PREFIX`` in the
+internal cache variable ``rapids_conda_prefix``. On subsequent configures, if ``CONDA_PREFIX``
+differs from the recorded value, configure terminates with a fatal error that includes
+``rebuild_instruction`` for the user.
+
+``rebuild_instruction``
+  Instructions shown to the user on how to delete the build directory and reconfigure.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+  :cmake:variable:`rapids_conda_prefix` will be set to ``CONDA_PREFIX`` when
+  initially configured.
+
+#]=======================================================================]
+# rapids-pre-commit-hooks: enable[verify-hardcoded-version]
+function(rapids_cmake_check_conda_env rebuild_instruction)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cmake.check_conda_env")
+
+  if(DEFINED ENV{CONDA_PREFIX})
+    set(_current_conda "$ENV{CONDA_PREFIX}")
+    if(DEFINED rapids_conda_prefix AND NOT _current_conda STREQUAL "${rapids_conda_prefix}")
+      message(FATAL_ERROR "Conda environment changed since this build directory was configured.\n"
+                          "  Configured with: ${rapids_conda_prefix}\n"
+                          "  Current env:     ${_current_conda}\n"
+                          "Delete the build directory and reconfigure:\n"
+                          "  ${rebuild_instruction}")
+    endif()
+    set(rapids_conda_prefix "${_current_conda}"
+        CACHE INTERNAL
+              "Conda prefix at initial configure time; used to detect environment mismatches")
+  endif()
+endfunction()

--- a/rapids-cmake/cmake/check_conda_env.cmake
+++ b/rapids-cmake/cmake/check_conda_env.cmake
@@ -17,15 +17,16 @@ Detect when the active Conda environment has changed since the build directory w
 
   .. code-block:: cmake
 
-    rapids_cmake_check_conda_env(rebuild_instruction)
+    rapids_cmake_check_conda_env([REBUILD_INSTRUCTION <instruction>])
 
 When called from within a Conda environment, records the current ``CONDA_PREFIX`` in the
 internal cache variable ``rapids_conda_prefix``. On subsequent configures, if ``CONDA_PREFIX``
 differs from the recorded value, configure terminates with a fatal error that includes
-``rebuild_instruction`` for the user.
+``REBUILD_INSTRUCTION`` for the user.
 
-``rebuild_instruction``
-  Instructions shown to the user on how to delete the build directory and reconfigure.
+``REBUILD_INSTRUCTION``
+  Instructions shown to the user on how to delete the build directory and reconfigure. If not provided, a
+  default instruction ``rm -rf <build directory>`` is used.
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -34,8 +35,17 @@ Result Variables
 
 #]=======================================================================]
 # rapids-pre-commit-hooks: enable[verify-hardcoded-version]
-function(rapids_cmake_check_conda_env rebuild_instruction)
+function(rapids_cmake_check_conda_env)
   list(APPEND CMAKE_MESSAGE_CONTEXT "rapids.cmake.check_conda_env")
+
+  set(options)
+  set(one_value REBUILD_INSTRUCTION)
+  set(multi_value)
+  cmake_parse_arguments(_RAPIDS "${options}" "${one_value}" "${multi_value}" ${ARGN})
+
+  if(NOT DEFINED _RAPIDS_REBUILD_INSTRUCTION)
+    set(_RAPIDS_REBUILD_INSTRUCTION "rm -rf ${CMAKE_BINARY_DIR}")
+  endif()
 
   if(DEFINED ENV{CONDA_PREFIX})
     set(_current_conda "$ENV{CONDA_PREFIX}")
@@ -44,7 +54,7 @@ function(rapids_cmake_check_conda_env rebuild_instruction)
                           "  Configured with: ${rapids_conda_prefix}\n"
                           "  Current env:     ${_current_conda}\n"
                           "Delete the build directory and reconfigure:\n"
-                          "  ${rebuild_instruction}")
+                          "  ${_RAPIDS_REBUILD_INSTRUCTION}")
     endif()
     set(rapids_conda_prefix "${_current_conda}"
         CACHE INTERNAL

--- a/testing/cmake/CMakeLists.txt
+++ b/testing/cmake/CMakeLists.txt
@@ -11,6 +11,12 @@ add_cmake_config_test(build_type-debug.cmake)
 add_cmake_config_test(build_type-multiple.cmake)
 add_cmake_config_test(build_type-user-specified.cmake)
 
+add_cmake_config_test(check_conda_env.cmake)
+add_cmake_config_test(check_conda_env-mismatch.cmake
+                      SHOULD_FAIL
+                      "Conda environment changed since this build directory was configured\\.\n\n    Configured with: /opt/conda/prefix-a\n    Current env:     /opt/conda/prefix-b\n\n  Delete the build directory and reconfigure:\n\n    foo"
+)
+
 add_cmake_config_test(conda_env-build.cmake)
 add_cmake_config_test(conda_env-build-envvar.cmake)
 add_cmake_config_test(conda_env-cross-build-arm.cmake)

--- a/testing/cmake/CMakeLists.txt
+++ b/testing/cmake/CMakeLists.txt
@@ -11,11 +11,16 @@ add_cmake_config_test(build_type-debug.cmake)
 add_cmake_config_test(build_type-multiple.cmake)
 add_cmake_config_test(build_type-user-specified.cmake)
 
+string(CONCAT check_conda_env_error_message
+              "Conda environment changed since this build directory was configured\\.\n\n"
+              "    Configured with: /opt/conda/prefix-a\n"
+              "    Current env:     /opt/conda/prefix-b\n\n"
+              "  Delete the build directory and reconfigure:\n\n    ")
 add_cmake_config_test(check_conda_env.cmake)
-add_cmake_config_test(check_conda_env-mismatch.cmake
-                      SHOULD_FAIL
-                      "Conda environment changed since this build directory was configured\\.\n\n    Configured with: /opt/conda/prefix-a\n    Current env:     /opt/conda/prefix-b\n\n  Delete the build directory and reconfigure:\n\n    foo"
-)
+add_cmake_config_test(check_conda_env-mismatch.cmake SHOULD_FAIL
+                      "${check_conda_env_error_message}rm -rf ${CMAKE_BINARY_DIR}")
+add_cmake_config_test(check_conda_env-mismatch-rebuild-instruction.cmake SHOULD_FAIL
+                      "${check_conda_env_error_message}foo")
 
 add_cmake_config_test(conda_env-build.cmake)
 add_cmake_config_test(conda_env-build-envvar.cmake)

--- a/testing/cmake/check_conda_env-mismatch-rebuild-instruction.cmake
+++ b/testing/cmake/check_conda_env-mismatch-rebuild-instruction.cmake
@@ -8,6 +8,6 @@ include(${rapids-cmake-dir}/cmake/check_conda_env.cmake)
 
 # Fails configure when CONDA_PREFIX changes
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix-a")
-rapids_cmake_check_conda_env()
+rapids_cmake_check_conda_env(REBUILD_INSTRUCTION foo)
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix-b")
-rapids_cmake_check_conda_env()
+rapids_cmake_check_conda_env(REBUILD_INSTRUCTION foo)

--- a/testing/cmake/check_conda_env-mismatch.cmake
+++ b/testing/cmake/check_conda_env-mismatch.cmake
@@ -1,0 +1,13 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/cmake/check_conda_env.cmake)
+
+# Fails configure when CONDA_PREFIX changes
+set(ENV{CONDA_PREFIX} "/opt/conda/prefix-a")
+rapids_cmake_check_conda_env("")
+set(ENV{CONDA_PREFIX} "/opt/conda/prefix-b")
+rapids_cmake_check_conda_env(foo)

--- a/testing/cmake/check_conda_env-mismatch.cmake
+++ b/testing/cmake/check_conda_env-mismatch.cmake
@@ -8,6 +8,6 @@ include(${rapids-cmake-dir}/cmake/check_conda_env.cmake)
 
 # Fails configure when CONDA_PREFIX changes
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix-a")
-rapids_cmake_check_conda_env("")
+rapids_cmake_check_conda_env()
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix-b")
-rapids_cmake_check_conda_env(foo)
+rapids_cmake_check_conda_env(REBUILD_INSTRUCTION foo)

--- a/testing/cmake/check_conda_env.cmake
+++ b/testing/cmake/check_conda_env.cmake
@@ -1,0 +1,31 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/cmake/check_conda_env.cmake)
+
+# Do nothing when not in a conda environment
+unset(ENV{CONDA_PREFIX})
+unset(rapids_conda_prefix CACHE)
+rapids_cmake_check_conda_env("")
+if(DEFINED rapids_conda_prefix)
+  message(FATAL_ERROR "rapids_cmake_check_conda_env should not record a value when CONDA_PREFIX is unset"
+  )
+endif()
+
+# Records CONDA_PREFIX on the first call from within a conda environment
+set(ENV{CONDA_PREFIX} "/opt/conda/prefix-a")
+rapids_cmake_check_conda_env("")
+if(NOT rapids_conda_prefix STREQUAL "/opt/conda/prefix-a")
+  message(FATAL_ERROR "rapids_cmake_check_conda_env recorded '${rapids_conda_prefix}', but we expected '/opt/conda/prefix-a'"
+  )
+endif()
+
+# Do nothing when CONDA_PREFIX is unchanged
+rapids_cmake_check_conda_env("")
+if(NOT rapids_conda_prefix STREQUAL "/opt/conda/prefix-a")
+  message(FATAL_ERROR "rapids_cmake_check_conda_env changed the recorded value to '${rapids_conda_prefix}' on an unchanged re-call"
+  )
+endif()

--- a/testing/cmake/check_conda_env.cmake
+++ b/testing/cmake/check_conda_env.cmake
@@ -9,7 +9,7 @@ include(${rapids-cmake-dir}/cmake/check_conda_env.cmake)
 # Do nothing when not in a conda environment
 unset(ENV{CONDA_PREFIX})
 unset(rapids_conda_prefix CACHE)
-rapids_cmake_check_conda_env("")
+rapids_cmake_check_conda_env()
 if(DEFINED rapids_conda_prefix)
   message(FATAL_ERROR "rapids_cmake_check_conda_env should not record a value when CONDA_PREFIX is unset"
   )
@@ -17,14 +17,14 @@ endif()
 
 # Records CONDA_PREFIX on the first call from within a conda environment
 set(ENV{CONDA_PREFIX} "/opt/conda/prefix-a")
-rapids_cmake_check_conda_env("")
+rapids_cmake_check_conda_env()
 if(NOT rapids_conda_prefix STREQUAL "/opt/conda/prefix-a")
   message(FATAL_ERROR "rapids_cmake_check_conda_env recorded '${rapids_conda_prefix}', but we expected '/opt/conda/prefix-a'"
   )
 endif()
 
 # Do nothing when CONDA_PREFIX is unchanged
-rapids_cmake_check_conda_env("")
+rapids_cmake_check_conda_env()
 if(NOT rapids_conda_prefix STREQUAL "/opt/conda/prefix-a")
   message(FATAL_ERROR "rapids_cmake_check_conda_env changed the recorded value to '${rapids_conda_prefix}' on an unchanged re-call"
   )


### PR DESCRIPTION
## Description
When the conda environment is changed, CMake requires you to wipe the build directory and reconfigure. This may not be transparent to those unfamiliar with CMake, so this function provides a helper to error in such situations and show the command that solves this problem.

Implementation sourced from https://github.com/rapidsai/cuml/commit/62ef29e7ff1be122289cac90f03daa592cc2d749

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [x] I have added new files under rapids-cmake/
   - [x] I have added include guards (`include_guard(GLOBAL)`)
   - [x] I have added the associated docs/ rst file and update the api.rst
