### PR TITLE
enforce 'rstcheck' checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,18 @@ repos:
           ^[.]github/workflows/|
           (^|/)RAPIDS_BRANCH$|
           [.](md|rst)$
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.3.0
+    hooks:
+      - id: rstcheck
+        # 'sphinx-source-dir' setting is needed to resolve 'include::' directives that
+        # reference absolute paths.
+        #
+        # TODO: move that into pyproject.toml when https://github.com/rstcheck/rstcheck-core/issues/123 is resolved
+        #
+        args: ["--config", "pyproject.toml", "--sphinx-source-dir", "docs"]
+        additional_dependencies:
+          - rstcheck[sphinx,toml]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,7 +1,7 @@
 API Reference
 #############
 
-.. _`common`:
+.. _`common-functions`:
 
 Common
 ******
@@ -23,7 +23,7 @@ require.
    /command/rapids_cmake_write_git_revision_file
    /command/rapids_cmake_write_version_file
 
-.. _`cpm`:
+.. _`cpm-functions`:
 
 CPM
 ***
@@ -53,7 +53,7 @@ package uses :ref:`can be found here <cpm_versions>`.
 
 .. include:: /packages/packages.rst
 
-.. _`cython`:
+.. _`cython-functions`:
 
 Cython
 ******
@@ -72,7 +72,7 @@ The ``rapids-cython-core`` module allows projects to easily build cython modules
    /command/rapids_cython_core_create_modules
    /command/rapids_cython_core_add_rpath_entries
 
-.. _`find`:
+.. _`find-functions`:
 
 Find
 ****
@@ -86,8 +86,6 @@ tracking of these dependencies for correct export support.
    /command/rapids_find_generate_module
    /command/rapids_find_package
 
-.. _`cuda`:
-
 JSON
 ****
 
@@ -99,6 +97,8 @@ The `rapids_json` functions provide common JSON manipulation functions.
     rapids_json_array_append </command/rapids_json_array_append>
     rapids_json_array_extend </command/rapids_json_array_extend>
     rapids_json_compute_matrix_product </command/rapids_json_compute_matrix_product>
+
+.. _`cuda-functions`:
 
 CUDA
 ****
@@ -150,7 +150,7 @@ correct export generation. These should only be used when :cmake:command:`rapids
    rapids_export_find_package_root [Advanced] </command/rapids_export_find_package_root>
    rapids_export_package [Advanced] </command/rapids_export_package>
 
-.. _`testing`:
+.. _`testing-functions`:
 
 Testing
 *******

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -29,13 +29,13 @@ Usage
 ``rapids-cmake`` is designed for projects to use only the subset of features that they need. To enable
 this ``rapids-cmake`` comprises the following primary components:
 
-- :ref:`cmake <common>`
-- :ref:`cpm <cpm>`
-- :ref:`cython <cython>`
-- :ref:`cuda <cuda>`
+- :ref:`cmake <common-functions>`
+- :ref:`cpm <cpm-functions>`
+- :ref:`cython <cython-functions>`
+- :ref:`cuda <cuda-functions>`
 - :ref:`export <export>`
-- :ref:`find <find>`
-- :ref:`testing <testing>`
+- :ref:`find <find-functions>`
+- :ref:`testing <testing-functions>`
 
 There are two ways projects can use ``rapids-cmake`` functions.
 

--- a/docs/cpm.rst
+++ b/docs/cpm.rst
@@ -71,16 +71,16 @@ used instead of ALL overrides specified in that project. This would allow you to
 specify custom internal urls for all dependencies without modifying the project source code.
 
 
-```
-cmake -DRAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE=<abs/path/to/custom/override_versions.json> ....
-```
+.. code-block:: bash
+
+    cmake -DRAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE=<abs/path/to/custom/override_versions.json> ....
 
 To request the generation of a pinned package override file without having to modify
 the project use the :cmake:variable:`RAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE` variable:
 
-```
-cmake -DRAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE
-```
+.. code-block:: bash
+
+    cmake -DRAPIDS_CMAKE_CPM_PINNED_VERSIONS_FILE
 
 Additional CPM command line controls
 ************************************
@@ -93,17 +93,16 @@ we document some of the most important ones below.
 If you need to explicitly state a package must be downloaded and not searched
 for locally you enable the variable :cmake:variable:`CPM_DOWNLOAD_<package_name>`.
 
-```
-cmake -DCPM_DOWNLOAD_<package_name>=ON ....
-```
+.. code-block:: bash
+
+    cmake -DCPM_DOWNLOAD_<package_name>=ON ....
 
 If you need to explicitly state all packages must be downloaded and not searched
 for locally you enable the variable :cmake:variable:`CPM_DOWNLOAD_ALL`.
 
-```
-cmake -DCPM_DOWNLOAD_ALL=ON ....
-```
+.. code-block:: bash
 
+    cmake -DCPM_DOWNLOAD_ALL=ON ....
 
 Offline and Airgapped Usage
 ****************************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.codespell]
@@ -10,3 +10,41 @@ ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
 ignore-words-list = "thirdparty"
 builtin = "clear"
 quiet-level = 3
+
+[tool.rstcheck]
+report_level = "INFO"
+
+# rstcheck only knows about directives coming from 'docutils', not
+# those supplied by extensions. This list of ignores suppresses errors
+# like "no directive entry".
+ignore_directives = [
+    # rstcheck does not understand 'sphinxcontrib.moderncmakedomain' directives
+    "cmake-module",
+    # rstcheck does not understand 'sphinx.ext.auto*' directives
+    "autoclass",
+    "autofunction",
+    "automodule",
+    "autosummary",
+    # rstcheck does not understand 'sphinx-design' directives
+    "dropdown",
+    # rstcheck does not understand 'doxygen' directives
+    "doxygenenum",
+    "doxygenfunction",
+    "doxygengroup",
+    "doxygennamespace",
+    "doxygenstruct",
+    "doxygentypedef"
+]
+
+ignore_messages = '''(?x)(
+    # ignore links that look "unused" because they're there to provide stable anchors in hyperlinks
+    Hyperlink\ target\ .*\ is\ not\ referenced
+)
+'''
+
+ignore_roles = [
+    # rstcheck does not understand 'sphinxcontrib.moderncmakedomain roles
+    "cmake:command",
+    "cmake:module",
+    "cmake:variable"
+]


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/262

Proposes introducing `rstcheck` ([rstcheck/rstcheck](https://github.com/rstcheck/rstcheck)), a linter for ReStructuredText.

In my experience, it runs pretty quickly and catches things that `sphinx-build -W` does not, like:

* invalid syntax in `.. code-block::` blocks
* duplicated references (which can lead to unexpected behavior when sharing URLs with anchors)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/rapids-cmake/blob/HEAD/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The `cmake-format.json` is up to date with these changes.
- [ ] I have added new files under rapids-cmake/
   - [ ] I have added include guards (`include_guard(GLOBAL)`)
   - [ ] I have added the associated docs/ rst file and update the api.rst
