### PR TITLE
Update to rapids-logger 0.3

### DIFF
--- a/examples/pin-dependencies/pins.json
+++ b/examples/pin-dependencies/pins.json
@@ -18,9 +18,9 @@
     "rapids_logger": {
       "always_download": true,
       "git_shallow": false,
-      "git_tag": "4c72b598f99c8aa06af49468b3fc82f3931c6bf6",
+      "git_tag": "1124de618517654cce3636d69d022ee76e9df4b0",
       "git_url": "https://github.com/rapidsai/rapids-logger.git",
-      "version": "0.2.3"
+      "version": "0.3.0"
     },
     "rmm": {
       "always_download": true,

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -22,9 +22,9 @@
       "url_hash": "SHA256=4ec8320a0372839b991f0b431c7f8bf0e770006cb3c8631c6e373c434471fd45"
     },
     "rapids_logger": {
-      "version": "0.2.3",
-      "url": "https://github.com/rapidsai/rapids-logger/archive/4c72b598f99c8aa06af49468b3fc82f3931c6bf6.tar.gz",
-      "url_hash": "SHA256=4e7cbbde62ba8517dabd1a327b45955d50db2dfa1240d0124662071ce8f1afc9"
+      "version": "0.3.0",
+      "url": "https://github.com/rapidsai/rapids-logger/archive/1124de618517654cce3636d69d022ee76e9df4b0.tar.gz",
+      "url_hash": "SHA256=96a2f4ef04ad06d55546dbeee355cfe6e4fc94a33dee156d40f4f55dddc31686"
     },
     "GTest": {
       "version": "1.16.0",

--- a/testing/examples/CMakeLists.txt
+++ b/testing/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -15,8 +15,12 @@ add_cmake_build_test(find-generate-module SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/find-generate-module)
 add_cmake_build_test(offline-build SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/offline_build NO_CPM_CACHE)
-add_cmake_build_test(pin-dependencies SOURCE_DIR
-                     ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/pin-dependencies NO_CPM_CACHE)
+enable_language(CXX)
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL
+                                               13.3)
+  add_cmake_build_test(pin-dependencies SOURCE_DIR
+                       ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/pin-dependencies NO_CPM_CACHE)
+endif()
 add_cmake_build_test(project-bootstrap SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/project-bootstrap)
 add_cmake_build_test(project-override SOURCE_DIR


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/313.

Updates rapids-logger to version 0.3.
