### PR TITLE
Update CCCL to 3.4.1

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -11,9 +11,9 @@
       "url_hash": "SHA256=8e54280b4d9af3e4d2fd3dfa3f8d1198fc1c3a572d6f22c5eaf1abe38f2db0a8"
     },
     "CCCL": {
-      "version": "3.4.0",
-      "url": "https://github.com/NVIDIA/cccl/archive/a5630ac57111e1aaef8cfe0069ede566c3d15f60.tar.gz",
-      "url_hash": "SHA256=cbd4051441fe2fa19fe0da2987e8dea90bc51fe9d2111e55b75b0ec1301f33ae"
+      "version": "3.4.1",
+      "url": "https://github.com/NVIDIA/cccl/archive/6e3ed1e52479c17fca9904ce6508095cffc57b06.tar.gz",
+      "url_hash": "SHA256=0257d1da74269940617df55ac32ace32b3893640914a110ab28926ed9d8e03ea"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This PR updates CCCL to 3.4.1.

This is needed for 26.08 to include this fix which is known to affect scan kernels on Blackwell: https://github.com/NVIDIA/cccl/pull/9781

Comparison of CCCL commits: https://github.com/NVIDIA/cccl/compare/a5630ac57111e1aaef8cfe0069ede566c3d15f60...6e3ed1e52479c17fca9904ce6508095cffc57b06

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
  - [ ] I have added include guards (`include_guard(GLOBAL)`)
  - [ ] I have added the associated docs/ rst file and update the api.rst