### PR TITLE
Add binutils as an explicit dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -35,11 +35,11 @@ dependencies:
           - ninja
       - output_types: conda
         packages:
-          - c-compiler
-          - cxx-compiler
-          - cuda-nvcc
-          - make
           - binutils
+          - c-compiler
+          - cuda-nvcc
+          - cxx-compiler
+          - make
     specific:
       - output_types: conda
         matrices:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -39,6 +39,7 @@ dependencies:
           - cxx-compiler
           - cuda-nvcc
           - make
+          - binutils
     specific:
       - output_types: conda
         matrices:


### PR DESCRIPTION
The write_language tests require binutils with `ar` available to work correctly. Newer versions of the `c-compiler` conda package no longer require `binutils` so `ar` is not available which causes these tests to fail.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
