### PR TITLE
Update CCCL to 3.4.0

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -12,8 +12,8 @@
     },
     "CCCL": {
       "version": "3.4.0",
-      "url": "https://github.com/NVIDIA/cccl/archive/207502e57019cefacf6f21d3bb6045aeebef2a3e.tar.gz",
-      "url_hash": "SHA256=a71a14671bd7e72a45783f6c6e51ba3ea81d39e937e756f322f1be77d10555ee"
+      "url": "https://github.com/NVIDIA/cccl/archive/a5630ac57111e1aaef8cfe0069ede566c3d15f60.tar.gz",
+      "url_hash": "SHA256=cbd4051441fe2fa19fe0da2987e8dea90bc51fe9d2111e55b75b0ec1301f33ae"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This PR updates CCCL to the final `v3.4.0` tag.

Comparison of CCCL commits: https://github.com/NVIDIA/cccl/compare/207502e57019cefacf6f21d3bb6045aeebef2a3e...a5630ac57111e1aaef8cfe0069ede566c3d15f60

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst