### PR TITLE
Update docs to use NVIDIA Sphinx theme

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -119,7 +119,8 @@ dependencies:
               - sphinxcontrib-moderncmakedomain
           - sphinx
           - sphinx-copybutton
-          - sphinx_rtd_theme
+          - pip:
+              - nvidia-sphinx-theme
   test:
     common:
       - output_types: [conda, requirements]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import packaging.version
 
 # -- Project information -----------------------------------------------------
 
-project = "rapids-cmake"
+project = "NVIDIA rapids-cmake"
 copyright = f"2021-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Configuration file for the Sphinx documentation builder.
@@ -16,7 +16,6 @@
 import datetime
 import os.path
 import packaging.version
-import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
@@ -93,7 +92,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "nvidia_sphinx_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -128,5 +127,3 @@ autoclass_content = "init"
 
 def setup(app):
     app.add_js_file("copybutton_pydocs.js")
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,16 @@ todo_include_todos = False
 #
 
 html_theme = "nvidia_sphinx_theme"
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/rapidsai/rapids-cmake",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
+}
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
 .. rapids-cmake documentation file
 
-Welcome to rapids-cmake's documentation!
-========================================
+NVIDIA rapids-cmake Documentation
+=================================
 
-This is a collection of CMake modules that are useful for all RAPIDS
+NVIDIA rapids-cmake is a collection of CMake modules that are useful for all RAPIDS
 projects. By sharing the code in a single place it makes rolling out CMake
 fixes easier.
 


### PR DESCRIPTION
## Description

Updates the Sphinx documentation to use `nvidia_sphinx_theme` with the theme's default left navigation.

This replaces the previous Sphinx theme dependency, removes the legacy shared RAPIDS CSS/JavaScript injection where present, and regenerates dependency manifests.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed, including generated dependency files.
- `sphinx-build -E -b dirhtml . _html -W` and `sphinx-build -E -b text . _text -W` passed in a dedicated docs environment.
- Rendered HTML loads the NVIDIA theme, uses the default left navigation, and contains no legacy shared RAPIDS asset URLs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
