### PR TITLE
Add `--test-dir` argument when invoking CTest

### DIFF
--- a/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
+++ b/rapids-cmake/test/detail/generate_installed_CTestTestfile.cmake
@@ -345,7 +345,7 @@ set_tests_properties(generate_resource_spec PROPERTIES
 if(EXISTS "${_RAPIDS_BUILD_DIR}/CTestTestfile.cmake")
   # Support multi-generators by setting the CTest config mode to be equal to the install mode
   execute_process(COMMAND ${CMAKE_CTEST_COMMAND} -C "${CMAKE_INSTALL_CONFIG_NAME}"
-                          --show-only=json-v1 "${_RAPIDS_BUILD_DIR}"
+                          --show-only=json-v1 --test-dir "${_RAPIDS_BUILD_DIR}"
                   OUTPUT_VARIABLE ctest_json_output COMMAND_ERROR_IS_FATAL ANY)
   string(JSON test_array GET "${ctest_json_output}" tests)
   string(JSON num_tests LENGTH "${test_array}")


### PR DESCRIPTION
## Description
Follow-up to https://github.com/rapidsai/rapids-cmake/pull/1052, fixing a small bug

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
