### PR TITLE
Correct CI failures building examples 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
         exclude: |
           (?x)
           ^[.]github/workflows/|
+          ^examples/pin-dependencies/pins.json|
           (^|/)RAPIDS_BRANCH$|
           [.](md|rst)$
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/examples/offline_build/use_offline_source_cache.sh
+++ b/examples/offline_build/use_offline_source_cache.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # This script configures and builds the project entirely offline by pointing

--- a/testing/examples/CMakeLists.txt
+++ b/testing/examples/CMakeLists.txt
@@ -19,7 +19,8 @@ enable_language(CXX)
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL
                                                13.3)
   add_cmake_build_test(pin-dependencies SOURCE_DIR
-                       ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/pin-dependencies NO_CPM_CACHE)
+                       ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/pin-dependencies NO_CPM_CACHE
+                       WITH_PRESET with-pins)
 endif()
 add_cmake_build_test(project-bootstrap SOURCE_DIR
                      ${CMAKE_CURRENT_SOURCE_DIR}/../../examples/project-bootstrap)

--- a/testing/utils/cmake_test.cmake
+++ b/testing/utils/cmake_test.cmake
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -67,7 +67,7 @@ adds a test for each generator:
 # rapids-pre-commit-hooks: enable[verify-hardcoded-version]
 function(add_cmake_test mode source_or_dir)
   set(options SERIAL NO_DEV_ERRORS NO_CPM_CACHE NO_RAPIDS_CMAKE_HOOKS)
-  set(one_value SHOULD_FAIL SOURCE_DIR EXPECT_MATCH)
+  set(one_value SHOULD_FAIL SOURCE_DIR EXPECT_MATCH WITH_PRESET)
   set(multi_value)
   cmake_parse_arguments(RAPIDS_TEST "${options}" "${one_value}" "${multi_value}" ${ARGN})
 
@@ -102,6 +102,9 @@ function(add_cmake_test mode source_or_dir)
   endif()
   if(NOT (RAPIDS_TEST_NO_DEV_ERRORS OR RAPIDS_TEST_DISABLE_DEV_ERRORS))
     list(APPEND extra_configure_flags "-Werror=dev")
+  endif()
+  if(DEFINED RAPIDS_TEST_WITH_PRESET)
+    list(APPEND extra_configure_flags "--preset=${RAPIDS_TEST_WITH_PRESET}")
   endif()
   if(DEFINED CPM_SOURCE_CACHE AND NOT RAPIDS_TEST_NO_CPM_CACHE)
     list(APPEND extra_configure_flags "-DCPM_SOURCE_CACHE=${CPM_SOURCE_CACHE}")


### PR DESCRIPTION
## Description
We are seeing failures in other PR's (https://github.com/rapidsai/rapids-cmake/pull/1079) due to CCCL deprecation warning becoming errors. 

This exposed the fact that our PIN example wasn't being invoked using the proper CMake preset

