### PR TITLE
Update NVBench to e4b0878

### DIFF
--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -39,7 +39,7 @@
     "nvbench": {
       "version": "0.0",
       "url": "https://github.com/NVIDIA/nvbench/archive/e4b087805b002af49d357622cb37a8cc82894628.tar.gz",
-      "url_hash": "SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "url_hash": "SHA256=0253e356ecd0d30a68c367c3d1e2f20a0321fd9e2b1c969d0a208f2a7f3aaad8"
     },
     "nvtx3": {
       "version": "3.2.0",

--- a/rapids-cmake/cpm/versions.json
+++ b/rapids-cmake/cpm/versions.json
@@ -38,8 +38,8 @@
     },
     "nvbench": {
       "version": "0.0",
-      "url": "https://github.com/NVIDIA/nvbench/archive/80558bd11ea91d1da7efdcc662d5c42c07c91d7e.tar.gz",
-      "url_hash": "SHA256=370595e63912b44403197d0263109719de92a48b96787dfe11ac5200b74a776f"
+      "url": "https://github.com/NVIDIA/nvbench/archive/e4b087805b002af49d357622cb37a8cc82894628.tar.gz",
+      "url_hash": "SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
     },
     "nvtx3": {
       "version": "3.2.0",


### PR DESCRIPTION
## Description
Updates NVBench to `e4b087805b002af49d357622cb37a8cc82894628` to include the fix from https://github.com/NVIDIA/nvbench/pull/447.

Needed for NVIDIA/cudf-spark-jni#4932.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
