### PR TITLE
Update CCCL to 3.4.3 pre-release

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -11,9 +11,9 @@
       "url_hash": "SHA256=8e54280b4d9af3e4d2fd3dfa3f8d1198fc1c3a572d6f22c5eaf1abe38f2db0a8"
     },
     "CCCL": {
-      "version": "3.4.1",
-      "url": "https://github.com/NVIDIA/cccl/archive/6e3ed1e52479c17fca9904ce6508095cffc57b06.tar.gz",
-      "url_hash": "SHA256=0257d1da74269940617df55ac32ace32b3893640914a110ab28926ed9d8e03ea"
+      "version": "3.4.3",
+      "url": "https://github.com/NVIDIA/cccl/archive/9d65c77f9763cfec20452e4071128d3f0bd2625b.tar.gz",
+      "url_hash": "SHA256=9c1d579a8fa2d25ab4dcf17457f3811008eb969cee740ce37eddabd1076fb3e1"
     },
     "cuco": {
       "version": "0.0.1",


### PR DESCRIPTION
## Description
This PR updates CCCL to Update CCCL to 3.4.3 pre-release.

We need this fix for the 26.08 release: https://github.com/NVIDIA/cccl/pull/10571

Comparison of CCCL commits: https://github.com/NVIDIA/cccl/compare/6e3ed1e52479c17fca9904ce6508095cffc57b06...9d65c77f9763cfec20452e4071128d3f0bd2625b

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst