### PR TITLE
Remove missing copybutton docs asset

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,3 @@ numpydoc_show_inherited_class_members = True
 numpydoc_class_members_toctree = False
 
 autoclass_content = "init"
-
-
-def setup(app):
-    app.add_js_file("copybutton_pydocs.js")


### PR DESCRIPTION
## Description

Removes the obsolete copybutton_pydocs.js registration. The sphinx-copybutton extension provides copybutton.js. Currently the published docs are referencing a missing asset.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst