### PR TITLE
write_language: Disables hook when CMP0220 is set to NEW

### DIFF
--- a/rapids-cmake/export/write_language.cmake
+++ b/rapids-cmake/export/write_language.cmake
@@ -36,8 +36,9 @@ for packages included via `CPM` to enable extra languages.
   the language is enabled globally.
 
   In CMake 4.5 and later this is not needed as `enable_language` supports being called from
-  within functions and in subdirectories to enable languages globally. This function will act as
-  a no-op in these versions when the policy `CMP0220` is set to `NEW`.
+  within functions and in subdirectories to enable languages globally. This function will just
+  call `enable_language` in these versions when the policy `CMP0220` is set to `NEW` where the
+  `<file_path>` is included.
 
 #]=======================================================================]
 function(rapids_export_write_language type lang file_path)
@@ -50,15 +51,6 @@ function(rapids_export_write_language type lang file_path)
 # We have to presume all directories use a language
 # since linking to a target with language standards
 # means `using`
-
-# When CMP0220 is set to NEW, `enable_language` will make the language available globally
-if(POLICY CMP0220)
-    cmake_policy(GET CMP0220 rapids_cmp0220_value)
-    if(rapids_cmp0220_value STREQUAL "NEW")
-      message(DEBUG "CMP0220 is set to NEW, skipping custom language hook propagation logic for @lang@.")
-      return()
-    endif()
-endif()
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   if(NOT DEFINED CMAKE_CURRENT_FUNCTION)
@@ -89,6 +81,14 @@ endif()
 
 # Expose the language at the current scope
 enable_language(@lang@)
+
+# When CMP0220 is set to NEW, `enable_language` will make the language available globally
+if(POLICY CMP0220)
+    cmake_policy(GET CMP0220 rapids_cmp0220_value)
+    if(rapids_cmp0220_value STREQUAL "NEW")
+      return()
+    endif()
+endif()
 
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/cmake/PropagateCMake@lang@Compiler.cmake")
   # 1.

--- a/rapids-cmake/export/write_language.cmake
+++ b/rapids-cmake/export/write_language.cmake
@@ -35,6 +35,9 @@ for packages included via `CPM` to enable extra languages.
   and up the entire :cmake:command:`enable_language <cmake:command:add_subdirectory>` stack so
   the language is enabled globally.
 
+  In CMake 4.5 and later this is not needed as `enable_language` supports being called from
+  within functions and in subdirectories to enable languages globally. This function will act as
+  a no-op in these versions when the policy `CMP0220` is set to `NEW`.
 
 #]=======================================================================]
 function(rapids_export_write_language type lang file_path)

--- a/rapids-cmake/export/write_language.cmake
+++ b/rapids-cmake/export/write_language.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -47,6 +47,15 @@ function(rapids_export_write_language type lang file_path)
 # We have to presume all directories use a language
 # since linking to a target with language standards
 # means `using`
+
+# When CMP0220 is set to NEW, `enable_language` will make the language available globally
+if(POLICY CMP0220)
+    cmake_policy(GET CMP0220 rapids_cmp0220_value)
+    if(rapids_cmp0220_value STREQUAL "NEW")
+      message(DEBUG "CMP0220 is set to NEW, skipping custom language hook propagation logic for @lang@.")
+      return()
+    endif()
+endif()
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   if(NOT DEFINED CMAKE_CURRENT_FUNCTION)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -69,10 +69,7 @@ add_cmake_config_test(write_dependencies-multiple-directories)
 add_cmake_config_test(write_dependencies-root-dirs.cmake)
 
 if(POLICY CMP0220)
-  add_cmake_build_test(write_language-CMP0220
-                       EXPECT_MATCH
-                       "CMP0220 is set to NEW, skipping custom language hook propagation logic for CUDA\\."
-  )
+  add_cmake_build_test(write_language-CMP0220)
 endif()
 add_cmake_build_test(write_language-multiple-nested-enables)
 add_cmake_build_test(write_language-nested-dirs)

--- a/testing/export/CMakeLists.txt
+++ b/testing/export/CMakeLists.txt
@@ -68,5 +68,11 @@ add_cmake_config_test(write_dependencies-duplicate-cpm-and-package.cmake)
 add_cmake_config_test(write_dependencies-multiple-directories)
 add_cmake_config_test(write_dependencies-root-dirs.cmake)
 
+if(POLICY CMP0220)
+  add_cmake_build_test(write_language-CMP0220
+                       EXPECT_MATCH
+                       "CMP0220 is set to NEW, skipping custom language hook propagation logic for CUDA\\."
+  )
+endif()
 add_cmake_build_test(write_language-multiple-nested-enables)
 add_cmake_build_test(write_language-nested-dirs)

--- a/testing/export/write_language-CMP0220/A/CMakeLists.txt
+++ b/testing/export/write_language-CMP0220/A/CMakeLists.txt
@@ -1,0 +1,14 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+include(${rapids-cmake-dir}/export/write_language.cmake)
+
+set(path "${CMAKE_CURRENT_BINARY_DIR}/enable_cuda.cmake")
+rapids_export_write_language(BUILD CUDA "${path}")
+
+include(${path})
+
+add_library(A STATIC static.cu)

--- a/testing/export/write_language-CMP0220/A/static.cu
+++ b/testing/export/write_language-CMP0220/A/static.cu
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
 
 int static_launch_kernelA(int x, int y)

--- a/testing/export/write_language-CMP0220/A/static.cu
+++ b/testing/export/write_language-CMP0220/A/static.cu
@@ -1,0 +1,8 @@
+static __global__ void example_cuda_kernel(int& r, int x, int y) { r = x * y + (x * 4 - (y / 2)); }
+
+int static_launch_kernelA(int x, int y)
+{
+  int r;
+  example_cuda_kernel<<<1, 1>>>(r, x, y);
+  return r;
+}

--- a/testing/export/write_language-CMP0220/CMakeLists.txt
+++ b/testing/export/write_language-CMP0220/CMakeLists.txt
@@ -6,14 +6,17 @@
 # =============================================================================
 cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
 
-project(write_language-CMP0220 LANGUAGES NONE)
-
-include(${rapids-cmake-dir}/export/write_language.cmake)
+project(write_language-CMP0220 LANGUAGES CXX)
 
 cmake_policy(SET CMP0220 NEW)
 
-set(path "${CMAKE_CURRENT_BINARY_DIR}/enable_cuda.cmake")
-rapids_export_write_language(BUILD CUDA "${path}")
+add_subdirectory(A)
 
-add_custom_target(check_write_language_CMP0220 ALL COMMAND ${CMAKE_COMMAND} --log-level=DEBUG -P
-                                                           "${path}")
+add_executable(write_language-CMP0220 main.cpp)
+target_link_libraries(write_language-CMP0220 PRIVATE A)
+
+cmake_language(DEFER GET_CALL_IDS all_ids)
+list(LENGTH all_ids list_len)
+if(NOT list_len EQUAL 1)
+  message(FATAL_ERROR "Language hooks detected when CMP0220 is set to NEW: ${all_ids}")
+endif()

--- a/testing/export/write_language-CMP0220/CMakeLists.txt
+++ b/testing/export/write_language-CMP0220/CMakeLists.txt
@@ -1,0 +1,19 @@
+# =============================================================================
+# cmake-format: off
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# cmake-format: on
+# =============================================================================
+cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
+
+project(write_language-CMP0220 LANGUAGES NONE)
+
+include(${rapids-cmake-dir}/export/write_language.cmake)
+
+cmake_policy(SET CMP0220 NEW)
+
+set(path "${CMAKE_CURRENT_BINARY_DIR}/enable_cuda.cmake")
+rapids_export_write_language(BUILD CUDA "${path}")
+
+add_custom_target(check_write_language_CMP0220 ALL COMMAND ${CMAKE_COMMAND} --log-level=DEBUG -P
+                                                           "${path}")

--- a/testing/export/write_language-CMP0220/main.cpp
+++ b/testing/export/write_language-CMP0220/main.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <iostream>
 
 int static_launch_kernelA(int x, int y);

--- a/testing/export/write_language-CMP0220/main.cpp
+++ b/testing/export/write_language-CMP0220/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+
+int static_launch_kernelA(int x, int y);
+
+int main(int argc, char**)
+{
+  auto resultA = static_launch_kernelA(3, argc);
+
+  if (resultA != 6) { return 1; }
+
+  return 0;
+}

--- a/testing/export/write_language-multiple-nested-enables/CMakeLists.txt
+++ b/testing/export/write_language-multiple-nested-enables/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/testing/export/write_language-multiple-nested-enables/CMakeLists.txt
+++ b/testing/export/write_language-multiple-nested-enables/CMakeLists.txt
@@ -8,6 +8,10 @@ include(${rapids-cmake-dir}/export/write_language.cmake)
 
 cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
 
+if(POLICY CMP0220)
+  cmake_policy(SET CMP0220 OLD)
+endif()
+
 project(write_language-multiple-nested-enable LANGUAGES NONE)
 
 # verify that enabling langues CXX && CUDA in A/B/D and A/C only installs one hook in `A` and

--- a/testing/export/write_language-nested-dirs/CMakeLists.txt
+++ b/testing/export/write_language-nested-dirs/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================

--- a/testing/export/write_language-nested-dirs/CMakeLists.txt
+++ b/testing/export/write_language-nested-dirs/CMakeLists.txt
@@ -8,6 +8,10 @@ include(${rapids-cmake-dir}/export/write_language.cmake)
 
 cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
 
+if(POLICY CMP0220)
+  cmake_policy(SET CMP0220 OLD)
+endif()
+
 project(write_language-nested-dirs LANGUAGES NONE)
 
 # verify that enabling langues CUDA in A/B allows us to build targets that use CUDA


### PR DESCRIPTION
## Description
Now that [`enable_language` support in subdirectories](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/12222) has been merged to CMake upstream, `rapids_export_write_language` does not need to use its hook logic when the CMake policy `CMP0220` is set to `NEW`. Now simply calling `enable_language` is sufficient to get the behavior of `write_language`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
